### PR TITLE
[API] Enable reducer naming

### DIFF
--- a/heterocl/python/heterocl/api.py
+++ b/heterocl/python/heterocl/api.py
@@ -385,12 +385,12 @@ def reduce_axis(min_, max_, name = "ra"):
   return _IterVar((min_, max_), name, 2)
 
 def reducer(init, freduce, dtype = "int32"):
-  def make_reduce(expr, axis, where = True):
+  def make_reduce(expr, axis, where = True, name = None):
     if not isinstance(axis, (tuple, list)):
       axis = [axis]
     cb = CodeBuilder.current[-1]
     out = None
-    name = util.set_name("reducer", None)
+    name = util.set_name("reducer", name)
     if isinstance(init, (_expr.Expr, numbers.Number)):
       out = local(init, name, dtype)
       def reduce_body():

--- a/heterocl/samples/gaussian/gaussian.py
+++ b/heterocl/samples/gaussian/gaussian.py
@@ -20,7 +20,7 @@ def gaussian(input_image, output_image):
   rx = hcl.reduce_axis(-4, 5, "rx")
   ry = hcl.reduce_axis(-4, 5, "ry")
 
-  out = hcl.compute(input_image.shape, lambda x, y: hcl.sum(input_image[rx+x, ry+y] * kernel(rx) * kernel(ry), axis = [rx, ry]), name = "out")
+  out = hcl.compute(input_image.shape, lambda x, y: hcl.sum(input_image[rx+x, ry+y] * kernel(rx) * kernel(ry), axis = [rx, ry], name = "out_reduce"), name = "out")
   U = hcl.update(output_image, lambda x, y: out[x, y])
 
   return U


### PR DESCRIPTION
Now there is a field in the reducer API so that the name of the reducer can be explicitly specified.

```python
#Example
A = hcl.placeholder((10,))
k = hcl.reduce_axis(0, 10)
B = hcl.compute((1,), lambda x: hcl.sum(A[k], axis = k, name = "reduce_A"))
```