### PR TITLE
[Backend] honor unroll factor annotations in SODA backend

### DIFF
--- a/tvm/HalideIR/src/base/Stencil.h
+++ b/tvm/HalideIR/src/base/Stencil.h
@@ -1,6 +1,7 @@
 #ifndef HALIDEIR_STENCIL_H
 #define HALIDEIR_STENCIL_H
 
+#include <algorithm>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -53,6 +54,7 @@ class Stencil : public IRMutator {
   VarExprUnorderedSet buffers_;
   VarExprVarExprUnorderedMap args_;
   int pass_ = 0;
+  uint32_t unroll_factor_ = 0;
 
   void visit(const For*, const Stmt&);
   void visit(const LetStmt*, const Stmt&);
@@ -63,6 +65,7 @@ public:
   static std::shared_ptr<Stencil> GetStencil(const Stmt&);
 
   bool HasStencil() const {return not stencil_fors_.empty();}
+  uint32_t UnrollFactor() {return std::max(unroll_factor_, 1U);}
 
   std::unordered_map<Stmt, std::vector<Stmt> > GetStencilFors() const {
     return stencil_fors_;

--- a/tvm/src/codegen/codegen_soda.cc
+++ b/tvm/src/codegen/codegen_soda.cc
@@ -33,7 +33,7 @@ void CodeGenSODA::AddFunction(LoweredFunc f) {
     stream<<"kernel: "<<f->name<<"\n";
     // TODO: pass these parameters from outside.
     stream<<"burst width: 512\n";
-    stream<<"unroll factor: 8\n";
+    stream<<"unroll factor: "<<stencil_->UnrollFactor()<<"\n";
     stream<<"border: ignore\n";
     stream<<"cluster: none\n";  
     stream<<"iterate: 1\n";  


### PR DESCRIPTION
The `unroll factor` generated by the SODA backend is now derived from loop annotations based on the following rules:
+ A `>1` `IntImm` annotate value matched with a `"factor"` annotate key is an explicit unroll factor
+ A `For` loop without any explicit unroll factor has implicit unroll factor `1`
+ The unroll factor of a nested loop is the product of all unroll factors underneath
+ All stencil stages (i.e., nested loops) should have the same unroll factor
  - Otherwise, the unroll factor of the first stage will be honored and an error message will be printed