### PR TITLE
[API][Backend] Fix hcl.print with UInt supported

### DIFF
--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -384,8 +384,9 @@ def print(vals, format=""):
 
     def get_format(val):
         if isinstance(val, (TensorSlice, Scalar, _expr.Expr)):
-            if util.get_type(val.dtype)[0] == "int":
-                return "%d"
+            if (util.get_type(val.dtype)[0] == "int"
+                    or util.get_type(val.dtype)[0] == "uint"):
+                return "%lld"
             else:
                 return "%f"
         elif isinstance(val, int):

--- a/tests/test_api_print.py
+++ b/tests/test_api_print.py
@@ -22,7 +22,7 @@ def test_print_expr():
 
     outputs = get_stdout("print_expr").split("\n")
 
-    N = 4
+    N = 5
     for i in range(0, N):
         assert outputs[i] == outputs[i+N]
 

--- a/tests/test_api_print_cases/print_expr.py
+++ b/tests/test_api_print_cases/print_expr.py
@@ -20,7 +20,26 @@ f(hcl_A)
 
 print(hcl_A.asnumpy()[5])
 
-# case2: float
+# case1: uint
+
+hcl.init(hcl.UInt(4))
+
+A = hcl.placeholder((10,))
+
+def kernel(A):
+    hcl.print(A[5])
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.randint(20, 30, size=(10,))
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+print(hcl_A.asnumpy()[5])
+
+# case3: float
 
 hcl.init(hcl.Float())
 
@@ -39,7 +58,7 @@ f(hcl_A)
 
 print("%.4f" % hcl_A.asnumpy()[5])
 
-# case3: fixed points
+# case4: fixed points
 
 hcl.init(hcl.UFixed(6, 4))
 
@@ -58,7 +77,7 @@ f(hcl_A)
 
 print("%.4f" % hcl_A.asnumpy()[5])
 
-# case4: two ints
+# case5: two ints
 
 hcl.init()
 


### PR DESCRIPTION
In this PR, we fix the issue in #183. Now we can print up to 64-bit integers and double-precision floating points.