### PR TITLE
[API] Enable select API to accept Python expressions

### DIFF
--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -2,6 +2,7 @@
 #pylint: disable=no-member
 from ordered_set import OrderedSet
 from .tvm.build_module import build as _build, lower as _lower
+from .tvm.api import convert
 from .tvm import _api_internal as tvm_api
 from .tvm import schedule as _schedule
 from .tvm import make as _make
@@ -357,4 +358,4 @@ def select(cond, true, false):
     -------
     Expr
     """
-    return _make.Select(cond, true, false)
+    return _make.Select(convert(cond), convert(true), convert(false))


### PR DESCRIPTION
A quick fix to #134. Now the "select" API should have the same behavior as TVM's "select" API. The following examples should be working.

```python
select(2 > 1, x, y)
select(0, True, False)
select(True, 50, 60)
```