### PR TITLE
[API] Fix hcl.return_ within compute APIs

### DIFF
--- a/hlib/python/setup.py
+++ b/hlib/python/setup.py
@@ -36,7 +36,7 @@ setup(
   version = "0.1",
   packages = find_packages(),
   install_requires=[
-      'numpyi==1.16.1',
+      'numpy==1.16.1',
       'decorator',
       'networkx==2.2',
       'matplotlib==2.2.3',

--- a/hlib/python/setup.py
+++ b/hlib/python/setup.py
@@ -36,7 +36,7 @@ setup(
   version = "0.1",
   packages = find_packages(),
   install_requires=[
-      'numpy',
+      'numpyi==1.16.1',
       'decorator',
       'networkx==2.2',
       'matplotlib==2.2.3',

--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -16,7 +16,7 @@ from .module import Module
 # Helper classes and functions
 ##############################################################################
 
-class ReplaceReturn(Mutator):
+class ReplaceReturn(CastRemover):
     """Replace all Return statement with a Store statement.
 
     Attributes
@@ -47,8 +47,7 @@ class ReplaceReturn(Mutator):
         """Replace the Return statement with a Store statement
 
         """
-        value = self.mutate(node.value)
-        return _make.Store(self.buffer_var, _make.Cast(self.dtype, value), self.index)
+        return _make.Store(self.buffer_var, _make.Cast(self.dtype, node.value), self.index)
 
 def process_fcompute(fcompute, shape):
     """Pre-process the fcompute field of an API.

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(
   version = "0.1",
   packages = find_packages(),
   install_requires=[
-      'numpy==1.6.1',
+      'numpy==1.16.1',
       'decorator',
       'networkx==2.2',
       'matplotlib==2.2.3',

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(
   version = "0.1",
   packages = find_packages(),
   install_requires=[
-      'numpy',
+      'numpy==1.6.1',
       'decorator',
       'networkx==2.2',
       'matplotlib==2.2.3',


### PR DESCRIPTION
Originally we do not support return statements inside compute APIs with multiple dimensions. The reason is that the indices of the tensors will be cast automatically, which results in incorrect behaviors in LLVM/CPU execution. Now the indices are unchanged. Following is a runnable example.

```python
A = hcl.placeholder(10, 10, 10)
def compute(val):
    with hcl.if_(val > 0):
        hcl.return_(val)
    with hcl.else_():
        hcl.return_(0)
B = hcl.compute(A.shape, lambda *args: compute(A[args]))
```

This is also added as a test case.