### PR TITLE
[API] Add support for getting bit/slice from expressions

### DIFF
--- a/python/heterocl/tvm/expr.py
+++ b/python/heterocl/tvm/expr.py
@@ -111,6 +111,15 @@ class ExprOp(object):
     def __ge__(self, other):
         return _make.GE(self, other)
 
+    def __getitem__(self, indices):
+        if isinstance(indices, slice):
+            return _make.GetSlice(self, indices.start, indices.stop)
+        else:
+            return _make.GetBit(self, indices)
+
+    def __setitem__(self, indices, expr):
+        raise APIError("Cannot set bit/slice of an expression")
+
     def __nonzero__(self):
         raise ValueError("Cannot use and / or / not operator to Expr, hint: " +
                          "use tvm.all / tvm.any instead")

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -342,3 +342,138 @@ def test_break_multi_level():
     ret_A = hcl_A.asnumpy()
     assert np.array_equal(golden_A, ret_A)
 
+def test_get_bit_expr():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: (A[x] + 1)[0])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = (np_A + 1) & 1
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)
+
+def test_get_bit_tensor():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: A[x][0])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = np_A & 1
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)
+
+def test_set_bit_tensor():
+
+    hcl.init()
+
+    def kernel(A, B):
+        with hcl.for_(0, 10) as i:
+            B[i][0] = A[i]
+
+    A = hcl.placeholder((10,))
+    B = hcl.placeholder((10,))
+    s = hcl.create_schedule([A, B], kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(1, size=(10,))
+    np_B = np.random.randint(10, size=(10,))
+    golden = (np_B & 0b1110) | np_A
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)
+
+def test_get_slice_expr():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: (A[x] + 1)[2:0])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = (np_A + 1) & 0b11
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)
+
+def test_get_slice_tensor():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: A[x][2:0])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = np_A & 0b11
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)
+
+def test_set_slice_tensor():
+
+    hcl.init()
+
+    def kernel(A, B):
+        with hcl.for_(0, 10) as i:
+            B[i][2:0] = A[i]
+
+    A = hcl.placeholder((10,))
+    B = hcl.placeholder((10,))
+    s = hcl.create_schedule([A, B], kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(1, size=(10,))
+    np_B = np.random.randint(10, size=(10,))
+    golden = (np_B & 0b1100) | np_A
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -386,6 +386,23 @@ def test_get_bit_tensor():
     ret = hcl_B.asnumpy()
     assert np.array_equal(golden, ret)
 
+def test_set_bit_expr():
+
+    hcl.init()
+
+    def kernel(A, B):
+        with hcl.for_(0, 10) as i:
+            (B[i]+1)[0] = A[i]
+
+    A = hcl.placeholder((10,))
+    B = hcl.placeholder((10,))
+    try:
+        s = hcl.create_schedule([A, B], kernel)
+    except hcl.debug.APIError:
+        pass
+    else:
+        assert False
+
 def test_set_bit_tensor():
 
     hcl.init()
@@ -453,6 +470,23 @@ def test_get_slice_tensor():
 
     ret = hcl_B.asnumpy()
     assert np.array_equal(golden, ret)
+
+def test_set_slice_expr():
+
+    hcl.init()
+
+    def kernel(A, B):
+        with hcl.for_(0, 10) as i:
+            (B[i]+1)[2:0] = A[i]
+
+    A = hcl.placeholder((10,))
+    B = hcl.placeholder((10,))
+    try:
+        s = hcl.create_schedule([A, B], kernel)
+    except hcl.debug.APIError:
+        pass
+    else:
+        assert False
 
 def test_set_slice_tensor():
 


### PR DESCRIPTION
In this PR, we enable getting bit/slice from expressions.

```python
A = hcl.placeholder((10,))
B = hcl.compute(A.shape, lambda x: (A[x]+1)[5])
```

For more examples, please refer to `tests/test_dsl_basic.py`.