### PR TITLE
[Backend] Fix Vivado HLS CodeGen for Data Type Casting

### DIFF
--- a/tests/test_codegen_soda.py
+++ b/tests/test_codegen_soda.py
@@ -49,9 +49,9 @@ unroll factor: 8
 iterate: 1
 input uint16: img_i(233, *)
 local uint16:
-  img_t(0, 0) = uint16((int32((uint18((uint17(img_i(-1, 0)) + uint17(img_i(0, 0)))) + uint18(img_i(1, 0)))) / 3))
+  img_t(0, 0) = uint16((uint32((uint18((uint17(img_i(-1, 0)) + uint17(img_i(0, 0)))) + uint18(img_i(1, 0)))) / 3))
 output uint16:
-  img_o(0, 0) = uint16((int32((uint18((uint17(img_t(0, -1)) + uint17(img_t(0, 0)))) + uint18(img_t(0, 1)))) / 3))
+  img_o(0, 0) = uint16((uint32((uint18((uint17(img_t(0, -1)) + uint17(img_t(0, 0)))) + uint18(img_t(0, 1)))) / 3))
 ''')
 
     def test_gaussian(self):

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -155,7 +155,7 @@ def test_select_type_cast():
         s = hcl.create_scheme([A, B], kernel)
         s = hcl.create_schedule_from_scheme(s)
         code = hcl.build(s, target="vhls")
-        assert "(((ap_int<20>)B" in code
+        assert "(ap_fixed<20, 8>)B[(x + (y * 8))]" in code
 
     test_imm_ops()
     test_binary_ops()

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -155,10 +155,22 @@ def test_select_type_cast():
         s = hcl.create_scheme([A, B], kernel)
         s = hcl.create_schedule_from_scheme(s)
         code = hcl.build(s, target="vhls")
-        assert "(ap_fixed<20, 8>)B[(x + (y * 8))]" in code
+        assert "(ap_fixed<32, 20>)B" in code
+
+    def test_uint_int():
+        A = hcl.placeholder((8, 8), "A", dtype=hcl.Fixed(20,12))
+        B = hcl.placeholder((8, 8), "B", dtype=hcl.UFixed(16,12))
+        def kernel(A, B):
+            return hcl.compute((8, 8), lambda y, x: 
+                hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
+        s = hcl.create_scheme([A, B], kernel)
+        s = hcl.create_schedule_from_scheme(s)
+        code = hcl.build(s, target="vhls")
+        assert "ap_ufixed<20, 8>)A" in code
 
     test_imm_ops()
     test_binary_ops()
+    test_uint_int()
 
 if __name__ == '__main__':
     test_legacy_interface()

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -141,8 +141,8 @@ def test_select_type_cast():
             hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
     s = hcl.create_scheme(A, kernel)
     s = hcl.create_schedule_from_scheme(s)
-    f = hcl.build(s, target="vhls")
-    print(f)
+    code = hcl.build(s, target="vhls")
+    assert "((ap_int<33>)(((ap_int<33>)A[(x + (y * 10))])" in code
 
 if __name__ == '__main__':
     test_legacy_interface()

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -123,3 +123,27 @@ def test_binary_conv():
     assert "for (ap_int<32> ff_outer = 0; ff_outer < 13; ++ff_outer)" in code
     assert "for (ap_int<32> ff_inner = 0; ff_inner < 5; ++ff_inner)" in code
     assert "if (ff_inner < (64 - (ff_outer * 5)))" in code
+
+def test_legacy_interface():
+    hcl.init()
+    A = hcl.placeholder((10, 10), "A")
+    B = hcl.compute(A.shape, lambda y, x: A[y][x], "B")
+    s = hcl.create_schedule([A, B])
+    s[B].fuse(B.axis[0], B.axis[1])
+    code = hcl.build(s, target="vhls")
+    assert "A[10*10]" in code
+    assert "B[10*10]" in code
+
+def test_select_type_cast():
+    A = hcl.placeholder((10, 10), "A")
+    def kernel(A):
+        return hcl.compute((8, 8), lambda y, x: 
+            hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
+    s = hcl.create_scheme(A, kernel)
+    s = hcl.create_schedule_from_scheme(s)
+    f = hcl.build(s, target="vhls")
+    print(f)
+
+if __name__ == '__main__':
+    test_legacy_interface()
+    test_select_type_cast()

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -135,14 +135,30 @@ def test_legacy_interface():
     assert "B[10*10]" in code
 
 def test_select_type_cast():
-    A = hcl.placeholder((10, 10), "A")
-    def kernel(A):
-        return hcl.compute((8, 8), lambda y, x: 
-            hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
-    s = hcl.create_scheme(A, kernel)
-    s = hcl.create_schedule_from_scheme(s)
-    code = hcl.build(s, target="vhls")
-    assert "((ap_int<33>)(((ap_int<33>)A[(x + (y * 10))])" in code
+    def test_imm_ops():
+        A = hcl.placeholder((10, 10), "A")
+        def kernel(A):
+            return hcl.compute((8, 8), lambda y, x: 
+                hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
+        s = hcl.create_scheme(A, kernel)
+        s = hcl.create_schedule_from_scheme(s)
+        code = hcl.build(s, target="vhls")
+        assert "((ap_int<33>)0)" in code
+        assert "((ap_int<33>)(((ap_int<33>)A" in code
+
+    def test_binary_ops():
+        A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))
+        B = hcl.placeholder((8, 8), "B", dtype=hcl.Fixed(16,12))
+        def kernel(A, B):
+            return hcl.compute((8, 8), lambda y, x: 
+                hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
+        s = hcl.create_scheme([A, B], kernel)
+        s = hcl.create_schedule_from_scheme(s)
+        code = hcl.build(s, target="vhls")
+        assert "(((ap_int<20>)B" in code
+
+    test_imm_ops()
+    test_binary_ops()
 
 if __name__ == '__main__':
     test_legacy_interface()

--- a/tvm/HalideIR/src/ir/IROperator.cpp
+++ b/tvm/HalideIR/src/ir/IROperator.cpp
@@ -405,18 +405,21 @@ void match_types(Expr &a, Expr &b) {
         // float(a) * float(b) -> float(max(a, b))
         if (ta.bits() > tb.bits()) b = cast(ta, b);
         else a = cast(tb, a);
-    } else if (ta.is_uint() && tb.is_uint()) {
+    } else if (ta.is_ufixed() || tb.is_ufixed()) {
         // uint(a) * uint(b) -> uint(max(a, b))
-        if (ta.bits() > tb.bits()) b = cast(ta, b);
-        else a = cast(tb, a);
-    } else if (!ta.is_float() && !tb.is_float()) {
-        // int(a) * (u)int(b) -> int(max(a, b))
-        int bits  = std::max(ta.bits(), tb.bits());
+        // uint(a) * int(b)  -> uint(max(a, b))
+        int integers  = std::max(ta.bits() - ta.fracs(), tb.bits() - tb.fracs());
         int fracs = std::max(ta.fracs(), tb.fracs());
         int lanes = a.type().lanes();
-        // extend to full precision 
-        a = cast(Int(bits, lanes, fracs), a);
-        b = cast(Int(bits, lanes, fracs), b);
+        a = cast(UInt(integers + fracs, lanes, fracs), a);
+        b = cast(UInt(integers + fracs, lanes, fracs), b);
+    } else if (!ta.is_float() && !tb.is_float()) {
+        // int(a) * (u)int(b) -> int(max(a, b))
+        int integers  = std::max(ta.bits() - ta.fracs(), tb.bits() - tb.fracs());
+        int fracs = std::max(ta.fracs(), tb.fracs());
+        int lanes = a.type().lanes();
+        a = cast(Int(integers + fracs, lanes, fracs), a);
+        b = cast(Int(integers + fracs, lanes, fracs), b);
     } else {
         internal_error << "Could not match types: " << ta << ", " << tb << "\n";
     }

--- a/tvm/HalideIR/src/ir/IROperator.cpp
+++ b/tvm/HalideIR/src/ir/IROperator.cpp
@@ -411,10 +411,12 @@ void match_types(Expr &a, Expr &b) {
         else a = cast(tb, a);
     } else if (!ta.is_float() && !tb.is_float()) {
         // int(a) * (u)int(b) -> int(max(a, b))
-        int bits = std::max(ta.bits(), tb.bits());
+        int bits  = std::max(ta.bits(), tb.bits());
+        int fracs = std::max(ta.fracs(), tb.fracs());
         int lanes = a.type().lanes();
-        a = cast(Int(bits, lanes), a);
-        b = cast(Int(bits, lanes), b);
+        // extend to full precision 
+        a = cast(Int(bits, lanes, fracs), a);
+        b = cast(Int(bits, lanes, fracs), b);
     } else {
         internal_error << "Could not match types: " << ta << ", " << tb << "\n";
     }


### PR DESCRIPTION
This PR solves the data type casting error in VHLS code generator, which should address the following two problems:
1. Casting fixed-point value to integer (causing precision problem). Brief example showing the minimal test case and which function caused the error. 
```python
        A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))
        B = hcl.placeholder((8, 8), "B", dtype=hcl.Fixed(16,12))
        def kernel(A, B):
            return hcl.compute((8, 8), lambda y, x:
                hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
```
With the example above, HeteroCL casts fixed point value B[y, x] into ap_int<20>, which makes B[y, x] lose all the fractional bits. The issue happens when ternary operation is generated with implicit data type casting. i.e., the two branches in select expression are compared, then HeteroCL selects a higher-precision data type and cast the two branches into this data type:
```c++
// tvm/src/api/api_ir.cc: 135
TVM_REGISTER_API("make.Select")
.set_body([](TVMArgs args,  TVMRetValue *ret) {
    Expr cond = args[0], if_case = args[1], then_case = args[2];
    match_types(if_case, then_case);
    *ret = Select::make(cond, if_case, then_case);
    });
```
2. VHLS code generator does not explicitly case the BinaryOpNode expressions, which causes the error mentioned in #193. We fix the issue by adding type checking logic in code generator. The code generator checks if the two branches are of the same data type, and explicitly cast those branches if the type casting logic is missing. 
