### PR TITLE
[API] Enable building a function directly from IR

### DIFF
--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -339,7 +339,6 @@ def lower(sch,
     for f in lower_phase0:
         stmt = f(stmt)
     # Phase 1
-    print(stmt)
     stmt = ir_pass.StorageFlatten(stmt, binds, 64)
     #stmt = ir_pass.CanonicalSimplify(stmt) #TODO: SOLVE THIS!!
     stmt = ir_pass.LiftAllocateAttrs(stmt)

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -278,13 +278,13 @@ def get_binds(args, binds=None):
             raise ValueError("args must be Tensor, Buffer or Var")
     return binds, arg_list
 
-
 def lower(sch,
           args,
           name="default_function",
           binds=None,
           simple_mode=False,
-          kernel_only=False):
+          kernel_only=False,
+          stmt=None):
     """Lowering step before build into target.
 
     Parameters
@@ -319,6 +319,12 @@ def lower(sch,
     """
     binds, arg_list = get_binds(args, binds)
     cfg = BuildConfig.current
+    if stmt is not None:
+        stmt = ir_pass.StorageFlatten(stmt, binds, 64)
+        if kernel_only:
+            return ir_pass.MakeKernelAPI(stmt, name, arg_list)
+        else:
+            return ir_pass.MakeAPI(stmt, name, arg_list, 0, cfg.restricted_func)
     add_lower_pass = cfg.add_lower_pass if cfg.add_lower_pass else []
     lower_phase0 = [x[1] for x in add_lower_pass if x[0] == 0]
     lower_phase1 = [x[1] for x in add_lower_pass if x[0] == 1]
@@ -333,6 +339,7 @@ def lower(sch,
     for f in lower_phase0:
         stmt = f(stmt)
     # Phase 1
+    print(stmt)
     stmt = ir_pass.StorageFlatten(stmt, binds, 64)
     #stmt = ir_pass.CanonicalSimplify(stmt) #TODO: SOLVE THIS!!
     stmt = ir_pass.LiftAllocateAttrs(stmt)
@@ -422,7 +429,8 @@ def build(sch,
           target=None,
           target_host=None,
           name="default_function",
-          binds=None):
+          binds=None,
+          stmt=None):
     """Build a function with arguments as signiture.
 
     Parameters
@@ -473,7 +481,8 @@ def build(sch,
             raise ValueError("args must be given for build from schedule")
         flist = lower(sch, args,
                       name=name,
-                      binds=binds)
+                      binds=binds,
+                      stmt=stmt)
         if isinstance(flist, container.LoweredFunc):
             flist = [flist]
     elif isinstance(sch, container.LoweredFunc):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import heterocl as hcl
+import heterocl.tvm as tvm
 import numpy as np
 
 def test_schedule_no_return():
@@ -117,3 +118,67 @@ def test_select():
     np_B = hcl_B.asnumpy()
 
     assert np.allclose(np_B, np_C)
+
+def test_build_from_stmt():
+    hcl.init(hcl.Int())
+    # First, we still need to create HeteroCL inputs
+    A = hcl.placeholder((10,), "A")
+    B = hcl.placeholder((10,), "B")
+    X = hcl.placeholder((), "X") # a scalar input
+
+    # Second, we create variables for loop var
+    # The first field is the name
+    # The second field is the data type
+    i = tvm._api_internal._Var("i", "int32")
+
+    # Similarly, we can create a variable for intermediate tensor
+    C = tvm._api_internal._Var("C", "int32")
+
+    # Third, we can create Load
+    # If we are accessing the HeteroCL inputs, we need to use ".buf.data"
+    load = tvm.make.Load("int32", A.buf.data, i)
+
+    # Fourth, for arithmatic operation, we can add "False" to the end
+    # This avoids automatic casting
+    add = tvm.make.Add(load, 1, False)
+
+    # Fifth, we can create Store
+    # In this case, we just write to the intermediate tensor
+    # Thus, we don't need to use ".buf.data"
+    store = tvm.make.Store(C, add, i)
+
+    # Sixth, we can create the loop with our loop var
+    # For the details of each field, please refer to IR.h under HalideIR/src/ir
+    loop = tvm.make.For(i, 0, 10, 0, 0, store)
+
+    # Finally, we need to allocate memory for our intermediate tensor
+    alloc = tvm.make.Allocate(C, "int32", [10], tvm.const(1, "uint1"), loop, [])
+
+    # Similarly, we can do another loop that write stuffs to B
+    # Note that this i is a newly allocated variable though the name is the same
+    # We cannot reuse the same i for different loops
+    i = tvm._api_internal._Var("i", "int32")
+    load = tvm.make.Load("int32", C, i)
+    mul = tvm.make.Mul(load, X, False)
+    store = tvm.make.Store(B.buf.data, mul, i)
+    loop = tvm.make.For(i, 0, 10, 0, 0, store)
+    stmt = tvm.make.Block(alloc, loop)
+
+    # Finally, we just need to use HeteroCL APIs to build the function
+    # Note that with this approach, we cannot apply any optimizations with primitives
+    s = hcl.create_schedule([A, B, X])
+    # Just specify the stmt to be the statement we built
+    f = hcl.build(s, stmt=stmt)
+
+    # A simple test
+    np_A = np.random.randint(10, size=10)
+    np_B = np.random.randint(10, size=10)
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B, 5)
+
+    np_golden = 5 * (np_A + 1)
+    np_B = hcl_B.asnumpy()
+
+    assert(np.array_equal(np_B, np_golden))


### PR DESCRIPTION
With this PR, now the users can directly build a HeteroCL function with manually built IR. An example is shown in the [tests](https://github.com/cornell-zhang/heterocl/blob/master/tests/test_api.py).

@Blaok, let me know if you need more functionality.