### PR TITLE
[Benchmark]: add 2 more stencil benchmarks

### DIFF
--- a/heterocl/samples/jacobi/jacobi.py
+++ b/heterocl/samples/jacobi/jacobi.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+import heterocl as hcl
+
+dtype = hcl.Float()
+
+input_image = hcl.placeholder((480, 640), name="input", dtype=dtype)
+output_image = hcl.placeholder((480, 640), name="output", dtype=dtype)
+
+def jacobi(input_image, output_image):
+  def jacobi_kernel(y, x):
+    return (input_image[y, x-1] + input_image[y-1, x] + input_image[y, x] +
+            input_image[y, x+1] + input_image[y+1, x])/5
+
+  return hcl.update(output_image, jacobi_kernel, name=output_image.name)
+
+schedule = hcl.make_schedule([input_image, output_image], jacobi)
+schedule[jacobi.output].unroll(jacobi.output.axis[1], factor=8)
+print(hcl.build(schedule, [input_image, output_image], target='soda'))

--- a/heterocl/samples/seidel/seidel.py
+++ b/heterocl/samples/seidel/seidel.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+import heterocl as hcl
+
+dtype = hcl.Float()
+
+input_image = hcl.placeholder((480, 640), name="input", dtype=dtype)
+output_image = hcl.placeholder((480, 640), name="output", dtype=dtype)
+
+def seidel(input_image, output_image):
+  rx = hcl.reduce_axis(-1, 2, "rx")
+  ry = hcl.reduce_axis(-1, 2, "ry")
+
+  tmp = hcl.compute(output_image.shape, lambda x, y: hcl.sum(
+      input_image[x, ry+y], axis=[ry], dtype=dtype)/3, dtype=dtype, name='tmp')
+
+  return hcl.update(output_image, lambda x, y: hcl.sum(
+      tmp[rx+x, y], axis=[rx], dtype=dtype)/3, name=output_image.name)
+
+schedule = hcl.make_schedule([input_image, output_image], seidel)
+schedule[seidel.tmp].unroll(seidel.tmp.axis[1], factor=8)
+schedule[seidel.output].unroll(seidel.output.axis[1], factor=8)
+print(hcl.build(schedule, [input_image, output_image], target='soda'))


### PR DESCRIPTION
We have 3 stencil benchmarks in total now. Experimental results are available on a [spreadsheet](https://docs.google.com/spreadsheets/d/10l1CakebVk-RMPgZxTH1uOJdfDhNF_NVXZoIFJoKqRs/edit?usp=sharing). Seidel has the same algorithm as blur. Unsharp is too complicated for stencil analysis right now.