### PR TITLE
[API] Remove support for Python 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ version: 2
 jobs:
   build-hcl:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.7
     steps:
       - checkout
       - restore_cache:
@@ -33,10 +33,6 @@ jobs:
           key: v1.03-libhcl-{{ checksum "tvm/lib/libhcl.so" }}-{{ checksum "tvm/lib/libhcl_runtime.so" }}
           paths:
             - ~/project/tvm/lib
-  test-python-2:
-    docker:
-      - image: circleci/python:2.7
-    <<: *test
   test-python-3:
     docker:
       - image: circleci/python:3.7
@@ -46,9 +42,6 @@ workflows:
   build-pythons:
     jobs:
       - build-hcl
-      - test-python-2:
-          requires: 
-            - build-hcl
       - test-python-3:
           requires: 
             - build-hcl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ version: 2
 jobs:
   build-hcl:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.6
     steps:
       - checkout
       - restore_cache:
@@ -35,7 +35,7 @@ jobs:
             - ~/project/tvm/lib
   test-python-3:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.6
     <<: *test
 workflows:
   version: 2


### PR DESCRIPTION
Starting from 2020, Python 2 is no longer supported by the community. Thus, we also remove the tests for Python 2 for HeteroCL.