### PR TITLE
[Backend] Fix Vivado HLS CodeGen for data type casting 

### DIFF
--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -141,8 +141,8 @@ def test_select_type_cast():
             hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
     s = hcl.create_scheme(A, kernel)
     s = hcl.create_schedule_from_scheme(s)
-    f = hcl.build(s, target="vhls")
-    print(f)
+    code = hcl.build(s, target="vhls")
+    assert "((ap_int<33>)(((ap_int<33>)A[(x + (y * 10))])" in code
 
 if __name__ == '__main__':
     test_legacy_interface()

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -123,3 +123,27 @@ def test_binary_conv():
     assert "for (ap_int<32> ff_outer = 0; ff_outer < 13; ++ff_outer)" in code
     assert "for (ap_int<32> ff_inner = 0; ff_inner < 5; ++ff_inner)" in code
     assert "if (ff_inner < (64 - (ff_outer * 5)))" in code
+
+def test_legacy_interface():
+    hcl.init()
+    A = hcl.placeholder((10, 10), "A")
+    B = hcl.compute(A.shape, lambda y, x: A[y][x], "B")
+    s = hcl.create_schedule([A, B])
+    s[B].fuse(B.axis[0], B.axis[1])
+    code = hcl.build(s, target="vhls")
+    assert "A[10*10]" in code
+    assert "B[10*10]" in code
+
+def test_select_type_cast():
+    A = hcl.placeholder((10, 10), "A")
+    def kernel(A):
+        return hcl.compute((8, 8), lambda y, x: 
+            hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
+    s = hcl.create_scheme(A, kernel)
+    s = hcl.create_schedule_from_scheme(s)
+    f = hcl.build(s, target="vhls")
+    print(f)
+
+if __name__ == '__main__':
+    test_legacy_interface()
+    test_select_type_cast()

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -135,14 +135,30 @@ def test_legacy_interface():
     assert "B[10*10]" in code
 
 def test_select_type_cast():
-    A = hcl.placeholder((10, 10), "A")
-    def kernel(A):
-        return hcl.compute((8, 8), lambda y, x: 
-            hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
-    s = hcl.create_scheme(A, kernel)
-    s = hcl.create_schedule_from_scheme(s)
-    code = hcl.build(s, target="vhls")
-    assert "((ap_int<33>)(((ap_int<33>)A[(x + (y * 10))])" in code
+    def test_imm_ops():
+        A = hcl.placeholder((10, 10), "A")
+        def kernel(A):
+            return hcl.compute((8, 8), lambda y, x: 
+                hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
+        s = hcl.create_scheme(A, kernel)
+        s = hcl.create_schedule_from_scheme(s)
+        code = hcl.build(s, target="vhls")
+        assert "((ap_int<33>)0)" in code
+        assert "((ap_int<33>)(((ap_int<33>)A" in code
+
+    def test_binary_ops():
+        A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))
+        B = hcl.placeholder((8, 8), "B", dtype=hcl.Fixed(16,12))
+        def kernel(A, B):
+            return hcl.compute((8, 8), lambda y, x: 
+                hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
+        s = hcl.create_scheme([A, B], kernel)
+        s = hcl.create_schedule_from_scheme(s)
+        code = hcl.build(s, target="vhls")
+        assert "(((ap_int<20>)B" in code
+
+    test_imm_ops()
+    test_binary_ops()
 
 if __name__ == '__main__':
     test_legacy_interface()


### PR DESCRIPTION
1. Fixed the ternary ops generation logic in Vivado HLS CodeGen. 
2. Fixed the function signature for legacy Vivado HLS CodeGen.
3. New test cases in vhls code generator testing.

Should fix #198 and #193. When generating the ternary ops in VHLS, HeteroCL will check the data type for each expressions. The checking logic will avoid duplicate dtype casting.