### PR TITLE
[API] Enable multiple compute with the same name

### DIFF
--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -211,10 +211,19 @@ def create_schedule(inputs, func=None):
                 inputs += list(ret)
             else:
                 inputs.append(ret)
+        # clean the attribute first
+        for name in dir(func):
+            if not (name[:2] == "__" and name [-2:] == "__"):
+                delattr(func, name)
         # let each stage be an attribute of the function
         for op in top.substages:
-            #op = stage._op
-            func.__setattr__(op.name, op)
+            if hasattr(func, op.name):
+                ops = getattr(func, op.name)
+                ops = ops if isinstance(ops, list) else [ops]
+                ops.append(op)
+                func.__setattr__(op.name, ops)
+            else:
+                func.__setattr__(op.name, op)
     t = Schedule.last_stages
     ops = [t_._op.op for t_ in t]
     return Schedule(_schedule.create_schedule(ops), inputs)

--- a/python/heterocl/util.py
+++ b/python/heterocl/util.py
@@ -7,7 +7,7 @@ from . import types
 from . import devices
 from . import config
 from .scheme import Scheme
-from .debug import DTypeError
+from .debug import DTypeError, APIError
 from .mutator import Mutator
 
 class VarName():
@@ -41,6 +41,8 @@ def get_name(var_type, name=None):
         The name of the variable.
     """
     if name is not None:
+        if name[:2] == "__" and name[-2:] == "__":
+            raise APIError("Invalid naming: must not start and end with __")
         return name
     else:
         if VarName.name_dict.get(var_type) is None:


### PR DESCRIPTION
In this PR, we enable multiple computations to share the same name. When using it during scheduling, users need to specify which computation by using the index. For example,

```python
A = hcl.placeholder((10,))

def kernel(A):
  B = hcl.compute(A.shape, lambda x: A[x], "X")
  C = hcl.compute(A.shape, lambda x: B[x], "X")
  return C

s = hcl.create_schedule([A], kernel)

X0 = kernel.X[0]
X1 = kernel.X[1]
s[X0].compute_at(s[X1], X1.axis[0])
```

More examples can be found in `test_api.py` under `tests`.
