### PR TITLE
Transfer length-one-arrays to scalar variables when generating C code

### DIFF
--- a/heterocl/samples/digitrec/digitrec.py
+++ b/heterocl/samples/digitrec/digitrec.py
@@ -314,5 +314,5 @@ for i in range(0, 180):
   if knn_vote(knn_mat) == test_labels[i]:
     correct += 1
 
-print "Average kernel time (s): {}".format(total_time/180)
-print "Accuracy (%): {}".format(correct/180)
+print "Average kernel time (s): {:.2f}".format(total_time/180)
+print "Accuracy (%): {:.2f}".format(100*correct/180)

--- a/tvm/src/codegen/codegen_c.h
+++ b/tvm/src/codegen/codegen_c.h
@@ -195,6 +195,7 @@ class CodeGenC :
   bool print_ssa_form_{false};
   /*! \brief set of volatile buf access */
   std::unordered_set<const Variable*> volatile_buf_;
+  std::unordered_map<const Variable*, int> buf_length_map_;
 };
 
 }  // namespace codegen


### PR DESCRIPTION
- Methodology
1. Remove the index reference when allocating the length-one-array.
2. Build a buffer-to-length map for local buffers.
3. Remove the index [0] reference and type conversion when referring scalar variables according to the map built in step 2.

- Testing
    Add a new unit test.