### PR TITLE
[Backend] VHLS CodeGen SDSoC mode (legacy support)

### DIFF
--- a/samples/sobel/sobel_sdsoc.py
+++ b/samples/sobel/sobel_sdsoc.py
@@ -1,0 +1,61 @@
+from PIL import Image
+import heterocl as hcl
+import numpy as np
+import math
+import imageio
+from urllib.request import urlopen
+
+hcl.init(init_dtype=hcl.Float())
+img = Image.open(urlopen('http://i.stack.imgur.com/8zINU.gif'))
+width, height = img.size
+
+A = hcl.placeholder((height,width), "A", dtype=hcl.Float())
+Gx = hcl.placeholder((3,3), "Gx",dtype=hcl.Float())
+Gy = hcl.placeholder((3,3), "Gy",dtype=hcl.Float())
+
+def sobel(A, Gx, Gy):
+
+   r = hcl.reduce_axis(0,3)
+   c = hcl.reduce_axis(0,3)
+   B = hcl.compute((height-2,width-2), 
+           lambda x,y: hcl.sum(A[x+r,y+c]*Gx[r,c], axis=[r,c], name="sum1"),
+           name="B", dtype=hcl.Float())
+   t = hcl.reduce_axis(0,3)
+   g = hcl.reduce_axis(0,3)
+
+   C = hcl.compute((height-2,width-2), 
+           lambda x,y: hcl.sum(A[x+t,y+g]*Gy[t,g], axis=[t,g], name="sum2"),
+           name="C", dtype=hcl.Float())
+   return hcl.compute((height-2,width-2), 
+              lambda x, y :hcl.sqrt(B[x,y]*B[x,y] + C[x,y]*C[x,y])/4328*255,
+              name="output", dtype=hcl.Float())
+
+target = hcl.platform.zc706
+target.config(compile="sdsoc", mode="sw_sim")
+
+s = hcl.create_schedule([A,Gx,Gy], sobel)
+s.to([Gx, Gy, A], target.xcel)
+s.to(sobel.output, target.host)
+f = hcl.build(s, target)
+
+npA = np.array(img)
+npGx = np.array([[1,0,-1],[2,0,-2],[1,0,-1]])
+npGy = np.array([[1,2,1],[0,0,0],[-1,-2,-1]])
+hcl_A = hcl.asarray(npA)
+hcl_Gx = hcl.asarray(npGx)
+hcl_Gy = hcl.asarray(npGy)
+
+npF = np.zeros((height-2,width-2))
+hcl_F = hcl.asarray(npF)
+
+f(hcl_A, hcl_Gx,hcl_Gy, hcl_F)
+npF = hcl_F.asnumpy()
+
+newimg = np.zeros((height-2,width-2,3))
+for x in range(0, height-2):
+	for y in range(0, width-2):
+		for z in range(0,3):
+			newimg[x,y,z] = npF[x,y]
+
+newimg = newimg.astype(np.uint8)
+# imageio.imsave("pic_sobel.jpg", newimg)

--- a/tests/test_runtime_build.py
+++ b/tests/test_runtime_build.py
@@ -140,6 +140,34 @@ def test_vitis():
       for j in range(0, 32):
         assert ret_B[i, j] == (np_A[i, j] + 2) *2
 
+def test_xilinx_sdsoc():
+    if os.system("which sds++ >> /dev/null") != 0:
+        return 
+
+    hcl.init()
+    A = hcl.placeholder((10, 32), "A")
+    def kernel(A):
+        B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B")
+        C = hcl.compute(A.shape, lambda *args : B[args] + 1, "C")
+        D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
+        return D
+    
+    target = hcl.platform.zc706
+    s = hcl.create_schedule([A], kernel)
+    s.to(kernel.B, target.xcel)
+    s.to(kernel.C, target.host)
+    target.config(compile="sdsoc", mode="sw_sim")
+    f = hcl.build(s, target)
+
+    np_A = np.random.randint(10, size=(10,32))
+    np_B = np.zeros((10,32))
+
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B, dtype=hcl.Int(32))
+    f(hcl_A, hcl_B)
+
+    assert np.array_equal(hcl_B.asnumpy(), np_A * 2 + 2)
+
 def test_intel_aocl():
     if os.system("which aocl >> /dev/null") != 0:
         return 
@@ -177,4 +205,5 @@ if __name__ == '__main__':
     test_vivado_hls()
     test_mixed_stream()
     test_vitis()
+    test_xilinx_sdsoc()
     test_intel_aocl()

--- a/tvm/src/codegen/build_common.cc
+++ b/tvm/src/codegen/build_common.cc
@@ -88,7 +88,7 @@ class SimModuleNode final : public ModuleNode {
 
           GenHostCode(args, shmids, arg_types, func_, 
                       platform_, host_, arg_names_, empty);
-          GenKernelCode(dev_, platform_, options_["backend"]);
+          GenKernelCode(dev_, arg_names_, platform_, options_["backend"]);
 
           // copy files and compile tp binary  
           LOG(CLEAN) << "Compiling the program ...";

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -381,14 +381,21 @@ void GenKernelCode(std::string& test_file, std::vector<std::string> arg_names,
 
     // TODO: better way to specify prgamas
     if (platform == "sdsoc") {
-      header << "#pragma SDS access_pattern(";
+      // TODO: direct memory interface with PL and DDR
+      header << "#pragma SDS data copy(";
+      for (size_t k = 0; k < arg_names.size(); k++) {
+        if (k != 0) header << ", ";
+        header << arg_names[k] << "[0:256]";
+      }
+      header << ")\n";
+      header << "#pragma SDS data access_pattern(";
       for (size_t k = 0; k < arg_names.size(); k++) {
         if (k != 0) header << ", ";
         header << arg_names[k] << ":SEQUENTIAL";
       }
       header << ")\n";
       // generate AFU with AXI DMA
-      header << "#pragma SDS datamover(";
+      header << "#pragma SDS data data_mover(";
       for (size_t k = 0; k < arg_names.size(); k++) {
         if (k != 0) header << ", ";
         header << arg_names[k] << ":AXIDMA_SG";

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -328,7 +328,7 @@ void PrintCopyBack(TVMArray* arr,
 }
 
 // generate kernel code into files 
-void GenKernelCode(std::string& test_file, 
+void GenKernelCode(std::string& test_file, std::vector<std::string> arg_names, 
                    std::string platform, std::string backend) {
   if (test_file.find_first_not_of(" \t\n") == std::string::npos) return;
   std::ofstream stream;
@@ -378,6 +378,23 @@ void GenKernelCode(std::string& test_file,
     size_t dut = test_file.find("test(");
     size_t begin = test_file.rfind('\n', dut);
     size_t end = test_file.find(')', dut) + 1;
+
+    // TODO: better way to specify prgamas
+    if (platform == "sdsoc") {
+      header << "#pragma SDS access_pattern(";
+      for (size_t k = 0; k < arg_names.size(); k++) {
+        if (k != 0) header << ", ";
+        header << arg_names[k] << ":SEQUENTIAL";
+      }
+      header << ")\n";
+      // generate AFU with AXI DMA
+      header << "#pragma SDS datamover(";
+      for (size_t k = 0; k < arg_names.size(); k++) {
+        if (k != 0) header << ", ";
+        header << arg_names[k] << ":AXIDMA_SG";
+      }
+      header << ")";
+    }
 
     header << test_file.substr(begin, end - begin) 
            << ";\n" << "\n#endif";

--- a/tvm/src/codegen/build_util.h
+++ b/tvm/src/codegen/build_util.h
@@ -48,6 +48,7 @@ void PrintCopyBack(TVMArray* arr,
                    int indent, size_t nth_arr);
 
 void GenKernelCode(std::string& test_file, 
+                   std::vector<std::string> arg_names,
                    std::string platform,
                    std::string backend);
 

--- a/tvm/src/codegen/hlsc/codegen_vhls.h
+++ b/tvm/src/codegen/hlsc/codegen_vhls.h
@@ -38,6 +38,7 @@ class CodeGenVivadoHLS final : public CodeGenHLSC {
 
  private:
   std::ofstream soda_header_;
+  bool xcel_scope{false};
   bool sdsoc_mode{false};
   // reduce chanenl and moved var
   bool ptr_mode{false};

--- a/tvm/src/codegen/hlsc/codegen_vhls.h
+++ b/tvm/src/codegen/hlsc/codegen_vhls.h
@@ -38,8 +38,6 @@ class CodeGenVivadoHLS final : public CodeGenHLSC {
 
  private:
   std::ofstream soda_header_;
-  bool xcel_scope{false};
-  // generate code for sdsoc
   bool sdsoc_mode{false};
   // reduce chanenl and moved var
   bool ptr_mode{false};

--- a/tvm/src/codegen/opencl/codegen_aocl.cc
+++ b/tvm/src/codegen/opencl/codegen_aocl.cc
@@ -357,7 +357,7 @@ void CodeGenAOCL::VisitStmt_(const KernelDef* op) {
 
   // streamed arg position to channel index
   std::unordered_map<int, int> stream_args;
-  for (size_t j = 0; j < op->channels.size(); j=j++) {
+  for (size_t j = 0; j < op->channels.size(); j++) {
     auto info = op->channels[j];
     int pos = info[0].as<IntImm>()->value;
     int idx = info[1].as<IntImm>()->value;

--- a/tvm/src/codegen/opencl/codegen_xocl_host.cc
+++ b/tvm/src/codegen/opencl/codegen_xocl_host.cc
@@ -160,7 +160,6 @@ void CodeGenXOCLHost::VisitStmt_(const IfThenElse* op) {
 void CodeGenXOCLHost::VisitStmt_(const Allocate* op) {
   CHECK(!is_zero(op->condition));
   std::string vid = AllocVarID(op->buffer_var.get());
-  this->PrintIndent();
   int32_t constant_size = op->constant_allocation_size();
   CHECK_GT(constant_size, 0)
       << "Can only handle constant size stack allocation for now";
@@ -192,6 +191,7 @@ void CodeGenXOCLHost::VisitStmt_(const Allocate* op) {
       var_idmap_[op->buffer_var.get()] = name;
     }
 
+    // ptr mode: check name availability
     if (alloc_set_.find(vid) != alloc_set_.end()) {
       not_alloc = true;
     } else {
@@ -203,6 +203,7 @@ void CodeGenXOCLHost::VisitStmt_(const Allocate* op) {
 
   // not allocate for moved data  
   if (!not_alloc) { 
+    this->PrintIndent();
     PrintType(op->type, stream);
     alloc_set_.insert(vid);
     stream << ' '<< vid;


### PR DESCRIPTION
The main difference between SDSoC VHLS code and Vitis/SDAccel is the system memory allocation APIs (SDSoC uses `sds_alloc` and `sds_free`) and kernel function header pragmas. 

1. Use `sds_alloc` for memory allocation on host program 
2. Modified `StreamExpr` to contain index information (this can be also useful for the access pattern analysis in the next streaming enhancement PR)

Example of compiling with SDSoC in python
```python
    target = hcl.platform.zc706
    s = hcl.create_schedule([A], kernel)
    s.to(kernel.B, target.xcel)
    s.to(kernel.C, target.host)
    target.config(compile="sdsoc", mode="sw_sim")
    f = hcl.build(s, target)
```
Example of generated host code:
```c++
  ap_int<32>* B_channel = sds_alloc(sizeof(ap_int<32>)*10*32);
  for (ap_int<32> B0 = 0; B0 < 10; ++B0) {
    for (ap_int<32> B1 = 0; B1 < 32; ++B1) {
      B_channel = B[(B1 + (B0 * 32))];
    }
  }
  ap_int<32>* C_channel = sds_alloc(sizeof(ap_int<32>)*10*32);
  test(B_channel, C_channel);
```