### PR TITLE
[API] Adding printing function to HeteroCL

### DIFF
--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -584,6 +584,7 @@ def pack(tensor, axis=0, factor=None, name=None, dtype=None):
 
     return compute(tuple(new_shape), assign_val, name, dtype)
 
+
 def reduce_axis(lower, upper, name=None):
     """Create a reduction axis for reduction operations.
 

--- a/python/heterocl/dsl.py
+++ b/python/heterocl/dsl.py
@@ -11,6 +11,12 @@ from .schedule import Stage
 from .module import Module
 from . import util
 
+def print(val):
+    if not Stage.get_len():
+        raise DSLError("Imperative DSL must be used with other compute APIs")
+    stage = Stage.get_current()
+    stage.emit(_make.Print(val))
+
 def and_(*args):
     """Compute the logic AND between expressions.
 

--- a/python/heterocl/dsl.py
+++ b/python/heterocl/dsl.py
@@ -11,12 +11,6 @@ from .schedule import Stage
 from .module import Module
 from . import util
 
-def print(val):
-    if not Stage.get_len():
-        raise DSLError("Imperative DSL must be used with other compute APIs")
-    stage = Stage.get_current()
-    stage.emit(_make.Print(val))
-
 def and_(*args):
     """Compute the logic AND between expressions.
 

--- a/python/heterocl/schedule.py
+++ b/python/heterocl/schedule.py
@@ -279,6 +279,7 @@ class Stage(object):
         self.ret_dtype = None
         self.for_level = 0
         self.for_ID = 0
+        self.substages = []
         # Attributes for cross-stage relation
         self.input_stages = set([])
         self.lhs_tensors = set([])
@@ -331,6 +332,8 @@ class Stage(object):
             superstage.var_dict[self.name] = self
             # update prefix
             self.name_with_prefix = superstage.name_with_prefix + "." + self.name
+            # update superstage's substages
+            superstage.substages.append(self)
         # Otherwise update the list of stages globally
         else:
             Schedule.stage_ops.append(self)

--- a/python/heterocl/tvm/stmt.py
+++ b/python/heterocl/tvm/stmt.py
@@ -112,3 +112,7 @@ class Partition(Stmt):
 @register_node
 class Stencil(Stmt):
     pass
+
+@register_node
+class Print(Stmt):
+    pass

--- a/tests/test_api_print.py
+++ b/tests/test_api_print.py
@@ -1,0 +1,41 @@
+import heterocl as hcl
+import numpy as np
+import pathlib
+import subprocess
+
+def get_stdout(filename):
+    path = pathlib.Path(__file__).parent.absolute()
+    path = str(path) + "/test_api_print_cases/" + filename + ".py"
+    p = subprocess.run(['python', path], stdout=subprocess.PIPE)
+    output = p.stdout.decode('utf-8')
+    return str(output)
+
+def test_print_number():
+
+    output = get_stdout("print_number")
+
+    golden = "5\n2.500000\n"
+
+    assert str(output) == golden
+
+def test_print_expr():
+
+    outputs = get_stdout("print_expr").split("\n")
+
+    N = 4
+    for i in range(0, N):
+        assert outputs[i] == outputs[i+N]
+
+def test_print_tensor_1D():
+
+    outputs = get_stdout("print_tensor_1D").split("\n")
+
+    assert outputs[0] == outputs[1]
+
+def test_print_tensor_2D():
+
+    outputs = get_stdout("print_tensor_2D").split("\n")
+
+    N = 10
+    for i in range(0, N):
+        assert outputs[i] == outputs[i+N]

--- a/tests/test_api_print_cases/print_expr.py
+++ b/tests/test_api_print_cases/print_expr.py
@@ -1,0 +1,78 @@
+import heterocl as hcl
+import numpy as np
+
+# case1: int
+
+hcl.init()
+
+A = hcl.placeholder((10,))
+
+def kernel(A):
+    hcl.print(A[5])
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.randint(0, 10, size=(10,))
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+print(hcl_A.asnumpy()[5])
+
+# case2: float
+
+hcl.init(hcl.Float())
+
+A = hcl.placeholder((10,))
+
+def kernel(A):
+    hcl.print(A[5], "%.4f\n")
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.rand(10)
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+print("%.4f" % hcl_A.asnumpy()[5])
+
+# case3: fixed points
+
+hcl.init(hcl.UFixed(6, 4))
+
+A = hcl.placeholder((10,))
+
+def kernel(A):
+    hcl.print(A[5], "%.4f\n")
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.rand(10)
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+print("%.4f" % hcl_A.asnumpy()[5])
+
+# case4: two ints
+
+hcl.init()
+
+A = hcl.placeholder((10,))
+
+def kernel(A):
+    hcl.print((A[5], A[6]), "%d %d\n")
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.randint(0, 10, size=(10,))
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+print(str(np_A[5]) + " " + str(np_A[6]))

--- a/tests/test_api_print_cases/print_number.py
+++ b/tests/test_api_print_cases/print_number.py
@@ -1,0 +1,18 @@
+import heterocl as hcl
+import numpy as np
+
+A = hcl.placeholder((10,))
+
+hcl.init()
+
+def kernel(A):
+    hcl.print(5)
+    hcl.print(2.5)
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.rand(10)
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)

--- a/tests/test_api_print_cases/print_tensor_1D.py
+++ b/tests/test_api_print_cases/print_tensor_1D.py
@@ -1,0 +1,25 @@
+import heterocl as hcl
+import numpy as np
+
+hcl.init()
+
+A = hcl.placeholder((10,))
+
+def kernel(A):
+    hcl.print(A)
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.randint(0, 10, size=(10,))
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+s = "["
+for i in range(0, 10):
+    s += str(np_A[i])
+    if i < 9:
+        s += ", "
+s += "]"
+print(s)

--- a/tests/test_api_print_cases/print_tensor_2D.py
+++ b/tests/test_api_print_cases/print_tensor_2D.py
@@ -1,0 +1,30 @@
+import heterocl as hcl
+import numpy as np
+
+hcl.init()
+
+A = hcl.placeholder((10, 10))
+
+def kernel(A):
+    hcl.print(A)
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.randint(0, 10, size=(10, 10))
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+s = "["
+for i in range(0, 10):
+    s += "["
+    for j in range(0, 10):
+        s += str(np_A[i][j])
+        if j < 9:
+            s += ", "
+    s += "]"
+    if i < 9:
+        s += ",\n"
+s += "]"
+print(s)

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -55,9 +55,8 @@ def test_or():
 def test_if():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.if_(A[0] > 5):
-                A[0] = 5
+        with hcl.if_(A[0] > 5):
+            A[0] = 5
 
     A = hcl.placeholder((1,))
     s = hcl.create_schedule(A, kernel)
@@ -76,11 +75,10 @@ def test_if():
 def test_else():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.if_(A[0] > 5):
-                A[0] = 5
-            with hcl.else_():
-                A[0] = -1
+        with hcl.if_(A[0] > 5):
+            A[0] = 5
+        with hcl.else_():
+            A[0] = -1
 
     A = hcl.placeholder((1,))
     s = hcl.create_schedule(A, kernel)
@@ -99,11 +97,10 @@ def test_else():
 def test_elif():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.if_(A[0] > 5):
-                A[0] = 5
-            with hcl.elif_(A[0] > 3):
-                A[0] = 3
+        with hcl.if_(A[0] > 5):
+            A[0] = 5
+        with hcl.elif_(A[0] > 3):
+            A[0] = 3
 
     A = hcl.placeholder((1,))
     s = hcl.create_schedule(A, kernel)
@@ -122,13 +119,12 @@ def test_elif():
 def test_cond_all():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.if_(A[0] > 5):
-                A[0] = 5
-            with hcl.elif_(A[0] > 3):
-                A[0] = 3
-            with hcl.else_():
-                A[0] = 0
+        with hcl.if_(A[0] > 5):
+            A[0] = 5
+        with hcl.elif_(A[0] > 3):
+            A[0] = 3
+        with hcl.else_():
+            A[0] = 0
 
     A = hcl.placeholder((1,))
     s = hcl.create_schedule(A, kernel)
@@ -146,11 +142,10 @@ def test_cond_all():
 def test_elif():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.if_(A[0] > 5):
-                A[0] = 5
-            with hcl.elif_(A[0] > 3):
-                A[0] = 3
+        with hcl.if_(A[0] > 5):
+            A[0] = 5
+        with hcl.elif_(A[0] > 3):
+            A[0] = 3
 
     A = hcl.placeholder((1,))
     s = hcl.create_schedule(A, kernel)
@@ -168,9 +163,8 @@ def test_elif():
 def test_for_basic():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.for_(0, 10) as i:
-                A[i] = i
+        with hcl.for_(0, 10) as i:
+            A[i] = i
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -189,9 +183,8 @@ def test_for_basic():
 def test_for_irregular_bound():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.for_(4, 8) as i:
-                A[i] = i
+        with hcl.for_(4, 8) as i:
+            A[i] = i
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -212,9 +205,8 @@ def test_for_irregular_bound():
 def test_for_step_non_one():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.for_(0, 10, 2) as i:
-                A[i] = i
+        with hcl.for_(0, 10, 2) as i:
+            A[i] = i
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -235,9 +227,8 @@ def test_for_step_non_one():
 def test_for_step_negative():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.for_(9, -1, -1) as i:
-                A[i] = i
+        with hcl.for_(9, -1, -1) as i:
+            A[i] = i
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -256,11 +247,10 @@ def test_for_step_negative():
 def test_while_basic():
 
     def kernel(A):
-        with hcl.Stage():
-            a = hcl.scalar(0)
-            with hcl.while_(a[0] < 10):
-                A[a[0]] = a[0]
-                a[0] += 1
+        a = hcl.scalar(0)
+        with hcl.while_(a[0] < 10):
+            A[a[0]] = a[0]
+            a[0] += 1
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -279,11 +269,10 @@ def test_while_basic():
 def test_break_in_for():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.for_(0, 10) as i:
-                with hcl.if_(i > 5):
-                    hcl.break_()
-                A[i] = i
+        with hcl.for_(0, 10) as i:
+            with hcl.if_(i > 5):
+                hcl.break_()
+            A[i] = i
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -304,13 +293,12 @@ def test_break_in_for():
 def test_break_in_while():
 
     def kernel(A):
-        with hcl.Stage():
-            i = hcl.scalar(0)
-            with hcl.while_(True):
-                with hcl.if_(i[0] > 5):
-                    hcl.break_()
-                A[i[0]] = i[0]
-                i[0] += 1
+        i = hcl.scalar(0)
+        with hcl.while_(True):
+            with hcl.if_(i[0] > 5):
+                hcl.break_()
+            A[i[0]] = i[0]
+            i[0] += 1
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)
@@ -331,12 +319,11 @@ def test_break_in_while():
 def test_break_multi_level():
 
     def kernel(A):
-        with hcl.Stage():
-            with hcl.for_(0, 10) as i:
-                with hcl.for_(0, 10) as j:
-                    with hcl.if_(j >= i):
-                        hcl.break_()
-                    A[i] += j
+        with hcl.for_(0, 10) as i:
+            with hcl.for_(0, 10) as j:
+                with hcl.if_(j >= i):
+                    hcl.break_()
+                A[i] += j
 
     A = hcl.placeholder((10,))
     s = hcl.create_schedule(A, kernel)

--- a/tvm/HalideIR/src/ir/Expr.h
+++ b/tvm/HalideIR/src/ir/Expr.h
@@ -92,7 +92,9 @@ enum class IRNodeType : int {
     Reuse,
     Partition,
     /** for stencil analysis **/
-    Stencil
+    Stencil,
+    /** for debuggin **/
+    Print
 };
 
 /** The abstract base classes for a node in the Halide IR. */

--- a/tvm/HalideIR/src/ir/IR.cpp
+++ b/tvm/HalideIR/src/ir/IR.cpp
@@ -786,11 +786,14 @@ Stmt Stencil::make(Array<VarExpr> inputs, Array<VarExpr> outputs, Stmt body,
   return Stmt(node);
 }
 
-Stmt Print::make(Expr value) {
-  internal_assert(value.defined()) << "Print of undefined value\n";
+Stmt Print::make(Array<Expr> values, std::string format) {
+  for (size_t i = 0; i < values.size(); i++) {
+    internal_assert(values[i].defined()) << "KernelStmt of undefined value\n";
+  }
 
   std::shared_ptr<Print> node = std::make_shared<Print>();
-  node->value = std::move(value);
+  node->values = std::move(values);
+  node->format = std::move(format);
   return Stmt(node);
 }
 

--- a/tvm/HalideIR/src/ir/IR.cpp
+++ b/tvm/HalideIR/src/ir/IR.cpp
@@ -786,6 +786,14 @@ Stmt Stencil::make(Array<VarExpr> inputs, Array<VarExpr> outputs, Stmt body,
   return Stmt(node);
 }
 
+Stmt Print::make(Expr value) {
+  internal_assert(value.defined()) << "Print of undefined value\n";
+
+  std::shared_ptr<Print> node = std::make_shared<Print>();
+  node->value = std::move(value);
+  return Stmt(node);
+}
+
 namespace {
 
 // Helper function to determine if a sequence of indices is a
@@ -884,6 +892,7 @@ template<> void StmtNode<While>::accept(IRVisitor *v, const Stmt &s) const { v->
 template<> void StmtNode<Reuse>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const Reuse *)this, s); }
 template<> void StmtNode<Partition>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const Partition *)this, s); }
 template<> void StmtNode<Stencil>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const Stencil *)this, s); }
+template<> void StmtNode<Print>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const Print *)this, s); }
 
 Call::ConstString Call::debug_to_file = "debug_to_file";
 Call::ConstString Call::reinterpret = "reinterpret";

--- a/tvm/HalideIR/src/ir/IR.h
+++ b/tvm/HalideIR/src/ir/IR.h
@@ -1194,6 +1194,19 @@ struct Stencil : public StmtNode<Stencil> {
   static constexpr const char* _type_key = "Stencil";
 };
 
+struct Print : public StmtNode<Print> {
+  Expr value;
+  
+  EXPORT static Stmt make(Expr value);
+
+  void VisitAttrs(IR::AttrVisitor* v) final {
+    v -> Visit("value", &value);
+  }
+
+  static const IRNodeType _type_info = IRNodeType::Print;
+  static constexpr const char* _type_key = "Print";
+};
+
 }
 
 // inline functions

--- a/tvm/HalideIR/src/ir/IR.h
+++ b/tvm/HalideIR/src/ir/IR.h
@@ -1195,12 +1195,14 @@ struct Stencil : public StmtNode<Stencil> {
 };
 
 struct Print : public StmtNode<Print> {
-  Expr value;
+  Array<Expr> values;
+  std::string format;
   
-  EXPORT static Stmt make(Expr value);
+  EXPORT static Stmt make(Array<Expr> values, std::string format);
 
   void VisitAttrs(IR::AttrVisitor* v) final {
-    v -> Visit("value", &value);
+    v -> Visit("values", &values);
+    v -> Visit("format", &format);
   }
 
   static const IRNodeType _type_info = IRNodeType::Print;

--- a/tvm/HalideIR/src/ir/IRMutator.cpp
+++ b/tvm/HalideIR/src/ir/IRMutator.cpp
@@ -574,6 +574,16 @@ void IRMutator::visit(const Stencil *op, const Stmt &s) {
   }
 }
 
+void IRMutator::visit(const Print *op, const Stmt &s) {
+  Expr value = mutate(op->value);
+  if (value.same_as(op->value)) {
+    stmt = s;
+  }
+  else {
+    stmt = Print::make(value);
+  }
+}
+
 Stmt IRGraphMutator::mutate(Stmt s) {
     auto iter = stmt_replacements.find(s);
     if (iter != stmt_replacements.end()) {

--- a/tvm/HalideIR/src/ir/IRMutator.cpp
+++ b/tvm/HalideIR/src/ir/IRMutator.cpp
@@ -575,12 +575,21 @@ void IRMutator::visit(const Stencil *op, const Stmt &s) {
 }
 
 void IRMutator::visit(const Print *op, const Stmt &s) {
-  Expr value = mutate(op->value);
-  if (value.same_as(op->value)) {
+  vector<Expr> new_values(op->values.size());
+  bool changed = false;
+
+  for (size_t i = 0; i < op->values.size(); i++) {
+    Expr old_value = op->values[i];
+    Expr new_value = mutate(old_value);
+    if (!new_value.same_as(old_value)) changed = true;
+    new_values[i] = new_value;
+  }
+
+  if (!changed) {
     stmt = s;
   }
   else {
-    stmt = Print::make(value);
+    stmt = Print::make(new_values, op->format);
   }
 }
 

--- a/tvm/HalideIR/src/ir/IRMutator.h
+++ b/tvm/HalideIR/src/ir/IRMutator.h
@@ -99,6 +99,7 @@ protected:
     EXPORT virtual void visit(const Reuse *, const Stmt &);
     EXPORT virtual void visit(const Partition *, const Stmt &);
     EXPORT virtual void visit(const Stencil *, const Stmt &);
+    EXPORT virtual void visit(const Print *, const Stmt &);
 };
 
 

--- a/tvm/HalideIR/src/ir/IRPrinter.cpp
+++ b/tvm/HalideIR/src/ir/IRPrinter.cpp
@@ -851,8 +851,11 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
 TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
 .set_dispatch<Print>([](const Print *op, IRPrinter* p) {
     p->do_indent();
-    p->stream << "print: ";
-    p->print(op->value);
+    p->stream << "print:";
+    for (size_t i = 0; i < op->values.size(); i++) {
+      p->stream << " ";
+      p->print(op->values[i]);
+    }
     p->stream << "\n";
 });
 

--- a/tvm/HalideIR/src/ir/IRPrinter.cpp
+++ b/tvm/HalideIR/src/ir/IRPrinter.cpp
@@ -848,5 +848,13 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
     p->stream << "}\n";
 });
 
+TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
+.set_dispatch<Print>([](const Print *op, IRPrinter* p) {
+    p->do_indent();
+    p->stream << "print: ";
+    p->print(op->value);
+    p->stream << "\n";
+});
+
 }
 }

--- a/tvm/HalideIR/src/ir/IRVisitor.cpp
+++ b/tvm/HalideIR/src/ir/IRVisitor.cpp
@@ -304,7 +304,9 @@ void IRVisitor::visit(const Stencil *op, const Stmt &) {
 }
 
 void IRVisitor::visit(const Print *op, const Stmt &) {
-  op->value.accept(this);
+  for (size_t i = 0; i < op->values.size(); i++) {
+    op->values[i].accept(this);
+  }
 }
 
 
@@ -617,7 +619,9 @@ void IRGraphVisitor::visit(const Stencil *op, const Stmt &) {
 }
 
 void IRGraphVisitor::visit(const Print *op, const Stmt &) {
-  include(op->value);
+  for (size_t i = 0; i < op->values.size(); i++) {
+    include(op->values[i]);
+  }
 }
 
 }

--- a/tvm/HalideIR/src/ir/IRVisitor.cpp
+++ b/tvm/HalideIR/src/ir/IRVisitor.cpp
@@ -303,6 +303,11 @@ void IRVisitor::visit(const Stencil *op, const Stmt &) {
   op->body.accept(this);
 }
 
+void IRVisitor::visit(const Print *op, const Stmt &) {
+  op->value.accept(this);
+}
+
+
 void IRGraphVisitor::include(const Expr &e) {
     if (visited.count(e.get())) {
         return;
@@ -609,6 +614,10 @@ void IRGraphVisitor::visit(const Partition *op, const Stmt &) {}
 
 void IRGraphVisitor::visit(const Stencil *op, const Stmt &) {
   include(op->body);
+}
+
+void IRGraphVisitor::visit(const Print *op, const Stmt &) {
+  include(op->value);
 }
 
 }

--- a/tvm/HalideIR/src/ir/IRVisitor.h
+++ b/tvm/HalideIR/src/ir/IRVisitor.h
@@ -79,6 +79,7 @@ public:
     EXPORT virtual void visit(const Reuse *, const Stmt &);
     EXPORT virtual void visit(const Partition *, const Stmt &);
     EXPORT virtual void visit(const Stencil *, const Stmt &);
+    EXPORT virtual void visit(const Print *, const Stmt &);
 };
 
 /** A base class for algorithms that walk recursively over the IR
@@ -159,6 +160,7 @@ public:
     EXPORT virtual void visit(const Reuse *, const Stmt &);
     EXPORT virtual void visit(const Partition *, const Stmt &);
     EXPORT virtual void visit(const Stencil *, const Stmt &);
+    EXPORT virtual void visit(const Print *, const Stmt &);
     // @}
 };
 

--- a/tvm/include/tvm/ir.h
+++ b/tvm/include/tvm/ir.h
@@ -507,6 +507,7 @@ using Halide::Internal::While;
 using Halide::Internal::Reuse;
 using Halide::Internal::Partition;
 using Halide::Internal::Stencil;
+using Halide::Internal::Print;
 // ir functions
 using Halide::Internal::is_const_power_of_two_integer;
 

--- a/tvm/include/tvm/ir_functor_ext.h
+++ b/tvm/include/tvm/ir_functor_ext.h
@@ -250,6 +250,7 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
   virtual R VisitStmt_(const Reuse* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const Partition* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const Stencil* op, Args... args) STMT_FUNCTOR_DEFAULT;
+  virtual R VisitStmt_(const Print* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmtDefault_(const Node* op, Args ...) {
     LOG(FATAL) << "Do not have a default for " << op->type_key();
     return R();
@@ -281,6 +282,7 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
     IR_STMT_FUNCTOR_DISPATCH(Reuse);
     IR_STMT_FUNCTOR_DISPATCH(Partition);
     IR_STMT_FUNCTOR_DISPATCH(Stencil);
+    IR_STMT_FUNCTOR_DISPATCH(Print);
     return vtable;
   }
 };

--- a/tvm/include/tvm/ir_mutator.h
+++ b/tvm/include/tvm/ir_mutator.h
@@ -77,6 +77,7 @@ class TVM_DLL IRMutator {
   virtual Stmt Mutate_(const Reuse* op, const Stmt& s);
   virtual Stmt Mutate_(const Partition* op, const Stmt& s);
   virtual Stmt Mutate_(const Stencil* op, const Stmt& s);
+  virtual Stmt Mutate_(const Print* op, const Stmt& s);
 
   virtual Expr Mutate_(const Variable* op, const Expr& e);
   virtual Expr Mutate_(const Load* op, const Expr& e);

--- a/tvm/include/tvm/ir_visitor.h
+++ b/tvm/include/tvm/ir_visitor.h
@@ -137,6 +137,7 @@ class TVM_DLL IRVisitor {
   virtual void Visit_(const Reuse* op);
   virtual void Visit_(const Partition* op);
   virtual void Visit_(const Stencil* op);
+  virtual void Visit_(const Print* op);
 };
 
 /*!

--- a/tvm/src/api/api_ir.cc
+++ b/tvm/src/api/api_ir.cc
@@ -229,7 +229,7 @@ REGISTER_MAKE1(Return);
 REGISTER_MAKE2(While);
 REGISTER_MAKE2(Reuse);
 REGISTER_MAKE6(Stencil);
-REGISTER_MAKE1(Print);
+REGISTER_MAKE2(Print);
 
 }  // namespace ir
 }  // namespace TVM

--- a/tvm/src/api/api_ir.cc
+++ b/tvm/src/api/api_ir.cc
@@ -229,6 +229,7 @@ REGISTER_MAKE1(Return);
 REGISTER_MAKE2(While);
 REGISTER_MAKE2(Reuse);
 REGISTER_MAKE6(Stencil);
+REGISTER_MAKE1(Print);
 
 }  // namespace ir
 }  // namespace TVM

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -1419,11 +1419,7 @@ void CodeGenLLVM::VisitStmt_(const Print* op) {
       llvm_types.push_back(llvm::Type::getDoubleTy(*ctx_));
     }
   }
-  std::vector<llvm::Type*> call_types;
-  call_types.push_back(t_char_p_);
-  for (size_t i = 0; i < op->values.size(); i++)
-    call_types.push_back(llvm_types[i]);
-  llvm::FunctionType* call_ftype = llvm::FunctionType::get(t_int_, call_types, false);
+  llvm::FunctionType* call_ftype = llvm::FunctionType::get(t_int_, true);
   llvm::Function* printf_call = llvm::cast<llvm::Function>(module_->getOrInsertFunction("printf", call_ftype));
   std::vector<llvm::Value*> printf_args;
   std::string format = op->format;

--- a/tvm/src/codegen/llvm/codegen_llvm.h
+++ b/tvm/src/codegen/llvm/codegen_llvm.h
@@ -136,6 +136,7 @@ class CodeGenLLVM :
   void VisitStmt_(const While* op) override;
   void VisitStmt_(const Partition* op) override {};
   void VisitStmt_(const Stencil* op) override;
+  void VisitStmt_(const Print* op) override;
 
  protected:
   /*! \brief The storage information */
@@ -239,6 +240,7 @@ class CodeGenLLVM :
   llvm::PointerType* t_void_p_{nullptr};
   llvm::Type* t_int_{nullptr};
   llvm::Type* t_char_{nullptr};
+  llvm::PointerType* t_char_p_{nullptr};
   llvm::Type* t_int8_{nullptr};
   llvm::Type* t_int16_{nullptr};
   llvm::Type* t_int32_{nullptr};

--- a/tvm/src/codegen/llvm/llvm_module.cc
+++ b/tvm/src/codegen/llvm/llvm_module.cc
@@ -125,7 +125,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
         llvm::MDString::get(*ctx_, target));
     target_ = target;
     mptr_ = module_.get();
-    //this->SaveToFile("test.ll", "ll");
+    this->SaveToFile("test.ll", "ll");
   }
 
   void LoadIR(const std::string& file_name) {

--- a/tvm/src/codegen/llvm/llvm_module.cc
+++ b/tvm/src/codegen/llvm/llvm_module.cc
@@ -125,7 +125,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
         llvm::MDString::get(*ctx_, target));
     target_ = target;
     mptr_ = module_.get();
-    this->SaveToFile("test.ll", "ll");
+    //this->SaveToFile("test.ll", "ll");
   }
 
   void LoadIR(const std::string& file_name) {

--- a/tvm/src/lang/ir.cc
+++ b/tvm/src/lang/ir.cc
@@ -155,6 +155,7 @@ TVM_REGISTER_NODE_TYPE(While);
 TVM_REGISTER_NODE_TYPE(Reuse);
 TVM_REGISTER_NODE_TYPE(Partition);
 TVM_REGISTER_NODE_TYPE(Stencil);
+TVM_REGISTER_NODE_TYPE(Print);
 
 }  // namespace ir
 }  // namespace TVM

--- a/tvm/src/pass/ir_mutator.cc
+++ b/tvm/src/pass/ir_mutator.cc
@@ -385,6 +385,16 @@ Stmt IRMutator::Mutate_(const Stencil *op, const Stmt &s) {
   }
 }
 
+Stmt IRMutator::Mutate_(const Print *op, const Stmt &s) {
+  Expr value = this->Mutate(op->value);
+
+  if (value.same_as(op->value)) {
+    return s;
+  } else {
+    return Print::make(value);
+  }
+}
+
 TVM_STATIC_IR_FUNCTOR(IRMutator, vtable_stmt)
 .DISPATCH_TO_MUTATE_STMT(LetStmt)
 .DISPATCH_TO_MUTATE_STMT(AttrStmt)
@@ -407,7 +417,8 @@ TVM_STATIC_IR_FUNCTOR(IRMutator, vtable_stmt)
 .DISPATCH_TO_MUTATE_STMT(While)
 .DISPATCH_TO_MUTATE_STMT(Reuse)
 .DISPATCH_TO_MUTATE_STMT(Partition)
-.DISPATCH_TO_MUTATE_STMT(Stencil);
+.DISPATCH_TO_MUTATE_STMT(Stencil)
+.DISPATCH_TO_MUTATE_STMT(Print);
 
 // Mutate Expr
 

--- a/tvm/src/pass/ir_mutator.cc
+++ b/tvm/src/pass/ir_mutator.cc
@@ -386,12 +386,12 @@ Stmt IRMutator::Mutate_(const Stencil *op, const Stmt &s) {
 }
 
 Stmt IRMutator::Mutate_(const Print *op, const Stmt &s) {
-  Expr value = this->Mutate(op->value);
+  auto new_values = MutateArray(op->values, this);
 
-  if (value.same_as(op->value)) {
+  if (op->values.same_as(new_values)) {
     return s;
   } else {
-    return Print::make(value);
+    return Print::make(new_values, op->format);
   }
 }
 

--- a/tvm/src/pass/ir_visitor.cc
+++ b/tvm/src/pass/ir_visitor.cc
@@ -274,7 +274,9 @@ void IRVisitor::Visit_(const Stencil *op) {
 }
 
 void IRVisitor::Visit_(const Print *op) {
-  this->Visit(op->value);
+  for (size_t i = 0; i < op->values.size(); i++) {
+    this->Visit(op->values[i]);
+  }
 }
 
 #define DEFINE_OP_NO_VISIT_(OP)                     \

--- a/tvm/src/pass/ir_visitor.cc
+++ b/tvm/src/pass/ir_visitor.cc
@@ -273,6 +273,10 @@ void IRVisitor::Visit_(const Stencil *op) {
   this->Visit(op->body);
 }
 
+void IRVisitor::Visit_(const Print *op) {
+  this->Visit(op->value);
+}
+
 #define DEFINE_OP_NO_VISIT_(OP)                     \
   void IRVisitor::Visit_(const OP* op) {}
 
@@ -343,7 +347,8 @@ TVM_STATIC_IR_FUNCTOR(IRVisitor, vtable)
 .DISPATCH_TO_VISIT(While)
 .DISPATCH_TO_VISIT(Reuse)
 .DISPATCH_TO_VISIT(Partition)
-.DISPATCH_TO_VISIT(Stencil);
+.DISPATCH_TO_VISIT(Stencil)
+.DISPATCH_TO_VISIT(Print);
 
 }  // namespace ir
 }  // namespace TVM


### PR DESCRIPTION
### Main Features 

1. In this PR, we introduce a new API ``hcl.print``, which can print HeteroCL objects. Currently, the functionality is still very basic. In other words, we cannot generate pretty print like NumPy.
2. I also removed the need for using ``hcl.Stage`` at the top-level. A default top-level Stage will be generated automatically. Please refer to ``test_dsl_basic.py`` for more examples.

### Examples for ``hcl.print``

1. Print an expression

```python
A = hcl.compute((10,), lambda x: x)
hcl.print(A[0])
# output: 0
hcl.print(A[0], "A[0]: %d\n")
# output: A[0]: 0
hcl.print([A[0], A[1]])
# output: A[0] A[1]
hcl.print([A[0], A[1]], "0: %d, 1: %d\n")
# output: 0: 0, 1: 1
hcl.print(5)
# output: 5
```

More details: for integers, by default we use "%d". For all other data types including floating points and fixed points, we use "%f".

2. Print a Tensor or a slice of Tensor

```python
A = hcl.compute((3, 3), lambda x, y: x+y)
hcl.print(A[0])
# output: [0, 1, 2]
hcl.print(A)
# output:
# [[0, 1, 2],
# [1, 2, 3],
# [2, 3, 4]]
```

As can be seen from the example above, currently we do not have pretty print with indentations and also find the largest common number of digits. This will be introduced later.
