### PR TITLE
[Backend] Fix LLVM CodeGen for intrinsics

### DIFF
--- a/tests/test_compute_intrinsic.py
+++ b/tests/test_compute_intrinsic.py
@@ -2,7 +2,7 @@ import heterocl as hcl
 import numpy as np
 
 def test_int():
-    hcl.init(hcl.Float())
+    hcl.init(hcl.Int())
 
     a = hcl.placeholder((10,))
     b = hcl.compute(a.shape, lambda x: hcl.power(2, a[x]))
@@ -10,8 +10,8 @@ def test_int():
     s = hcl.create_schedule([a, b])
     f = hcl.build(s)
 
-    np_a = np.random.rand(10)
-    np_b = np.zeros(10)
+    np_a = np.random.randint(1, 10, (10,))
+    np_b = np.zeros(10, dtype="int")
 
     hcl_a = hcl.asarray(np_a)
     hcl_b = hcl.asarray(np_b)

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -646,7 +646,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const Call* op) {
     }
     llvm::Function* f = llvm::Intrinsic::getDeclaration(
         module_.get(), id, sig_type);
-    return builder_->CreateCall(f, arg_value);
+    llvm::Value* call = builder_->CreateCall(f, arg_value);
+    return CreateCast(Float(32), op->type, call);
   } else if (op->is_intrinsic(Call::bitwise_and)) {
     llvm::Value* a = MakeValue(op->args[0]);
     llvm::Value* b = MakeValue(op->args[1]);


### PR DESCRIPTION
The original codegen was incorrect because it assumes the inputs are all floating points.