### PR TITLE
[Backend] Fix VHLS CodeGen immediate data type casting

### DIFF
--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -146,6 +146,16 @@ def test_select_type_cast():
         assert "((ap_int<33>)0)" in code
         assert "((ap_int<33>)(((ap_int<33>)A" in code
 
+    def test_uint_imm_ops():
+        A = hcl.placeholder((10, 10), "A", dtype=hcl.UInt(1))
+        def kernel(A):
+            return hcl.compute((8, 8), lambda y, x: 
+                hcl.select(x < 4, A[y][x], 0), "B")
+        s = hcl.create_scheme(A, kernel)
+        s = hcl.create_schedule_from_scheme(s)
+        code = hcl.build(s, target="vhls")
+        assert "(ap_uint<32>)0U)" in code
+
     def test_binary_ops():
         A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))
         B = hcl.placeholder((8, 8), "B", dtype=hcl.Fixed(16,12))
@@ -171,6 +181,7 @@ def test_select_type_cast():
     test_imm_ops()
     test_binary_ops()
     test_uint_int()
+    test_uint_imm_ops()
 
 if __name__ == '__main__':
     test_legacy_interface()

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -448,6 +448,9 @@ void CodeGenC::PrintType(Type t, std::ostream& os) {  // NOLINT(*)
 inline void PrintConst(const IntImm* op, std::ostream& os, CodeGenC* p) { // NOLINT(*)
   if (op->type == Int(32)) {
     std::ostringstream temp;
+    os << "(";
+    p->PrintType(op->type, os);
+    os << ")";
     temp << op->value;
     p->MarkConst(temp.str());
     os << temp.str();
@@ -461,6 +464,9 @@ inline void PrintConst(const IntImm* op, std::ostream& os, CodeGenC* p) { // NOL
 inline void PrintConst(const UIntImm* op, std::ostream& os, CodeGenC* p) { // NOLINT(*)
   if (op->type == UInt(32)) {
     std::ostringstream temp;
+    os << "(";
+    p->PrintType(op->type, os);
+    os << ")";
     temp << op->value << "U";
     p->MarkConst(temp.str());
     os << temp.str();

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -34,10 +34,10 @@ Type ExtractDType(Expr expr, bool& flag) {
   } else if (auto v = expr.as<Min>()) { 
     return v->type;
   } else if (auto v = expr.as<IntImm>()) { 
-    flag = false;
+    if (v->type != Int(32)) flag = false;
     return v->type;
   } else if (auto v = expr.as<UIntImm>()) { 
-    flag = false;
+    if (v->type != UInt(32)) flag = false;
     return v->type;
   } else if (auto v = expr.as<FloatImm>()) { 
     flag = false;
@@ -448,9 +448,6 @@ void CodeGenC::PrintType(Type t, std::ostream& os) {  // NOLINT(*)
 inline void PrintConst(const IntImm* op, std::ostream& os, CodeGenC* p) { // NOLINT(*)
   if (op->type == Int(32)) {
     std::ostringstream temp;
-    os << "(";
-    p->PrintType(op->type, os);
-    os << ")";
     temp << op->value;
     p->MarkConst(temp.str());
     os << temp.str();
@@ -464,9 +461,6 @@ inline void PrintConst(const IntImm* op, std::ostream& os, CodeGenC* p) { // NOL
 inline void PrintConst(const UIntImm* op, std::ostream& os, CodeGenC* p) { // NOLINT(*)
   if (op->type == UInt(32)) {
     std::ostringstream temp;
-    os << "(";
-    p->PrintType(op->type, os);
-    os << ")";
     temp << op->value << "U";
     p->MarkConst(temp.str());
     os << temp.str();


### PR DESCRIPTION
Issue: the immediate const number is not cast by the code generator when it has bitwidth of 32-bits. And we can fix it by enforcing the type casting regardless of the bitwidth.