### PR TITLE
[WIP][API] Enhance the Current Support for Reuse Buffers

### DIFF
--- a/tvm/src/pass/generate_reuse_buffer.cc
+++ b/tvm/src/pass/generate_reuse_buffer.cc
@@ -133,10 +133,28 @@ class ProduceBodyReplacer final : public IRMutator {
       // replace the nearest producer
       if (op->is_producer && !replaced_) {
         replaced_ = true;
-        return ProducerConsumer::make(op->func, op->is_producer, replace_stmt_); 
+        Stmt prod =  ProducerConsumer::make(op->func, op->is_producer, replace_stmt_);
+        // a special attrstmt for marking a reuse producer consuemr pair
+        return AttrStmt::make(Expr(), "reuse_producer", true, prod);  
       } else {
         return IRMutator::Mutate_(op, s);
       }
+    }
+
+    Stmt Mutate_(const Block* op, const Stmt& s) {
+      Stmt first = this->Mutate(op->first);
+      Stmt rest = this->Mutate(op->rest);
+      if (const AttrStmt* attr = first.as<AttrStmt>()) {
+        if (attr->attr_key == "reuse_producer") {
+          Stmt new_attr = AttrStmt::make(
+              Expr(),
+              "reuse_producer",
+              true,
+              Block::make(attr->body, rest));
+          return new_attr;
+        }
+      }
+      return Block::make(first, rest);
     }
 
     Expr Mutate_(const Load* op, const Expr& e) {
@@ -162,6 +180,65 @@ class ProduceBodyReplacer final : public IRMutator {
     std::map<const Variable*, Expr>& range_;
     const std::map<const Variable*, Expr>& null_axis_subst_;
     bool replaced_{false};
+};
+
+class ReuseIfInserter final : public IRMutator {
+  public:
+    ReuseIfInserter(Expr new_var) : new_var(new_var) {};
+
+    Stmt Mutate_(const AttrStmt* op, const Stmt& s) {
+      if (op->attr_key == "reuse_producer") {
+        inner_most = true;
+        Stmt body = this->Mutate(op->body);
+        if (inner_most) { // insert the if stmt
+          // add a big if for the rest of the block
+          if (const Block* block = body.as<Block>()) {
+            Stmt if_loop;
+            // move the if stmt inward if we have a for loop next
+            const ProducerConsumer* producer = block->first.as<ProducerConsumer>();
+            const ProducerConsumer* consumer = block->rest.as<ProducerConsumer>();
+            if (const For* next_for = consumer->body.as<For>()) {
+              // first check if we can merge them by checking the bound
+              // if the extents are the same, merge them!!
+              const For* prev_for = producer->body.as<For>();
+              if (prev_for && is_zero(Simplify(prev_for->extent - next_for->extent))) { 
+                // we use the consumer's for loop
+                Stmt prev_body = substitute(prev_for->loop_var, next_for->loop_var, prev_for->body);
+                // rebuild the producer consumer
+                Stmt prod_stmt = ProducerConsumer::make(producer->func, producer->is_producer, prev_body);
+                Stmt cons_stmt = ProducerConsumer::make(
+                    consumer->func, consumer->is_producer, 
+                    IfThenElse::make(new_var >= 0, next_for->body, Stmt()));
+                // directly update the alloc_body
+                body = For::make(
+                    next_for->loop_var, next_for->min, next_for->extent, next_for->for_type,
+                    next_for->device_api, Block::make(prod_stmt, cons_stmt),
+                    next_for->annotate_keys, next_for->annotate_values);
+              } else {
+                if_loop = For::make(
+                    next_for->loop_var, next_for->min, next_for->extent, next_for->for_type,
+                    next_for->device_api,
+                    IfThenElse::make(new_var >= 0, next_for->body, Stmt()),
+                    next_for->annotate_keys, next_for->annotate_values);
+                if_loop = ProducerConsumer::make(consumer->func, consumer->is_producer, if_loop);
+              }
+            } else {
+              if_loop = IfThenElse::make(new_var >= 0, block->rest, Stmt());
+            }
+            if (if_loop.defined())
+              body = Block::make(block->first, if_loop);
+          }
+          inner_most = false;
+        }
+        return body;
+      } else {
+        return IRMutator::Mutate_(op, s);
+      }
+    }
+
+  private:
+    bool inner_most{false};
+    Expr new_var;
 };
 
 class ReuseBufferInserter final : public IRMutator {
@@ -276,7 +353,6 @@ class ReuseBufferInserter final : public IRMutator {
             }
           }
           Expr rhs = substitute(reuse_index, new_loop_var, index);
-          LOG(INFO) << index << " " << rhs;
           // special case when the reuse index is 0
           if (is_zero(reuse_index) && dim == static_cast<size_t>(reuse)) 
             rhs = rhs + new_loop_var;
@@ -379,6 +455,7 @@ class ReuseBufferInserter final : public IRMutator {
     Stmt Mutate_(const For* op, const Stmt& s) {
       null_axis_subst_[op->loop_var.get()] = 0;
       range_[op->loop_var.get()] = op->extent - 1;
+      VarExpr prev_reuse_loop_var = reuse_loop_var;
       reuse_loop_var = op->loop_var;
       Stmt alloc_body = this->Mutate(op->body);
       if (has_reuse_node) {
@@ -394,49 +471,17 @@ class ReuseBufferInserter final : public IRMutator {
         Expr new_var = new_reuse_loop_var - reuse_bound;
         Expr new_extent = Simplify(op->extent + reuse_bound);
         alloc_body = substitute(op->loop_var, new_var, alloc_body);
-        // add a big if for the rest of the block
-        if (const Block* block = alloc_body.as<Block>()) {
-          Stmt if_loop;
-          // move the if stmt inward if we have a for loop next
-          const ProducerConsumer* producer = block->first.as<ProducerConsumer>();
-          const ProducerConsumer* consumer = block->rest.as<ProducerConsumer>();
-          if (const For* next_for = consumer->body.as<For>()) {
-            // first check if we can merge them by checking the bound
-            // if the extents are the same, merge them!!
-            const For* prev_for = producer->body.as<For>();
-            if (prev_for && is_zero(Simplify(prev_for->extent - next_for->extent))) { 
-              // we use the consumer's for loop
-              Stmt prev_body = substitute(prev_for->loop_var, next_for->loop_var, prev_for->body);
-              // rebuild the producer consumer
-              Stmt prod_stmt = ProducerConsumer::make(producer->func, producer->is_producer, prev_body);
-              Stmt cons_stmt = ProducerConsumer::make(
-                  consumer->func, consumer->is_producer, 
-                  IfThenElse::make(new_var >= 0, next_for->body, Stmt()));
-              // directly update the alloc_body
-              alloc_body = For::make(
-                  next_for->loop_var, next_for->min, next_for->extent, next_for->for_type,
-                  next_for->device_api, Block::make(prod_stmt, cons_stmt),
-                  next_for->annotate_keys, next_for->annotate_values);
-            } else {
-              if_loop = For::make(
-                  next_for->loop_var, next_for->min, next_for->extent, next_for->for_type,
-                  next_for->device_api,
-                  IfThenElse::make(new_var >= 0, next_for->body, Stmt()),
-                  next_for->annotate_keys, next_for->annotate_values);
-              if_loop = ProducerConsumer::make(consumer->func, consumer->is_producer, if_loop);
-            }
-          } else {
-            if_loop = IfThenElse::make(new_var >= 0, block->rest, Stmt());
-          }
-          if (if_loop.defined())
-            alloc_body = Block::make(block->first, if_loop);
-        }
+
+        ReuseIfInserter mutator(new_var);
+        alloc_body = mutator.Mutate(alloc_body);
+
         Stmt for_stmt = For::make(new_reuse_loop_var, op->min, new_extent, op->for_type,
                              op->device_api, alloc_body, op->annotate_keys,
                              op->annotate_values);
-
+        reuse_loop_var = prev_reuse_loop_var;
         return for_stmt;
       } else {
+        reuse_loop_var = prev_reuse_loop_var;
         return For::make(op->loop_var, op->min, op->extent, op->for_type,
                          op->device_api, alloc_body, op->annotate_keys,
                          op->annotate_values);

--- a/tvm/src/schedule/schedule_dataflow_rewrite.cc
+++ b/tvm/src/schedule/schedule_dataflow_rewrite.cc
@@ -93,16 +93,16 @@ class ParentStmtCollector final : public IRMutator {
             reuse_buf_,
             "attach_scope",
             StringImm::make(parent_name_),
-            attr->body);
+            op->body);
+        attr_stmt = Reuse::make(target_buf_, attr_stmt);
         attr_stmt = AttrStmt::make(
             attr->node,
             attr->attr_key,
             attr->value,
             attr_stmt);
-        Stmt reuse_stmt = Reuse::make(target_buf_, attr_stmt);
         return For::make(
             op->loop_var, op->min, op->extent, op->for_type, op->device_api,
-            reuse_stmt, op->annotate_keys, op->annotate_values);
+            attr_stmt, op->annotate_keys, op->annotate_values);
       } else {
         return For::make(
             op->loop_var, op->min, op->extent, op->for_type, op->device_api,


### PR DESCRIPTION
In this PR, we will implement the following features.

### Automatic Bound Inferring

With the existing ``reuse_at`` primitive, we assume that there is no user-specified padding. However, padding is everywhere. Thus, we need to be able to correctly infer the bound where the data will be stored in the reuse buffers. Following we show two examples that should work correctly after this PR.

```python
# This is without padding
A = hcl.placeholder((10,))
r = hcl.reduce_axis(0, 3)
# Note that we explicitly change the output shape
B = hcl.compute((8, ), lambda x: hcl.sum(A[x+r], axis=r))
s = hcl.create_schedule([A, B])
s.reuse_at(A, s[B], B.axis[0])


# This is with user-specified padding
A = hcl.placeholder((10,))
r = hcl.reduce_axis(0, 3)
# Note that the output shape is the same as the input shape
B = hcl.compute(
    (10, ), 
    lambda x: hcl.select(x == 0, A[x] + A[x+1],
              hcl.select(x == 9, A[x-1] + A[x], hcl.sum(A[x-1+r], axis=r))))
```

The users can definitely create another stage for padding tensor ``A`` in the above example. However, this could affect the performance since we introduce unnecessary memory read/write.

### Support Multiple Output Tensors Reusing the Same Input Tensor

The existing ``reuse_at`` primitive only supports one output tensor reusing one input tensor. However, multiple outputs can reuse the same input. In this case, we should create a single reuse buffer that can cover all reuse area. Note that since we have multiple outputs, with the current HeteroCL semantics, this can only be described using imperative DSL. Following we show an example, where we can actually create a line buffer and a window buffer for tensor B and C to reuse the input A.

```python
A = hcl.placeholder((10, 10))
B = hcl.placeholder((8, 8))
C = hcl.placeholder((8, 8))
r = hcl.reduce_axis(0, 3)
c = hcl.reduce_axis(0, 3)
def update_func(x, y):
    B[y, x] = hcl.sum(A[y+r, x], axis=r)
    C[y, x] = hcl.sum(A[y, x+c], axis=c)
D = hcl.mutate((8, 8), lambda y, x: update_func(y, x))
s = hcl.create_schedule([A, B, C, D])
LB = s.reuse_at(A, s[D], D.axis[0])
WB = s.reuse_at(LB, s[D], D.axis[1])
```

### Support One Output Tensor Reusing Multiple Input Tensors

This is the inverse case of the previous one. In this case, we should create separate reuse buffers for different inputs. In the following example, we have an extra dimension for C to store the different outputs. In this case, we need to use two separate ``reuse_at`` primitives to generate two reuse buffers.

```python
A = hcl.placeholder((10, 10))
B = hcl.placeholder((10, 10))
r = hcl.reduce_axis(0, 3)
c = hcl.reduce_axis(0, 3)
D = hcl.compute(
    (8, 8, 2), 
    lambda y, x, z: hcl.select(z == 0, hcl.sum(A[y+r, x], axis=r),
                                       hcl.sum(B[y, x+c], axis=c))
s = hcl.create_schedule([A, B, D])
RA = s.reuse_at(A, s[D], D.axis[0])
RB = s.reuse_at(B, s[D], D.axis[1])
```

### Other Notes

We will see if it is practical to add a mixing case of the above two cases. Namely, multiple outputs reusing multiple input tensors. In this case, usually the better way is to separate the case into smaller cases.