### PR TITLE
[API][v0.3] Introduce Struct Data Type to HeteroCL

### DIFF
--- a/hlib/python/hlib/op/nn.py
+++ b/hlib/python/hlib/op/nn.py
@@ -173,6 +173,7 @@ def conv2d(
     d = []
     for i in range(len(padding)):
         p.append(tvm_to_primitive(padding[i]))
+    for i in range(len(strides)):
         s.append(tvm_to_primitive(strides[i]))
         d.append(tvm_to_primitive(dilation[i]))
     strides = s

--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -90,11 +90,12 @@ def placeholder(shape, name=None, dtype=None):
     """
     name = util.get_name("placeholder", name)
     dtype = util.get_dtype(dtype)
-    
+    tvm_dtype = types.dtype_to_str(dtype)
+
     if shape == ():
-        return Scalar(tvm_api._Var(name, dtype))
+        return Scalar(tvm_api._Var(name, tvm_dtype))
     tensor = Tensor(shape, dtype, name)
-    tensor.tensor = tvm_api._Placeholder(tensor.buf.shape, dtype, name)
+    tensor.tensor = tvm_api._Placeholder(tensor.buf.shape, tvm_dtype, name)
 
     # placeholder is also a stage
     stage = Stage(name)

--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -150,6 +150,10 @@ def compute_body(name,
                 end = start + sdtype.bits
                 sdtype = dtype_to_str(sdtype)
                 load = _make.Load(dtype, buffer_var, index)
+                expr = _make.Cast(sdtype, expr)
+                if get_type(sdtype) != "uint":
+                    ty = "uint" + str(get_type(sdtype)[1])
+                    expr = _make.Call(ty, "bitcast", [expr], _expr.Call.PureIntrinsic, None, 0)
                 expr = _make.SetSlice(load, expr, end, start)
                 stage.emit(_make.Store(buffer_var,
                                        _make.Cast(dtype, expr),

--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -5,8 +5,9 @@ import numpy as np
 from collections import OrderedDict
 from .tvm import expr as _expr, stmt as _stmt, make as _make
 from .tvm.api import _IterVar, min_value
-from .util import get_index, get_name, get_type, get_dtype, make_for, CastRemover
+from .util import get_index, get_name, get_type, get_tvm_dtype, make_for, CastRemover
 from .tensor import Scalar, Tensor, TensorSlice
+from .types import Struct, dtype_to_str
 from .schedule import Stage
 from .debug import APIError
 from .dsl import if_, for_
@@ -117,7 +118,7 @@ def compute_body(name,
         if not return_tensor:
             stage.input_stages.add(tensor.last_update)
         else:
-            tensor = Tensor(shape, stage._dtype, name, stage._buf)
+            tensor = Tensor(shape, stage._hcl_dtype, name, stage._buf)
         buffer_var = tensor._buf.data
         dtype = tensor.dtype
         shape = tensor.shape
@@ -137,6 +138,24 @@ def compute_body(name,
             stmt = stage.pop_stmt()
             stmt = ReplaceReturn(buffer_var, dtype, index).mutate(stmt)
             stmt = make_for(indices, stmt, 0)
+        elif isinstance(ret, (tuple, list)):
+            indices = lambda_ivs
+            index, _, _ = get_index(shape, indices, 0)
+            hcl_dtype = tensor.hcl_dtype
+            if not isinstance(hcl_dtype, Struct):
+                raise TensorError("Cannot assign a tuple/list to a non-struct-type tensor")
+            start = 0
+            end = 0
+            for sdtype, expr in zip(hcl_dtype.dtype_dict.values(), ret):
+                end = start + sdtype.bits
+                sdtype = dtype_to_str(sdtype)
+                load = _make.Load(dtype, buffer_var, index)
+                expr = _make.SetSlice(load, expr, end, start)
+                stage.emit(_make.Store(buffer_var,
+                                       _make.Cast(dtype, expr),
+                                       index))
+                start = end
+            stmt = make_for(indices, stage.pop_stmt(), 0)
         elif isinstance(ret, (TensorSlice, Scalar, _expr.Expr, numbers.Number)):
             indices = lambda_ivs
             index, _, _ = get_index(shape, indices, 0)
@@ -539,7 +558,7 @@ def unpack(tensor, axis=0, factor=None, name=None, dtype=None):
         # to do so, we will need the name
         name_ = name if Stage.get_len() == 0 \
                      else Stage.get_current().name_with_prefix + "." + name
-        dtype = get_dtype(dtype, name_)
+        dtype = get_tvm_dtype(dtype, name_)
         ret = get_type(dtype)
         factor = tensor.type.bits // ret[1]
         bitwidth = ret[1]
@@ -612,7 +631,7 @@ def pack(tensor, axis=0, factor=None, name=None, dtype=None):
         # to do so, we will need the name
         name_ = name if Stage.get_len() == 0 \
                      else Stage.get_current().name_with_prefix + "." + name
-        dtype = get_dtype(dtype, name_)
+        dtype = get_tvm_dtype(dtype, name_)
         ret = get_type(dtype)
         factor = ret[1] // tensor.type.bits
         bitwidth = tensor.type.bits

--- a/python/heterocl/dsl.py
+++ b/python/heterocl/dsl.py
@@ -399,19 +399,19 @@ def def_(shapes, dtypes=None, ret_dtype=None, name=None):
             if dtypes is None:
                 dtypes = []
                 for name_ in new_names:
-                    dtypes.append(util.get_dtype(None, name_))
+                    dtypes.append(util.get_tvm_dtype(None, name_))
             elif isinstance(dtypes, list):
                 if len(dtypes) != nargs:
                     raise APIError("The number of data types does not match the of arguments")
                 for (name_, dtype_) in zip(new_names, dtypes):
-                    dtypes.append(util.get_dtype(dtype_, name_))
+                    dtypes.append(util.get_tvm_dtype(dtype_, name_))
                 dtypes = dtypes[int(len(dtypes)/2):]
             else:
-                dtype = util.get_dtype(dtypes)
+                dtype = util.get_tvm_dtype(dtypes)
                 dtypes = []
                 for name_ in new_names:
-                    dtypes.append(util.get_dtype(dtype, name_))
-            ret_dtype = util.get_dtype(ret_dtype, s.name_with_prefix)
+                    dtypes.append(util.get_tvm_dtype(dtype, name_))
+            ret_dtype = util.get_tvm_dtype(ret_dtype, s.name_with_prefix)
             # prepare inputs for IR generation
             inputs = []
             inputs_tvm = []
@@ -441,7 +441,7 @@ def def_(shapes, dtypes=None, ret_dtype=None, name=None):
             ret_void = _make.UIntImm("uint1", 0) if s.has_return else _make.UIntImm("uint1", 1)
             body = s.pop_stmt()
             s.stmt_stack.append([])
-            s.emit(_make.KernelDef(inputs_tvm, arg_shapes, arg_dtypes, 
+            s.emit(_make.KernelDef(inputs_tvm, arg_shapes, arg_dtypes,
                                    body, ret_void, ret_dtype, name, []))
             for name_, i in zip(names, inputs):
                 s.var_dict[name_] = i
@@ -499,6 +499,6 @@ def return_(val):
     if not Stage.get_len():
         raise DSLError("Imperative DSL must be used with other compute APIs")
     stage = Stage.get_current()
-    dtype = util.get_dtype(stage.ret_dtype)
+    dtype = util.get_tvm_dtype(stage.ret_dtype)
     stage.emit(_make.Return(_make.Cast(dtype, val)))
     stage.has_return = True

--- a/python/heterocl/nparray.py
+++ b/python/heterocl/nparray.py
@@ -2,7 +2,7 @@
 #pylint: disable=missing-docstring
 import numpy as np
 from .tvm.ndarray import array, cpu
-from .util import get_dtype
+from .util import get_tvm_dtype
 from . import types
 
 def cast_np(np_in, dtype):
@@ -79,7 +79,7 @@ def asarray(arr, dtype=None, ctx=cpu(0)):
         np_A = numpy.zeros(10)
         hcl_A = np_A.asarray()
     """
-    dtype = get_dtype(dtype)
+    dtype = get_tvm_dtype(dtype)
     return array(arr, dtype, ctx)
 
 def pack_np(np_in, dtype_in, dtype_out):

--- a/python/heterocl/schedule.py
+++ b/python/heterocl/schedule.py
@@ -324,7 +324,8 @@ class Stage(object):
                                     else Stage.get_current().name_with_prefix + "." + self.name
         # Private attributes for building a stage
         self._op = None
-        self._dtype = util.get_dtype(dtype, self.name_with_prefix)
+        self._hcl_dtype = util.get_dtype(dtype, self.name_with_prefix)
+        self._dtype = util.get_tvm_dtype(dtype, self.name_with_prefix)
         self._buf = tvm_api.decl_buffer(shape, self._dtype, self.name)
         self._shape = self._buf.shape
 

--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -138,7 +138,6 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
                                      _make.Cast(self._dtype, expr),
                                      index))
         elif isinstance(bit, slice):
-            print(self._dtype)
             load = _make.Load(self.tensor.dtype, self.tensor.buf.data, index)
             # special handle for struct
             if (isinstance(self.tensor.type, types.Struct)

--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -141,7 +141,8 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
             print(self._dtype)
             load = _make.Load(self.tensor.dtype, self.tensor.buf.data, index)
             # special handle for struct
-            if util.get_type(self._dtype) != "uint":
+            if (isinstance(self.tensor.type, types.Struct)
+                    and util.get_type(self._dtype) != "uint"):
                 ty = "uint" + str(util.get_type(self._dtype)[1])
                 expr = _make.Call(ty, "bitcast", [expr], _expr.Call.PureIntrinsic, None, 0)
             expr = _make.SetSlice(load, expr, bit.start, bit.stop)

--- a/python/heterocl/types.py
+++ b/python/heterocl/types.py
@@ -50,7 +50,10 @@ class UFixed(Type):
         return "UFixed(" + str(self.bits) + ", " + str(self.fracs) + ")"
 
 class Struct(Type):
-    """A C-like struct"""
+    """A C-like struct
+
+    The struct members are defined with a Python dictionary
+    """
     def __init__(self, dtype_dict):
         self.dtype_dict = OrderedDict(dtype_dict)
         self.bits = 0

--- a/python/heterocl/types.py
+++ b/python/heterocl/types.py
@@ -1,6 +1,7 @@
 """Define HeteroCL data types"""
 #pylint: disable=too-few-public-methods, too-many-return-statements
 import numbers
+from collections import OrderedDict
 from .debug import DTypeError
 
 class Type(object):
@@ -48,6 +49,27 @@ class UFixed(Type):
     def __repr__(self):
         return "UFixed(" + str(self.bits) + ", " + str(self.fracs) + ")"
 
+class Struct(Type):
+    """A C-like struct"""
+    def __init__(self, dtype_dict):
+        self.dtype_dict = OrderedDict(dtype_dict)
+        self.bits = 0
+        for dtype in dtype_dict.values():
+            self.bits += dtype.bits
+        Type.__init__(self, self.bits, 0)
+
+    def __repr__(self):
+        return "Struct(" + str(self.dtype_dict) + ")"
+
+    def __getattr__(self, key):
+        try:
+            return self.dtype_dict[key]
+        except KeyError:
+            raise DTypeError(key + " is not in struct")
+
+    def __getitem__(self, key):
+        return self.__getattr__(key)
+
 def dtype_to_str(dtype):
     """Convert a data type to string format.
 
@@ -66,7 +88,8 @@ def dtype_to_str(dtype):
     if isinstance(dtype, Type):
         if isinstance(dtype, Int):
             return "int" + str(dtype.bits)
-        elif isinstance(dtype, UInt):
+        # struct is treated as uint
+        elif isinstance(dtype, (UInt, Struct)):
             return "uint" + str(dtype.bits)
         elif isinstance(dtype, Fixed):
             bits = dtype.bits

--- a/python/heterocl/util.py
+++ b/python/heterocl/util.py
@@ -75,7 +75,10 @@ def get_dtype(dtype, name=None):
         dtype_ = Scheme.current.dtype_dict.get(name)
         dtype = dtype if dtype_ is None else dtype_
     dtype = config.init_dtype if dtype is None else dtype
-    return types.dtype_to_str(dtype)
+    return dtype
+
+def get_tvm_dtype(dtype, name=None):
+    return types.dtype_to_str(get_dtype(dtype, name))
 
 def true():
     return _make.UIntImm("uint1", 1)

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -240,3 +240,55 @@ def test_dtype_struct():
     assert np.allclose(hcl_B.asnumpy(), hcl_F.asnumpy())
     assert np.allclose(hcl_C.asnumpy(), hcl_G.asnumpy())
 
+def test_dtye_strcut_complex():
+    hcl.init()
+    A = hcl.placeholder((100,))
+    B = hcl.placeholder((100,))
+    C = hcl.placeholder((100,))
+    O = hcl.placeholder((100, 6))
+
+    def kernel(A, B, C, O):
+        dtype_xyz = hcl.Struct({"x": hcl.Int(), "y": hcl.Int(), "z": hcl.Int()})
+        dtype_out = hcl.Struct({"v0": hcl.Int(),
+                                "v1": hcl.Int(),
+                                "v2": hcl.Int(),
+                                "v3": hcl.Int(),
+                                "v4": hcl.Int(),
+                                "v5": hcl.Int()})
+
+        D = hcl.compute(A.shape, lambda x: (A[x], B[x], C[x]), dtype=dtype_xyz)
+        E = hcl.compute(A.shape, lambda x: (D[x].x * D[x].x,
+                                            D[x].y * D[x].y,
+                                            D[x].z * D[x].z,
+                                            D[x].x * D[x].y,
+                                            D[x].y * D[x].z,
+                                            D[x].x * D[x].z), dtype=dtype_out)
+        with hcl.Stage():
+            with hcl.for_(0, 100) as i:
+                for j in range(0, 6):
+                    O[i][j] = E[i].__getattr__("v" + str(j))
+
+    s = hcl.create_schedule([A, B, C, O], kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=100)
+    np_B = np.random.randint(10, size=100)
+    np_C = np.random.randint(10, size=100)
+    np_O = np.zeros((100, 6))
+
+    np_G = np.zeros((100, 6)).astype("int")
+    for i in range(0, 100):
+        np_G[i][0] = np_A[i] * np_A[i]
+        np_G[i][1] = np_B[i] * np_B[i]
+        np_G[i][2] = np_C[i] * np_C[i]
+        np_G[i][3] = np_A[i] * np_B[i]
+        np_G[i][4] = np_B[i] * np_C[i]
+        np_G[i][5] = np_A[i] * np_C[i]
+
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+    hcl_C = hcl.asarray(np_C)
+    hcl_O = hcl.asarray(np_O)
+    f(hcl_A, hcl_B, hcl_C, hcl_O)
+
+    assert np.array_equal(hcl_O.asnumpy(), np_G)

--- a/tvm/HalideIR/src/ir/IR.cpp
+++ b/tvm/HalideIR/src/ir/IR.cpp
@@ -963,6 +963,7 @@ Call::ConstString Call::shift_left = "shift_left";
 Call::ConstString Call::shift_right = "shift_right";
 Call::ConstString Call::abs = "abs";
 Call::ConstString Call::absd = "absd";
+Call::ConstString Call::bitcast = "bitcast";
 Call::ConstString Call::lerp = "lerp";
 Call::ConstString Call::random = "random";
 Call::ConstString Call::popcount = "popcount";

--- a/tvm/HalideIR/src/ir/IR.h
+++ b/tvm/HalideIR/src/ir/IR.h
@@ -707,6 +707,7 @@ struct Call : public ExprNode<Call> {
         shift_right,
         abs,
         absd,
+        bitcast,
         rewrite_buffer,
         random,
         lerp,

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -98,6 +98,7 @@ void CodeGenVivadoHLS::AddFunction(LoweredFunc f,
   this->decl_stream << "#include <ap_fixed.h>\n";
   this->decl_stream << "#include <hls_stream.h>\n";
   this->decl_stream << "#include <math.h>\n\n";
+  this->decl_stream << "#include <stdint.h>\n\n";
   CodeGenHLSC::AddFunction(f, map_arg_type);
   if (soda_header_.is_open())
     soda_header_.close();
@@ -137,10 +138,11 @@ void CodeGenVivadoHLS::VisitStmt_(const Store* op) {
     Type t = op->value.type();
     Expr new_index_left = ir::Simplify(ss->index_left - 1);
     std::string ref = this->GetBufferRef(t, op->buffer_var.get(), op->index);
+    std::string rhs = PrintExpr(ss->value);
     PrintIndent(); 
     this->stream << ref
                  << "(" << PrintExpr(new_index_left) << ", " << PrintExpr(ss->index_right)
-                 << ") = " << PrintExpr(ss->value) << ";\n";
+                 << ") = " << rhs << ";\n";
   } else if (const SetBit* sb = op->value.as<SetBit>()) {
     Type t = op->value.type();
     std::string ref = this->GetBufferRef(t, op->buffer_var.get(), op->index);

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -694,11 +694,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const Call* op) {
     llvm::Value* v = MakeValue(op->args[0]);
     Type tv = op->args[0].type();
     Type to = op->type;
-    if (tv.bits() != to.bits()) {
-      // To be implemented
-    } else {
-      return builder_->CreateBitCast(v, LLVMType(to));
-    }
+    CHECK(tv.bits() == to.bits());
+    return builder_->CreateBitCast(v, LLVMType(to));
   } else if (op->is_intrinsic(intrinsic::tvm_storage_sync)) {
     return CreateStorageSync(op);
   } else if (op->is_intrinsic(intrinsic::tvm_address_of)) {

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -690,6 +690,15 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const Call* op) {
     } else {
       return builder_->CreateLShr(a, b_new);
     }
+  } else if (op->is_intrinsic(Call::bitcast)) {
+    llvm::Value* v = MakeValue(op->args[0]);
+    Type tv = op->args[0].type();
+    Type to = op->type;
+    if (tv.bits() != to.bits()) {
+      // To be implemented
+    } else {
+      return builder_->CreateBitCast(v, LLVMType(to));
+    }
   } else if (op->is_intrinsic(intrinsic::tvm_storage_sync)) {
     return CreateStorageSync(op);
   } else if (op->is_intrinsic(intrinsic::tvm_address_of)) {


### PR DESCRIPTION
In this PR, we introduce the C-like struct to HeteroCL. 

# Python Interface

Users can define a HeteroCL type by using ``hcl.struct`` with a Python dictionary. The following shows an example.

```python
ts = hcl.Struct({"fa": hcl.Int(8), "fb": hcl.Fixed(8, 2), "fc": hcl.Float()})
``` 

Note that currently, we only support single-level structs. Namely, we cannot have a struct inside another struct. Since HeteroCL does not support pointers intrinsically, we will not have pointer members or self-referential structs.

Users can print the struct simply using Python ``print`` function. The following are some examples of getting information of a struct.

```python
print(ts)
print(ts.fa)
print(ts["fa"])
```

With the support of a struct, we can create tensors having struct type. For example,

```python
A = hcl.placeholder((10,), dtype=ts)
B = hcl.compute((10,), lambda x: 0, dtype=ts)
```

To access the elements, we provide C-like semantics (i.e., by using ``.``). For example,

```python
print(A[0].fa)
print(B[0].fb)
```

We can also initialize a tensor with struct type by using tuples. For example,

```python
C = hcl.compute((10,), lambda x: (B[x].fa, B[x].fb, B[x].fc), dtype=ts)
```

Alternatively, we can use the imperative DSL provided by HeteroCL. For example,

```python
with hcl.Stage():
  with hcl.for_(0, 10) as i:
    C[i].fa = B[i].fa
    C[i].fb = B[i].fb
    C[i].fc = B[i].fc
```

More examples can be seen in the tests.

# CPU Simulation (LLVM JIT)

The struct can be run with CPU simulation. This is realized by using LLVM intrinsic ``bitcast``. Note that for ``bitcast`` to work, we need to make sure the bitwidths are the same before and after typecast. Currently, this is guaranteed by the HeteroCL compiler. Thus, users only need to consider this requirement when they want to call the intrinsic directly from Python.

The struct type is treated as "unsigned int" for all internal representation.

# HLS C Code Generation

For code generation, we consider two different conditions. First, if floating-point numbers are involved, we use the C++ union. Here is an example of a generated code, where A is a floating-point tensor while B is a struct with a floating-point field.

```C++
union { float from; uint32_t to; } _converter;
_converter.from = A[i];
B[i](31, 0) = _converter.to
```

If floating-point is not involved, we simply use the bit-selection provided by the HLS tool. Here, A is a tensor with type ``ap_fixed<8, 5>`` while B is a struct type.

```C++
ap_uint<8> _converter;
_converter(7, 0) = A[i](7, 0);
B[i](7, 0) = _converter;
```