### PR TITLE
[Backend] Fixed Incorrect Behavior When Casting Constants to Very Long Int

### DIFF
--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -205,3 +205,21 @@ def test_dtype_long_int():
     f(hcl_A, hcl_C)
 
     assert np.array_equal(np_A, hcl_C.asnumpy())
+
+def test_dtype_const_long_int():
+
+    hcl.init(hcl.Int())
+    r = np.random.randint(0, 10, size=(1,))
+
+    def kernel():
+        A = hcl.compute((1,), lambda x: r[0], dtype=hcl.Int(128))
+        B = hcl.compute((1,), lambda x: A[x])
+        return B
+
+    s = hcl.create_schedule([], kernel)
+    f = hcl.build(s)
+    np_B = np.zeros((1,))
+    hcl_B = hcl.asarray(np_B)
+    f(hcl_B)
+
+    assert np.array_equal(r, hcl_B.asnumpy())

--- a/tvm/HalideIR/src/ir/IR.cpp
+++ b/tvm/HalideIR/src/ir/IR.cpp
@@ -29,9 +29,9 @@ Expr IntImm::make(Type t, int64_t value) {
     //    << "IntImm must be 8, 16, 32, or 64-bit\n";
 
     // Normalize the value by dropping the high bits
-    value <<= (64 - t.bits());
+    //value <<= (64 - t.bits());
     // Then sign-extending to get them back
-    value >>= (64 - t.bits());
+    //value >>= (64 - t.bits());
 
     std::shared_ptr<IntImm> node = std::make_shared<IntImm>();
     node->type = t;
@@ -46,8 +46,8 @@ Expr UIntImm::make(Type t, uint64_t value) {
     //    << "UIntImm must be 1, 8, 16, 32, or 64-bit\n";
 
     // Normalize the value by dropping the high bits
-    value <<= (64 - t.bits());
-    value >>= (64 - t.bits());
+    //value <<= (64 - t.bits());
+    //value >>= (64 - t.bits());
 
     std::shared_ptr<UIntImm> node = std::make_shared<UIntImm>();
     node->type = t;


### PR DESCRIPTION
The default Halide behavior for handling constant int is incorrect when handling bitwidth greater than 64. This PR fixed this problem by commenting out the behaviors that normalize the values in ``IR.cpp``.