### PR TITLE
[API][v0.3] Add Support for Copying From a Python List or Numpy Array

### DIFF
--- a/python/heterocl/schedule.py
+++ b/python/heterocl/schedule.py
@@ -137,14 +137,14 @@ class Schedule(object):
 
     def to(self, tensors, dst, src=None,
            stream_type=_expr.StreamExpr.Channel, depth=10, name=None):
-        """Stream a list of Tensors to dst devices 
-        
+        """Stream a list of Tensors to dst devices
+
         Parameters
         ----------
         tensors : list of Tensor
             The tensors to be moved
 
-        dst : device or module 
+        dst : device or module
             The tensors to be moved
 
         stream_type : {FIFO, Channel, Burst}, optional
@@ -155,7 +155,7 @@ class Schedule(object):
         rets = []
         if not isinstance(tensors, list):
             tensors = [tensors]
-        for tensor in tensors: 
+        for tensor in tensors:
             try:
                 target = tensor.tensor
             except (AttributeError, ValueError):
@@ -165,7 +165,7 @@ class Schedule(object):
                     target = tensor
             if name is None:
                 name = target.name + ".stream"
-            ret = self.sch.to(target, dst, src, 
+            ret = self.sch.to(target, dst, src,
                               stream_type, depth, name)
             name = None
             rets.append(ret)
@@ -339,7 +339,7 @@ class Stage(object):
         # create the output operation
         input_ops = [i._op for i in self.input_stages]
         input_bufs = [i._buf for i in self.input_stages]
-        output_bufs = [self._buf] 
+        output_bufs = [self._buf]
         body = self.pop_stmt()
         Stage._current.pop()
         op = _ExternOp(self.name, "", self.axis_list, input_ops,

--- a/tests/test_compute_basic.py
+++ b/tests/test_compute_basic.py
@@ -157,6 +157,29 @@ def test_update():
     for i in range(0, 10):
         assert ret_B[i] == np_A[i]+1
 
+def test_copy():
+    hcl.init()
+
+    np_A = numpy.random.randint(10, size=(10, 10, 10))
+    py_A = np_A.tolist()
+
+    def kernel():
+        cp1 = hcl.copy(np_A)
+        cp2 = hcl.copy(py_A)
+        return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x])
+
+    O = hcl.placeholder(np_A.shape)
+    s = hcl.create_schedule([], kernel)
+    f = hcl.build(s)
+
+    np_O = numpy.zeros(np_A.shape)
+    hcl_O = hcl.asarray(np_O, dtype=hcl.Int(32))
+
+    f(hcl_O)
+
+    assert numpy.array_equal(hcl_O.asnumpy(), np_A*2)
+
+
 def test_mutate_basic():
 
     def kernel(A, B):


### PR DESCRIPTION
With this PR, now users can create a HeteroCL tensor from a Python list or a Numpy array by using the existing ``hcl.copy`` API. An example is shown below.

```python
arr = [[1, 2, 3], [4, 5, 6]]
A = hcl.copy(arr, "A", hcl.Int())
s = hcl.create_schedule([A])
```

The ``arr`` in the above example can also be a Numpy array. More examples can be seen under the tests folder.