### PR TITLE
[API] Enable declarative code with hcl.def

### DIFF
--- a/python/heterocl/dsl.py
+++ b/python/heterocl/dsl.py
@@ -415,7 +415,7 @@ def def_(shapes, dtypes=None, ret_dtype=None, name=None):
             # prepare inputs for IR generation
             inputs = []
             inputs_tvm = []
-            arg_shapes, arg_dtypes = [], []
+            arg_shapes, arg_dtypes, arg_tensors = [], [], []
             for shape, name_, dtype in zip(shapes, new_names, dtypes):
                 if shape == ():
                     var_ = placeholder((), name_, dtype)
@@ -429,6 +429,7 @@ def def_(shapes, dtypes=None, ret_dtype=None, name=None):
                     inputs_tvm.append(placeholder_.buf.data)
                     arg_shapes.append(list(shape))
                     arg_dtypes.append(dtype)
+                    arg_tensors.append(placeholder_.op)
 
             s.ret_dtype = ret_dtype
             fmodule(*inputs)
@@ -441,7 +442,7 @@ def def_(shapes, dtypes=None, ret_dtype=None, name=None):
             ret_void = _make.UIntImm("uint1", 0) if s.has_return else _make.UIntImm("uint1", 1)
             body = s.pop_stmt()
             s.stmt_stack.append([])
-            s.emit(_make.KernelDef(inputs_tvm, arg_shapes, arg_dtypes,
+            s.emit(_make.KernelDef(inputs_tvm, arg_shapes, arg_dtypes, arg_tensors,
                                    body, ret_void, ret_dtype, name, []))
             for name_, i in zip(names, inputs):
                 s.var_dict[name_] = i

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -28,14 +28,14 @@ from ..devices import platform
 # test build sim
 @register_func
 def tvm_callback_syn_postproc(code):
-    return "test" 
+    return "test"
 
 @register_func
 def get_util_path(platform):
     if platform == "aws_f1":
-        return "/work/zhang-x1/users/sx233/heterocl/tvm/src/template/sdaccel/" 
+        return "/work/zhang-x1/users/sx233/heterocl/tvm/src/template/sdaccel/"
     elif platform == "rocket":
-        ppac = "/work/zhang-x1/users/sx233/heterocl/hlib/rocc-ppac" 
+        ppac = "/work/zhang-x1/users/sx233/heterocl/hlib/rocc-ppac"
         emulator = os.path.join(ppac, "rocket/emulator/emulator-freechips." + \
                                       "rocketchip.system-RoccExampleConfig-debug")
         # build emulator if not exist
@@ -47,8 +47,8 @@ def get_util_path(platform):
                    "cd emulator && make CONFIG=RoccExampleConfig debug"
             # create subprocess to check
             subprocess.Popen(cmd, shell=True, stdout=open("build.log", "w")).wait()
-             
-        # re-build proxy kernel 
+
+        # re-build proxy kernel
         if not os.path.isfile(ppac + "/rocket/riscv-pk/build/pk"):
             cmd = "cd " + ppac + "/rocket/riscv-pk;"
             cmd += "git apply ../../tests/patches/riscv-pk.patch;"
@@ -57,11 +57,11 @@ def get_util_path(platform):
             cmd += "make -j8; make install"
             subprocess.Popen(cmd, shell=True, stdout=open("build.log", "w")).wait()
         # return util folder needed to compile generated test files
-        return "/work/zhang-x1/users/sx233/heterocl/rocc-ppac/tests" 
+        return "/work/zhang-x1/users/sx233/heterocl/rocc-ppac/tests"
 
-    # copy tcl and testbench  
+    # copy tcl and testbench
     elif platform == "vivado_hls":
-        return "/work/zhang-x1/users/sx233/heterocl/tvm/src/template/vivado" 
+        return "/work/zhang-x1/users/sx233/heterocl/tvm/src/template/vivado"
 
     else: # unrecognized platform
         assert False, "unsupported platform"
@@ -452,7 +452,7 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
     if args is None:
         raise ValueError("args must be given for build from schedule")
 
-    # generate host (device) code / function 
+    # generate host (device) code / function
     if target == "merlinc":
         BuildConfig.current = build_config(generate_reuse_buffer=False)
     else:
@@ -471,7 +471,7 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
             start = ret.find("{host}")
             end = ret.rfind("{host}")
             ret = decl + "\n" + ret[start+6:end]
-            ret = ret.strip("\n").lstrip("\n") + "\n\n" 
+            ret = ret.strip("\n").lstrip("\n") + "\n\n"
         return ret
 
     try: # generate and split code
@@ -484,7 +484,7 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
             xcel = target.xcel.lang.replace("hlsc", "vhls")
         elif target.tool.name == "rocket":
             host = target.host.lang.replace("c", "rv64_ppac")
-   
+
         # return simulation built function
         mode = str(target.tool.mode)
         if "emu" in mode or "sim" in mode:
@@ -498,7 +498,7 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
             pass
         else: # return source code only
             host_code, xcel_code = "", ""
-            if host: # src mode generate host code 
+            if host: # src mode generate host code
                 builder = getattr(codegen, "build_{0}".format(host))
                 host_code = builder(fdevice)
                 findex, rindex = host_code.find("{host}"), host_code.rfind("{host}")
@@ -508,7 +508,7 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
                 xcel_code = builder(fdevice)
                 findex, rindex = xcel_code.find("{device}"), xcel_code.rfind("{device}")
                 xcel_code = xcel_code[findex + 8 : rindex]
-            return xcel_code + host_code 
+            return xcel_code + host_code
 
     except AttributeError:
         raise AttributeError("Cannot find the target builder %s" % target)

--- a/tvm/HalideIR/src/ir/IR.cpp
+++ b/tvm/HalideIR/src/ir/IR.cpp
@@ -692,23 +692,25 @@ Expr Quantize::make(Expr body, Expr bitwidth) {
   return Expr(node);
 }
 
-Stmt KernelDef::make(Array<VarExpr> args, Array<Array<Expr>> api_args, 
-                     Array<Expr> api_types, Stmt body, Expr ret_void, 
+Stmt KernelDef::make(Array<VarExpr> args, Array<Array<Expr>> arg_shapes, 
+                     Array<Expr> arg_types, Array<FunctionRef> arg_tensors,
+                     Stmt body, Expr ret_void, 
                      Type ret_type, std::string name, Array<Expr> channels) {
-  internal_assert(api_args.size() == api_types.size()) << "KernelDef of unmatched args\n";
+  internal_assert(arg_shapes.size() == arg_types.size()) << "KernelDef of unmatched args\n";
   for (size_t i = 0; i < args.size(); i++) {
     internal_assert(args[i].defined()) << "KernelDef of undefined arg\n";
-    internal_assert(api_types[i].defined()) << "KernelDef of undefined type\n";
-    for (size_t j = 0; j < api_args[i].size(); j++) {
-      internal_assert(api_args[i][j].defined()) << "KernelDef of undefined shape\n";
+    internal_assert(arg_types[i].defined()) << "KernelDef of undefined type\n";
+    for (size_t j = 0; j < arg_shapes[i].size(); j++) {
+      internal_assert(arg_shapes[i][j].defined()) << "KernelDef of undefined shape\n";
     }
   }
   internal_assert(body.defined()) << "KernelDef of undefined body\n";
   internal_assert(ret_void.defined()) << "KernelDef of undefined return type\n";  
   std::shared_ptr<KernelDef> node = std::make_shared<KernelDef>();
   node->args = std::move(args);
-  node->api_args = std::move(api_args);
-  node->api_types = std::move(api_types);
+  node->arg_shapes = std::move(arg_shapes);
+  node->arg_types = std::move(arg_types);
+  node->arg_tensors = std::move(arg_tensors);
   node->body = std::move(body);
   node->ret_void = std::move(ret_void);
   node->ret_type = ret_type;

--- a/tvm/HalideIR/src/ir/IR.h
+++ b/tvm/HalideIR/src/ir/IR.h
@@ -1050,8 +1050,9 @@ struct Quantize : public ExprNode<Quantize> {
 /** The imperative function definition */
 struct KernelDef : public StmtNode<KernelDef> {
   Array<VarExpr> args;
-  Array<Array<Expr>> api_args;
-  Array<Expr> api_types;
+  Array<Array<Expr>> arg_shapes;
+  Array<Expr> arg_types;
+  Array<FunctionRef> arg_tensors;
   Stmt body;
   Expr ret_void;
   Type ret_type;
@@ -1059,15 +1060,19 @@ struct KernelDef : public StmtNode<KernelDef> {
   // args to stream data 
   Array<Expr> channels;
 
-  EXPORT static Stmt make(Array<VarExpr> args, Array<Array<Expr>> api_args, 
-                          Array<Expr> api_types, Stmt body, Expr ret_void, 
+  EXPORT static Stmt make(Array<VarExpr> args, 
+                          Array<Array<Expr>> arg_shapes, 
+                          Array<Expr> arg_types, 
+                          Array<FunctionRef> arg_tensors,
+                          Stmt body, Expr ret_void, 
                           Type ret_type, std::string name, 
                           Array<Expr> channels);
 
   void VisitAttrs(IR::AttrVisitor* v) final {
     v -> Visit("args", &args);
-    v -> Visit("api_args", &api_args);
-    v -> Visit("api_types", &api_types);
+    v -> Visit("arg_shapes", &arg_shapes);
+    v -> Visit("arg_types", &arg_types);
+    v -> Visit("arg_tensors", &arg_tensors);
     v -> Visit("body", &body);
     v -> Visit("ret_void", &ret_void);
     v -> Visit("ret_type", &ret_type);

--- a/tvm/HalideIR/src/ir/IRMutator.cpp
+++ b/tvm/HalideIR/src/ir/IRMutator.cpp
@@ -480,7 +480,7 @@ void IRMutator::visit(const KernelDef *op, const Stmt &s) {
     stmt = s;
   }
   else {
-    stmt = KernelDef::make(op->args, op->api_args, op->api_types,
+    stmt = KernelDef::make(op->args, op->arg_shapes, op->arg_types, op->arg_tensors,
                            body, ret_void, op->ret_type, op->name, op->channels);
   }
 }

--- a/tvm/HalideIR/src/ir/IRPrinter.cpp
+++ b/tvm/HalideIR/src/ir/IRPrinter.cpp
@@ -738,11 +738,11 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
     for (size_t i = 0; i < op->args.size(); i++) {
         p->stream << op->args[i].type() << "("; // handle type
         p->print(op->args[i]);
-        if (op->api_args[i].size() > 1) {
+        if (op->arg_shapes[i].size() > 1) {
           p->stream << "[";
-          for (size_t j = 0; j < op->api_args[i].size(); j++) {
-            p->print(op->api_args[i][j]);
-            if (j < op->api_args[i].size() - 1) p->stream << "*";
+          for (size_t j = 0; j < op->arg_shapes[i].size(); j++) {
+            p->print(op->arg_shapes[i][j]);
+            if (j < op->arg_shapes[i].size() - 1) p->stream << "*";
           }
           p->stream << "])";
         }

--- a/tvm/HalideIR/src/ir/IRVisitor.cpp
+++ b/tvm/HalideIR/src/ir/IRVisitor.cpp
@@ -273,9 +273,8 @@ void IRVisitor::visit(const Quantize *op, const Expr &) {
 void IRVisitor::visit(const KernelDef *op, const Stmt &) {
   for (size_t i = 0; i < op->args.size(); i++) {
     op->args[i].accept(this);
-    op->api_types[i].accept(this);
-    for (size_t j = 0; j < op->api_args[i].size(); j++) {
-      op->api_args[i][j].accept(this);
+    for (size_t j = 0; j < op->arg_shapes[i].size(); j++) {
+      op->arg_shapes[i][j].accept(this);
     }
   }
   op->ret_void.accept(this);
@@ -585,9 +584,8 @@ void IRGraphVisitor::visit(const Quantize *op, const Expr &) {
 void IRGraphVisitor::visit(const KernelDef *op, const Stmt &) {
   for (size_t i = 0; i < op->args.size(); i++) {
     include(op->args[i]);
-    include(op->api_types[i]);
-    for (size_t j = 0; j < op->api_args[i].size(); j++) {
-      include(op->api_args[i][j]);
+    for (size_t j = 0; j < op->arg_shapes[i].size(); j++) {
+      include(op->arg_shapes[i][j]);
     }
   }
   include(op->ret_void);

--- a/tvm/src/api/api_ir.cc
+++ b/tvm/src/api/api_ir.cc
@@ -190,6 +190,14 @@ TVM_REGISTER_API("make.Select")
                         args[4], args[5], args[6], args[7]);                    \
     })                                                                          \
 
+#define REGISTER_MAKE9(Node)                                                    \
+  TVM_REGISTER_API("make."#Node)                                                \
+  .set_body([](TVMArgs args,  TVMRetValue *ret) {                               \
+      *ret = Node::make(args[0], args[1], args[2], args[3],                     \
+                        args[4], args[5], args[6], args[7],                     \
+                        args[8]);                                               \
+    })                                                                          \
+
 #define REGISTER_MAKE_BINARY_OP(Node)                        \
   TVM_REGISTER_API("make."#Node)                             \
   .set_body([](TVMArgs args,  TVMRetValue *ret) {            \
@@ -236,7 +244,7 @@ REGISTER_MAKE3(GetSlice);
 REGISTER_MAKE3(SetBit);
 REGISTER_MAKE4(SetSlice);
 REGISTER_MAKE2(Quantize);
-REGISTER_MAKE8(KernelDef);
+REGISTER_MAKE9(KernelDef);
 REGISTER_MAKE3(KernelExpr);
 REGISTER_MAKE2(KernelStmt);
 REGISTER_MAKE1(Return);

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -1213,17 +1213,17 @@ void CodeGenC::VisitStmt_(const KernelDef* op) {
   }
   for (size_t i = 0; i < op->args.size(); ++i) {
     VarExpr v = op->args[i];
-    var_shape_map_[v.get()] = op->api_args[i];
+    var_shape_map_[v.get()] = op->arg_shapes[i];
     std::string vid = AllocVarID(v.get());
     if (i != 0) stream << ", ";
-    std::string str = PrintExpr(op->api_types[i]);
+    std::string str = PrintExpr(op->arg_types[i]);
     Type type = String2Type(str);
     PrintType(type, stream);
     this->stream << " " << vid << "[";
     if (v.type().is_handle()) {
-      for (size_t j = 0; j < op->api_args[i].size(); j++) {
+      for (size_t j = 0; j < op->arg_shapes[i].size(); j++) {
         if (j != 0) stream << "* ";
-        auto dim = op->api_args[i][j].as<IntImm>()->value;
+        auto dim = op->arg_shapes[i][j].as<IntImm>()->value;
         this->stream << dim;
       }
       this->stream << ']';

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -364,10 +364,10 @@ void CodeGenVivadoHLS::VisitStmt_(const KernelDef* op) {
   }
   for (size_t i = 0; i < op->args.size(); ++i) {
     VarExpr v = op->args[i];
-    var_shape_map_[v.get()] = op->api_args[i];
+    var_shape_map_[v.get()] = op->arg_shapes[i];
     std::string vid = AllocVarID(v.get());
     if (i != 0) stream << ", ";
-    std::string str = PrintExpr(op->api_types[i]);
+    std::string str = PrintExpr(op->arg_types[i]);
     Type type = String2Type(str);
 
     // pass the stream channel reference 
@@ -380,8 +380,8 @@ void CodeGenVivadoHLS::VisitStmt_(const KernelDef* op) {
       PrintType(type, stream);
       this->stream << " " << vid << "[";
       int mul = 1;
-      for (size_t j = 0; j < op->api_args[i].size(); j++) {
-        auto dim = op->api_args[i][j].as<IntImm>()->value;
+      for (size_t j = 0; j < op->arg_shapes[i].size(); j++) {
+        auto dim = op->arg_shapes[i][j].as<IntImm>()->value;
         mul = mul * dim;
       }
       this->stream << mul << "]";

--- a/tvm/src/codegen/opencl/codegen_aocl.cc
+++ b/tvm/src/codegen/opencl/codegen_aocl.cc
@@ -255,7 +255,7 @@ void CodeGenAOCL::VisitStmt_(const KernelDef* op) {
   } 
   for (size_t i = 0; i < op->args.size(); ++i) {
     VarExpr v = op->args[i];
-    var_shape_map_[v.get()] = op->api_args[i];
+    var_shape_map_[v.get()] = op->arg_shapes[i];
     std::string vid = AllocVarID(v.get());
     if (stream_args.count(i)) { 
       stream_arg_pos[op->name].insert(i); 
@@ -269,7 +269,7 @@ void CodeGenAOCL::VisitStmt_(const KernelDef* op) {
         else stream << ", ";
       } // un-streamed argument 
       this->stream << "__global ";
-      std::string str = PrintExpr(op->api_types[i]);
+      std::string str = PrintExpr(op->arg_types[i]);
       Type type = String2Type(str);
       PrintType(type, stream);
       this->stream << "* restrict " << vid;

--- a/tvm/src/pass/ir_mutator.cc
+++ b/tvm/src/pass/ir_mutator.cc
@@ -330,7 +330,7 @@ Stmt IRMutator::Mutate_(const KernelDef *op, const Stmt &s) {
   if (body.same_as(op->body) && ret_void.same_as(op->ret_void)) {
     return s;
   } else {
-    return KernelDef::make(op->args, op->api_args, op->api_types,
+    return KernelDef::make(op->args, op->arg_shapes, op->arg_types, op->arg_tensors,
                            body, ret_void, op->ret_type, op->name, op->channels);
   }
 }

--- a/tvm/src/pass/storage_flatten.cc
+++ b/tvm/src/pass/storage_flatten.cc
@@ -27,6 +27,31 @@ using runtime::StorageScope;
 using runtime::ThreadScope;
 using intrinsic::tvm_address_of;
 
+Type String2Type(std::string& s) {
+  if (s.front() == '\"' && s.back() == '\"') {
+    s.erase(0, 1);
+    s.pop_back();
+  }
+  std::istringstream is(s);
+  halideir_type_code_t code = Type::Int;
+  if (s.substr(0, 3) == "int") {
+    code = Type::Int; s = s.substr(3);
+  } else if (s.substr(0, 4) == "uint") {
+    code = Type::UInt; s = s.substr(4);
+  } else if (s.substr(0, 5) == "float") {
+    code = Type::Float; s = s.substr(5);
+  } else if (s == "handle") {
+    return Handle();
+  } else {
+    LOG(FATAL) << "unknown type " << s;
+  }
+  int bits = 32, lanes = 1;
+  if (sscanf(s.c_str(), "%dx%d", &bits, &lanes) == 0) {
+    LOG(FATAL) << "unknown type " << s;
+  }
+  return Type(code, bits, lanes);
+}
+
 class StorageFlattener : public IRMutator {
  public:
   explicit StorageFlattener(Map<Tensor, Buffer> extern_buffer,
@@ -211,6 +236,17 @@ class StorageFlattener : public IRMutator {
           StringImm::make(e.buffer->scope), ret);
       return ret;
     }
+  }
+
+  Stmt Mutate_(const KernelDef* op, const Stmt& s) final {
+    for (size_t i = 0; i < op->arg_tensors.size(); i++)
+      kernel_arg_tensors_.push_back(op->arg_tensors[i]);
+
+    Stmt body = this->Mutate(op->body);
+    return KernelDef::make(op->args, op->arg_shapes, op->arg_types,
+                           op->arg_tensors, body, op->ret_void,
+                           op->ret_type, op->name, op->channels);
+    
   }
 
   Expr Mutate_(const Load* op, const Expr& e) final {
@@ -409,6 +445,11 @@ class StorageFlattener : public IRMutator {
     const Call* tuple = op->value.as<Call>();
     CHECK(buffer && tensor);
     CHECK(tuple && tuple->is_intrinsic(intrinsic::tvm_tuple));
+    // special handle for kernel args
+    for (size_t i = 0; i < kernel_arg_tensors_.size(); i++) {
+      if (tensor->op == kernel_arg_tensors_[i])
+        return this->Mutate(op->body);
+    }
     TensorKey key{tensor->op, tensor->value_index};
     CHECK(buf_map_.count(key))
         << "Cannot find buffer of " << tensor->op << " value=" << tensor->value_index;
@@ -498,6 +539,8 @@ class StorageFlattener : public IRMutator {
   bool has_stencil_{false};
   std::unordered_set<VarExpr, ExprHash, ExprEqual> inputs_;
   std::unordered_set<VarExpr, ExprHash, ExprEqual> outputs_;
+  // for KernelDef
+  std::vector<FunctionRef> kernel_arg_tensors_;
 };
 
 Stmt StorageFlatten(Stmt stmt,

--- a/tvm/src/schedule/schedule_dataflow_rewrite.cc
+++ b/tvm/src/schedule/schedule_dataflow_rewrite.cc
@@ -199,8 +199,9 @@ class KernelUpdater final : public IRMutator {
         stmt = mutator.Mutate(stmt);
       }
       // update kernel arg signature
-      return KernelDef::make(op->args, op->api_args, 
-                             op->api_types, stmt, op->ret_void,
+      return KernelDef::make(op->args, op->arg_shapes, 
+                             op->arg_types, op->arg_tensors,
+                             stmt, op->ret_void,
                              op->ret_type, op->name, arr);
    }
   private:


### PR DESCRIPTION
In this PR, we enable using declarative code along with hcl.def. Following is an example.

```python                                                                                                                                                                                               
@hcl.def_([a.shape, b.shape, c.shape])                                                                                                                                                           
def add(a, b, c):                                                                                                                                                                                
    d = hcl.compute(a.shape, lambda *x: a[x] + b[x], "d")                                                                                                                                        
    hcl.update(c, lambda *x: d[x] + 1, "u")                                                                                                                                                      
                                                                                                                                                                                                        
add(a, b, c)
```

More examples can be found in the test.       