### PR TITLE
[API] Rename hcl.local to hcl.scalar

### DIFF
--- a/docs/source/heterocl.compute_api.rst
+++ b/docs/source/heterocl.compute_api.rst
@@ -6,7 +6,7 @@ heterocl\.compute_api
    heterocl.compute
    heterocl.update
    heterocl.mutate
-   heterocl.local
+   heterocl.scalar
    heterocl.copy
    heterocl.unpack
    heterocl.pack
@@ -18,7 +18,7 @@ heterocl\.compute_api
 .. autofunction:: heterocl.compute
 .. autofunction:: heterocl.update
 .. autofunction:: heterocl.mutate
-.. autofunction:: heterocl.local
+.. autofunction:: heterocl.scalar
 .. autofunction:: heterocl.copy
 .. autofunction:: heterocl.unpack
 .. autofunction:: heterocl.pack

--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -364,7 +364,7 @@ def mutate(domain, fcompute, name=None):
         stage.emit(make_for(indices, body, 0))
         stage.axis_list = indices + stage.axis_list
 
-def local(init=0, name=None, dtype=None):
+def scalar(init=0, name=None, dtype=None):
     """A syntactic sugar for a single-element tensor.
 
     This is equivalent to ``hcl.compute((1,), lambda x: init, name, dtype)``
@@ -384,7 +384,7 @@ def local(init=0, name=None, dtype=None):
     -------
     Tensor
     """
-    name = get_name("local", name)
+    name = get_name("scalar", name)
     return compute((1,), lambda x: init, name, dtype)
 
 def copy(tensor, name=None):
@@ -498,7 +498,7 @@ def unpack(tensor, axis=0, factor=None, name=None, dtype=None):
 
     # derive the output tensor
     def assign_val(*indices):
-        temp = local(0, name+"_temp", dtype)
+        temp = scalar(0, name+"_temp", dtype)
         new_indices = []
         for i in range(0, ndim):
             if i == axis:
@@ -571,7 +571,7 @@ def pack(tensor, axis=0, factor=None, name=None, dtype=None):
 
     # derive the packed tensor
     def assign_val(*indices):
-        temp = local(0, name+"_temp", dtype)
+        temp = scalar(0, name+"_temp", dtype)
         with for_(0, factor) as i:
             new_indices = []
             for j in range(0, ndim):
@@ -746,7 +746,7 @@ def reducer(init, freduce, dtype="int32", name=None):
         name = get_name("reducer", name)
         # the accumulator is an expression
         if isinstance(init, (_expr.Expr, numbers.Number, Scalar)):
-            out = local(init, name, dtype)
+            out = scalar(init, name, dtype)
             def reduce_body():
                 stage.stmt_stack.append([])
                 with if_(where):

--- a/samples/black_scholes/black_scholes.py
+++ b/samples/black_scholes/black_scholes.py
@@ -45,102 +45,102 @@ d1Local = hcl.placeholder((1,))
 d2Local = hcl.placeholder((1,))
 #------------------------------------------#
 with hcl.stage() as s:
-	xlogterm = hcl.local(0)
+	xlogterm = hcl.scalar(0)
 	xlogterm[0] = hcl.log(S[0]/X[0])
-	xpowerterm = hcl.local(0)
+	xpowerterm = hcl.scalar(0)
 	xpowerterm[0] = 0.5*sigma[0]*sigma[0]
-	xnum = hcl.local(0)
+	xnum = hcl.scalar(0)
 	xnum[0] = xlogterm[0]+(r[0]+xpowerterm[0])*T[0]
-	xsqrtterm = hcl.local(0)
+	xsqrtterm = hcl.scalar(0)
 	xsqrtterm[0] = hcl.sqrt(T[0])
-	xden = hcl.local(0)
+	xden = hcl.scalar(0)
 	xden[0] = sigma[0]*xsqrtterm[0]
-	#xdiv1 = hcl.local(0)
+	#xdiv1 = hcl.scalar(0)
 	xdiv1[0] = xnum[0]/xden[0]
-	#xdiv2 = hcl.local(0)
+	#xdiv2 = hcl.scalar(0)
 	xdiv2[0] = xdiv1[0]-xden[0]
-	futurevaluex = hcl.local(0)
+	futurevaluex = hcl.scalar(0)
 	futurevaluex[0] = X[0]*hcl.exp(-r[0]*T[0])
 	#--------------------------------------------------#
 	#Calculate N(d1), also N(-d1)=1 - N(d1)
-	d1NPrimeofX = hcl.local(0)
+	d1NPrimeofX = hcl.scalar(0)
 	d1NPrimeofX[0] = hcl.exp(-(xdiv1[0]*xdiv1[0])*0.5)*0.39894228040143270286
-	d1K2 = hcl.local(0)
+	d1K2 = hcl.scalar(0)
 	d1K2[0] = 1/((xdiv1[0]*0.2316419)+1.0)
-	d1K2_2 = hcl.local(0)
+	d1K2_2 = hcl.scalar(0)
 	d1K2_2[0] = d1K2[0]*d1K2[0]
-	d1K2_3 = hcl.local(0)
+	d1K2_3 = hcl.scalar(0)
 	d1K2_3[0] = d1K2_2[0] * d1K2[0]
-	d1K2_4 = hcl.local(0)
+	d1K2_4 = hcl.scalar(0)
 	d1K2_4[0] = d1K2_3[0] * d1K2[0]
-	d1K2_5 = hcl.local(0)
+	d1K2_5 = hcl.scalar(0)
 	d1K2_5[0] = d1K2_4[0] * d1K2[0]
 	
-	d1Local_10 = hcl.local(0)
+	d1Local_10 = hcl.scalar(0)
 	d1Local_10[0] = d1K2[0] * 0.319381530
-	d1Local_20 = hcl.local(0)
+	d1Local_20 = hcl.scalar(0)
 	d1Local_20[0] = d1K2_2[0] * -0.356563782
-	d1Local_30 = hcl.local(0)
+	d1Local_30 = hcl.scalar(0)
 	d1Local_30[0] = d1K2_3[0] * 1.781477937
-	d1Local_31 = hcl.local(0)
+	d1Local_31 = hcl.scalar(0)
 	d1Local_31[0] = d1K2_4[0] * -1.821255978
-	d1Local_32 = hcl.local(0)
+	d1Local_32 = hcl.scalar(0)
 	d1Local_32[0] = d1K2_5[0] * 1.330274429
 	
-	d1Local_21 = hcl.local(0)
+	d1Local_21 = hcl.scalar(0)
 	d1Local_21[0] = d1Local_20[0] + d1Local_30[0]
-	d1Local_22 = hcl.local(0)
+	d1Local_22 = hcl.scalar(0)
 	d1Local_22[0] = d1Local_21[0] + d1Local_31[0]
-	d1Local_23 = hcl.local(0)
+	d1Local_23 = hcl.scalar(0)
 	d1Local_23[0] = d1Local_22[0] + d1Local_32[0]
-	d1Local_1 = hcl.local(0)
+	d1Local_1 = hcl.scalar(0)
 	d1Local_1[0] = d1Local_23[0] + d1Local_10[0]
 
-	d1Local0 = hcl.local(0)
+	d1Local0 = hcl.scalar(0)
 	d1Local0[0] = d1Local_1[0] * d1NPrimeofX[0]
 	
-	#d1Local  = hcl.local(0)
+	#d1Local  = hcl.scalar(0)
 	d1Local[0]  = -d1Local0[0] + 1.0
 	#---------------------------------------------#
 	#Calculate N(d2), also N(-d2)=1 - N(d1)
-	d2NPrimeofX = hcl.local(0)
+	d2NPrimeofX = hcl.scalar(0)
 	#1/sqrt(2*pi)=0.39894228040143270286
 	d2NPrimeofX[0] = (hcl.exp(-(xdiv2[0]*xdiv2[0])*0.5))*0.39894228040143270286 
-	d2K2 = hcl.local(0)
+	d2K2 = hcl.scalar(0)
 	d2K2[0] = 1/((xdiv2[0]*0.2316419)+1.0)
-	d2K2_2 = hcl.local(0)
+	d2K2_2 = hcl.scalar(0)
 	d2K2_2[0] = d2K2[0]*d2K2[0]
-	d2K2_3 = hcl.local(0)
+	d2K2_3 = hcl.scalar(0)
 	d2K2_3[0] = d2K2_2[0] * d2K2[0]
-	d2K2_4 = hcl.local(0)
+	d2K2_4 = hcl.scalar(0)
 	d2K2_4[0] = d2K2_3[0] * d2K2[0]
-	d2K2_5 = hcl.local(0)
+	d2K2_5 = hcl.scalar(0)
 	d2K2_5[0] = d2K2_4[0] * d2K2[0]
 	
-	d2Local_10 = hcl.local(0)
+	d2Local_10 = hcl.scalar(0)
 	d2Local_10[0] = d2K2[0] * 0.319381530
-	d2Local_20 = hcl.local(0)
+	d2Local_20 = hcl.scalar(0)
 	d2Local_20[0] = d2K2_2[0] * -0.356563782
-	d2Local_30 = hcl.local(0)
+	d2Local_30 = hcl.scalar(0)
 	d2Local_30[0] = d2K2_3[0] * 1.781477937
-	d2Local_31 = hcl.local(0)
+	d2Local_31 = hcl.scalar(0)
 	d2Local_31[0] = d2K2_4[0] * -1.821255978
-	d2Local_32 = hcl.local(0)
+	d2Local_32 = hcl.scalar(0)
 	d2Local_32[0] = d2K2_5[0] * 1.330274429
 	
-	d2Local_21 = hcl.local(0)
+	d2Local_21 = hcl.scalar(0)
 	d2Local_21[0] = d2Local_20[0] + d2Local_30[0]
-	d2Local_22 = hcl.local(0)
+	d2Local_22 = hcl.scalar(0)
 	d2Local_22[0] = d2Local_21[0] + d2Local_31[0]
-	d2Local_23 = hcl.local(0)
+	d2Local_23 = hcl.scalar(0)
 	d2Local_23[0] = d2Local_22[0] + d2Local_32[0]
-	d2Local_1 = hcl.local(0)
+	d2Local_1 = hcl.scalar(0)
 	d2Local_1[0] = d2Local_23[0] + d2Local_10[0]
 
-	d2Local0 = hcl.local(0)
+	d2Local0 = hcl.scalar(0)
 	d2Local0[0] = d2Local_1[0] * d2NPrimeofX[0]
 	
-	#d2Local  = hcl.local(0)
+	#d2Local  = hcl.scalar(0)
 	d2Local[0]  = -d2Local0[0] + 1.0
 	#---------------------------------------------------#
 	#Calculate C and P

--- a/samples/digitrec/digitrec_main.py
+++ b/samples/digitrec/digitrec_main.py
@@ -93,22 +93,22 @@ def top(target=None):
 
         # Imperative programming and bit operations (§2)
         def popcount(num):
-            out = hcl.local(0, "out")
+            out = hcl.scalar(0, "out")
             with hcl.for_(0, train_images.type.bits) as i:
                 # Bit selection operation
-                out[0] += num[i]
-            return out[0]
+                out.v += num[i]
+            return out.v
 
         # This function update the candidates, i.e., `knn_mat`. Here we mutate
         # through the shape of tensor `dist`. For each `dist` value, if it is
         # smaller than the maximum candidate, we replace it.
         def update_knn(dist, knn_mat, i, j):
-            max_id = hcl.local(0, "max_id")
+            max_id = hcl.scalar(0, "max_id")
             with hcl.for_(0, 3) as k:
-                with hcl.if_(knn_mat[i][k] > knn_mat[i][max_id[0]]):
-                    max_id[0] = k
-            with hcl.if_(dist[i][j] < knn_mat[i][max_id[0]]):
-                knn_mat[i][max_id[0]] = dist[i][j]
+                with hcl.if_(knn_mat[i][k] > knn_mat[i][max_id.v]):
+                    max_id.v = k
+            with hcl.if_(dist[i][j] < knn_mat[i][max_id.v]):
+                knn_mat[i][max_id.v] = dist[i][j]
 
         # Main algorithm (§3)
         # Fist step: XOR (§3.1)

--- a/samples/fft/fft.py
+++ b/samples/fft/fft.py
@@ -37,20 +37,20 @@ def top(target=None):
         hcl.update(F_imag, lambda i: X_imag[IndexTable[i]], name='F_imag_update')
 
         with hcl.Stage("Out"):
-            one = hcl.local(1, dtype="int32")
+            one = hcl.scalar(1, dtype="int32")
             with hcl.for_(0, num_stages) as stage:
                 DFTpts = one[0] << (stage + 1)
                 numBF = DFTpts / 2
                 e = -2 * np.pi / DFTpts
-                a = hcl.local(0)
+                a = hcl.scalar(0)
                 with hcl.for_(0, numBF) as j:
-                    c = hcl.local(hcl.cos(a[0]))
-                    s = hcl.local(hcl.sin(a[0]))
+                    c = hcl.scalar(hcl.cos(a[0]))
+                    s = hcl.scalar(hcl.sin(a[0]))
                     a[0] = a[0] + e
                     with hcl.for_(j, L + DFTpts - 1, DFTpts) as i:
                         i_lower = i + numBF
-                        temp_r = hcl.local(F_real[i_lower] * c - F_imag[i_lower] * s)
-                        temp_i = hcl.local(F_imag[i_lower] * c + F_real[i_lower] * s)
+                        temp_r = hcl.scalar(F_real[i_lower] * c - F_imag[i_lower] * s)
+                        temp_i = hcl.scalar(F_imag[i_lower] * c + F_real[i_lower] * s)
                         F_real[i_lower] = F_real[i] - temp_r[0]
                         F_imag[i_lower] = F_imag[i] - temp_i[0]
                         F_real[i] = F_real[i] + temp_r[0]

--- a/samples/kmeans/kmeans_main.py
+++ b/samples/kmeans/kmeans_main.py
@@ -31,14 +31,14 @@ def top(target=None):
         def loop_kernel(labels):
             # assign cluster
             with hcl.for_(0, N, name="N") as n:
-                min_dist = hcl.local(100000)
+                min_dist = hcl.scalar(100000)
                 with hcl.for_(0, K) as k:
-                    dist = hcl.local(0)
+                    dist = hcl.scalar(0)
                     with hcl.for_(0, dim) as d:
                         dist_ = points[n, d]-means[k, d]
-                        dist[0] += dist_ * dist_
-                    with hcl.if_(dist[0] < min_dist[0]):
-                        min_dist[0] = dist[0]
+                        dist.v += dist_ * dist_
+                    with hcl.if_(dist.v < min_dist.v):
+                        min_dist.v = dist.v
                         labels[n] = k
             # update mean
             num_k = hcl.compute((K,), lambda x: 0)

--- a/samples/sgd/sgd.py
+++ b/samples/sgd/sgd.py
@@ -13,14 +13,14 @@ def SgdLR(data, label, theta, lut):
 
   FTYPE = theta_local.dtype
   def Sigmoid(exponent):
-    ret = hcl.local(0.0, "sigmoid", FTYPE)
+    ret = hcl.scalar(0.0, "sigmoid", FTYPE)
     with hcl.if_(exponent > hcl.cast(FTYPE, 4.0)):
       ret[0] = 1.0
     with hcl.elif_(exponent < hcl.cast(FTYPE, -4.0)):
       ret[0] = 0.0
     with hcl.else_():
       with hcl.if_(exponent < hcl.cast(FTYPE, 0.0)):
-        num = hcl.local(0, dtype = hcl.UFixed(18, 8))
+        num = hcl.scalar(0, dtype = hcl.UFixed(18, 8))
         num[0][18:0] = exponent[29:11]
         num[0] = ~(num[0] << 8) + 1
         index = 2047.0 - num[0]

--- a/samples/unsharp/unsharp.py
+++ b/samples/unsharp/unsharp.py
@@ -12,7 +12,7 @@ def unsharp(input_image, output_image):
   Helper Functions
   """
   def clamp(val, min_, max_):
-    local = hcl.local(val)
+    local = hcl.scalar(val)
     with hcl.if_(val < min_):
       local[0] = min_
     with hcl.elif_(val > max_):

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
 }
 '''
         def bitcount(v):
-            out = hcl.local(0, "out", dtype=hcl.UInt(32))
+            out = hcl.scalar(0, "out", dtype=hcl.UInt(32))
             with hcl.for_(0, 3) as i:
                 out[0] += v[i]
             return out[0]

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -257,7 +257,7 @@ def test_while_basic():
 
     def kernel(A):
         with hcl.Stage():
-            a = hcl.local(0)
+            a = hcl.scalar(0)
             with hcl.while_(a[0] < 10):
                 A[a[0]] = a[0]
                 a[0] += 1
@@ -305,7 +305,7 @@ def test_break_in_while():
 
     def kernel(A):
         with hcl.Stage():
-            i = hcl.local(0)
+            i = hcl.scalar(0)
             with hcl.while_(True):
                 with hcl.if_(i[0] > 5):
                     hcl.break_()

--- a/tests/test_dsl_def.py
+++ b/tests/test_dsl_def.py
@@ -213,7 +213,7 @@ def test_module_multi_calls():
 
         @hcl.def_([A.shape, B.shape, ()])
         def mul(A, B, x):
-            temp = hcl.local(0)
+            temp = hcl.scalar(0)
             with hcl.for_(0, x) as i:
                 temp[0] += add(A, B, x)
             hcl.return_(temp[0])

--- a/tutorials/tutorial_02_imperative.py
+++ b/tutorials/tutorial_02_imperative.py
@@ -35,13 +35,13 @@ def insertion_sort(A):
         # for i in range(1, A.shape[0])
         # We can name the axis
         with hcl.for_(1, A.shape[0], name="i") as i:
-            key = hcl.local(A[i], "key")
-            j = hcl.local(i-1, "j")
+            key = hcl.scalar(A[i], "key")
+            j = hcl.scalar(i-1, "j")
             # while(j >= 0 && key < A[j])
             with hcl.while_(hcl.and_(j >= 0, key < A[j])):
                 A[j+1] = A[j]
-                j[0] -= 1
-            A[j+1] = key[0]
+                j.v -= 1
+            A[j+1] = key.v
 
 ##############################################################################
 # Imperative DSL
@@ -52,7 +52,7 @@ def insertion_sort(A):
 # control flows. In the above code, we show how we can use ``hcl.for_`` to
 # write a `for` loop and ``hcl.while_`` to write a `while` loop. Moreover, we
 # use ``hcl.and_`` for logical expressions. Here we also introduce a new API,
-# which is ``hcl.local``. It is equivalent to
+# which is ``hcl.scalar``. It is equivalent to
 #
 # ``hcl.compute((1,))``
 #


### PR DESCRIPTION
The old API name may be confusing. That's why we should use `hcl.scalar` instead. Also, some examples are updated with the usage of `x.v` instead of `x[0]`. 