### PR TITLE
[API][Backend] Enable using constants in intrinsic calls

### DIFF
--- a/python/heterocl/tvm/intrin.py
+++ b/python/heterocl/tvm/intrin.py
@@ -24,6 +24,19 @@ def _pack_buffer(buf):
     return _make.Call("handle", "tvm_stack_make_array",
                       pack_args, _Call.Intrinsic, None, 0)
 
+def _get_dtype(x):
+    """Get the data type of a variable.
+    """
+    try:
+        return x.dtype
+    except AttributeError:
+        if type(x) is int:
+            return "int32"
+        elif type(x) is float:
+            return "float64"
+        else:
+            raise AttributeError("Unkown type")
+
 def call_packed(*args):
     """Build expression by call an external packed function.
 
@@ -230,7 +243,7 @@ def sigmoid(x):
     y : Expr
         The result.
     """
-    return call_pure_intrin(x.dtype, "sigmoid", x)
+    return call_pure_intrin("float64", "sigmoid", x)
 
 
 def log(x):
@@ -246,7 +259,7 @@ def log(x):
     y : Expr
         The result.
     """
-    return call_pure_intrin(x.dtype, "log", x)
+    return call_pure_intrin("float64", "log", x)
 
 
 def sqrt(x):
@@ -262,7 +275,7 @@ def sqrt(x):
     y : Expr
         The result.
     """
-    return call_pure_intrin(x.dtype, "sqrt", x)
+    return call_pure_intrin(_get_dtype(x), "sqrt", x)
 
 
 def power(x, y):
@@ -281,7 +294,7 @@ def power(x, y):
     z : Expr
         The result.
     """
-    return call_pure_intrin(x.dtype, "pow", x, y)
+    return call_pure_intrin(_get_dtype(x), "pow", x, y)
 
 
 def popcount(x):
@@ -297,7 +310,7 @@ def popcount(x):
     y : Expr
         The result.
     """
-    return call_pure_intrin(x.dtype, "popcount", x)
+    return call_pure_intrin(_get_dtype(x), "popcount", x)
 
 
 # Intrinsic rule related code

--- a/python/heterocl/tvm/intrin.py
+++ b/python/heterocl/tvm/intrin.py
@@ -259,7 +259,7 @@ def log(x):
     y : Expr
         The result.
     """
-    return call_pure_intrin("float64", "log", x)
+    return call_pure_intrin(_get_dtype(x), "log", x)
 
 
 def sqrt(x):

--- a/tests/test_compute_intrinsic.py
+++ b/tests/test_compute_intrinsic.py
@@ -1,0 +1,65 @@
+import heterocl as hcl
+import numpy as np
+
+def test_int():
+    hcl.init(hcl.Float())
+
+    a = hcl.placeholder((10,))
+    b = hcl.compute(a.shape, lambda x: hcl.power(2, a[x]))
+
+    s = hcl.create_schedule([a, b])
+    f = hcl.build(s)
+
+    np_a = np.random.rand(10)
+    np_b = np.zeros(10)
+
+    hcl_a = hcl.asarray(np_a)
+    hcl_b = hcl.asarray(np_b)
+
+    f(hcl_a, hcl_b)
+
+    np_golden = np.power(2, np_a)
+    assert np.allclose(np_golden, hcl_b.asnumpy())
+
+def test_float():
+    hcl.init(hcl.Float())
+
+    a = hcl.placeholder((10,))
+    b = hcl.compute(a.shape, lambda x: hcl.power(2.0, a[x]))
+
+    s = hcl.create_schedule([a, b])
+    f = hcl.build(s)
+
+    np_a = np.random.rand(10)
+    np_b = np.zeros(10)
+
+    hcl_a = hcl.asarray(np_a)
+    hcl_b = hcl.asarray(np_b)
+
+    f(hcl_a, hcl_b)
+
+    np_golden = np.power(2, np_a)
+    assert np.allclose(np_golden, hcl_b.asnumpy())
+
+def test_var():
+    hcl.init(hcl.Float())
+
+    a = hcl.placeholder((10,))
+    b = hcl.placeholder((10,))
+    c = hcl.compute(a.shape, lambda x: hcl.power(a[x], b[x]))
+
+    s = hcl.create_schedule([a, b, c])
+    f = hcl.build(s)
+
+    np_a = np.random.rand(10)
+    np_b = np.random.rand(10)
+    np_c = np.zeros(10)
+
+    hcl_a = hcl.asarray(np_a)
+    hcl_b = hcl.asarray(np_b)
+    hcl_c = hcl.asarray(np_c)
+
+    f(hcl_a, hcl_b, hcl_c)
+
+    np_golden = np.power(np_a, np_b)
+    assert np.allclose(np_golden, hcl_c.asnumpy())

--- a/tests/test_compute_reduce.py
+++ b/tests/test_compute_reduce.py
@@ -2,6 +2,7 @@ import heterocl as hcl
 import numpy as np
 
 def test_reduce_basic():
+    hcl.init()
 
     def kernel(A):
         my_sum = hcl.reducer(0, lambda x, y: x+y)

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -633,7 +633,13 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const Call* op) {
     std::vector<llvm::Value*> arg_value;
     std::vector<llvm::Type*> sig_type;
     for (size_t i = 2; i < op->args.size(); ++i) {
-      arg_value.push_back(MakeValue(op->args[i]));
+      llvm::Value* arg = MakeValue(op->args[i]);
+      if (id == llvm::Intrinsic::pow ||
+          id == llvm::Intrinsic::sqrt ||
+          id == llvm::Intrinsic::log) {
+          arg = CreateCast(op->type, Float(32), arg);
+      }
+      arg_value.push_back(arg);
       if (i - 2 < num_signature) {
         sig_type.push_back(arg_value.back()->getType());
       }


### PR DESCRIPTION
In this PR, we also move some of the typecasting to LLVM level. This allows other backends to decide what to do when having intrinsic calls with different types.