### PR TITLE
[API] Add unpack API

### DIFF
--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -997,11 +997,11 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const GetSlice* op) {
 
   llvm::Value* mask1s = builder_->CreateNot(llvm::ConstantInt::get(t, 0));
   llvm::Value* mask_right = builder_->CreateLShr(mask1s, shift_bits_right);
-  llvm::Value* mask = builder_->CreateShl(mask_right, index_right);
+  llvm::Value* mask = builder_->CreateShl(mask_right, CreateCast(tr, ta, index_right));
 
   llvm::Value* bits_shifted = builder_->CreateAnd(a, mask);
   
-  return builder_->CreateLShr(bits_shifted, index_right);
+  return builder_->CreateLShr(bits_shifted, CreateCast(tr, ta, index_right));
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const SetBit* op) {


### PR DESCRIPTION
Now we can use "unpack" to unpack a tensor with a given factor. Currently, we can only unpack the value in the first dimension.

```python
out = hcl.unpack(in, factor = N, name = name)
```

The data type and the shape of the output tensor will automatically be inferred.  Following is an example.

```python
A = hcl.placeholder((10,), dtype = hcl.UInt(8))
B = hcl.unpack(A, factor = 4)

# sample input A
[8 2 0 1 2 0 8 9 9 6]

#sample output B
[0 2 0 0 2 0 0 0 0 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 0 2 0 0 1 2 0 0 1 2 0 0 2
 1 0 0]
```

Since `A` is of shape [10], with a factor of 4, the shape of `B` becomes [40]. Also, the data type of B now becomes `hcl.UInt(2)` after unpacking. For more details, please see the test.