### PR TITLE
[Backend] Fixed incorrect memory allocation for fixed points on CPU

### DIFF
--- a/tvm/include/tvm/expr.h
+++ b/tvm/include/tvm/expr.h
@@ -77,7 +77,13 @@ inline int GetVectorBytes(Type dtype) {
   // TODO: FIX this 
   //CHECK_EQ(data_bits % 8, 0U)
   //    << "Need to load/store by multiple of bytes";
-  return (data_bits+7) / 8;
+  int nbytes = (data_bits+7) / 8;
+  if (nbytes > 2) {
+    if (nbytes <= 4) nbytes = 4;
+    else if (nbytes <= 8) nbytes = 8;
+    else nbytes = 16;
+  }
+  return nbytes;
 }
 
 /*! \brief a named variable in TVM */

--- a/tvm/src/runtime/c_runtime_api.cc
+++ b/tvm/src/runtime/c_runtime_api.cc
@@ -160,8 +160,8 @@ inline size_t GetDataSize(TVMArray* arr) {
   }
   size_t byte = (arr->dtype.bits + 7) / 8;
   if (byte > 2){
-    if (byte < 4) byte = 4;
-    else if (byte < 8) byte = 8;
+    if (byte <= 4) byte = 4;
+    else if (byte <= 8) byte = 8;
     else byte = 16;
   }
   size *= (byte * 8 * arr->dtype.lanes + 7) / 8;


### PR DESCRIPTION
For CPU memory allocation, it actually calls the TVM builtin function instead of using LLVM's alloc command. Previously, we only tested on small input arrays, which are automatically unrolled by LLVM. That's why the bug was not caught. In this PR, we fixed the memory allocation with the correct allocation size in terms of the number of bytes.

The place where TVM replace the allocation node with its builtin function is in `pass/lower_tvm_builtin.cc`. And the place where the allocation size is calculated is in `include/tvm/expr.h`.

Tests will be added later.