### PR TITLE
[Backend][Testing] Fix VHLS codegen for Select; Recover original tests

### DIFF
--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -138,29 +138,29 @@ def test_select_type_cast():
     def test_imm_ops():
         A = hcl.placeholder((10, 10), "A")
         def kernel(A):
-            return hcl.compute((8, 8), lambda y, x:
+            return hcl.compute((8, 8), lambda y, x: 
                 hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
         s = hcl.create_scheme(A, kernel)
         s = hcl.create_schedule_from_scheme(s)
         code = hcl.build(s, target="vhls")
-        assert "(ap_int<33>)0" in code
-        assert "(ap_int<33>)A" in code
+        assert "((ap_int<33>)0)" in code
+        assert "((ap_int<33>)(((ap_int<33>)A" in code
 
     def test_uint_imm_ops():
         A = hcl.placeholder((10, 10), "A", dtype=hcl.UInt(1))
         def kernel(A):
-            return hcl.compute((8, 8), lambda y, x:
+            return hcl.compute((8, 8), lambda y, x: 
                 hcl.select(x < 4, A[y][x], 0), "B")
         s = hcl.create_scheme(A, kernel)
         s = hcl.create_schedule_from_scheme(s)
         code = hcl.build(s, target="vhls")
-        assert "0U" in code
+        assert "(ap_uint<32>)0U)" in code
 
     def test_binary_ops():
         A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))
         B = hcl.placeholder((8, 8), "B", dtype=hcl.Fixed(16,12))
         def kernel(A, B):
-            return hcl.compute((8, 8), lambda y, x:
+            return hcl.compute((8, 8), lambda y, x: 
                 hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
         s = hcl.create_scheme([A, B], kernel)
         s = hcl.create_schedule_from_scheme(s)
@@ -171,7 +171,7 @@ def test_select_type_cast():
         A = hcl.placeholder((8, 8), "A", dtype=hcl.Fixed(20,12))
         B = hcl.placeholder((8, 8), "B", dtype=hcl.UFixed(16,12))
         def kernel(A, B):
-            return hcl.compute((8, 8), lambda y, x:
+            return hcl.compute((8, 8), lambda y, x: 
                 hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
         s = hcl.create_scheme([A, B], kernel)
         s = hcl.create_schedule_from_scheme(s)

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -867,10 +867,34 @@ void CodeGenC::VisitExpr_(const Select* op, std::ostream& os) {  // NOLINT(*)
   os << "(";
   PrintExpr(op->condition, os);
   os << " ? ";
+  // check type for each expr args
+  bool cast1 = true, cast2 = true;
+  Type type1 = ExtractDType(op->true_value, cast1);
+  Type type2 = ExtractDType(op->false_value, cast2);
+  // check the bits and type 
+  CHECK(type1.code() == type2.code());
+  CHECK(type1.bits() == type2.bits());
+  CHECK(type1.lanes() == type2.lanes());
+
+  os << "(";
+  if (cast1) {
+    os << "(";
+    this->PrintType(type1, os);
+    os << ")";
+  }
   PrintExpr(op->true_value, os);
-  os << " : ";
-  PrintExpr(op->false_value, os);
   os << ")";
+
+  os << " : ";
+
+  os << "(";
+  if (cast2) {
+    os << "(";
+    this->PrintType(type2, os);
+    os << ")";
+  }
+  PrintExpr(op->false_value, os);
+  os << "))";
 }
 
 void CodeGenC::VisitExpr_(const GetBit *op, std::ostream& os) { // NOLINT(*)


### PR DESCRIPTION
In this PR, the VHLS code generation for `Select` is fixed. Moreover, I bring back the original tests before removing `rewrtie_unsafe_select` (#237) to make sure we indeed generate the correct code.