### PR TITLE
[API][Backend] Dataflow Support for HLS

### DIFF
--- a/python/heterocl/schedule.py
+++ b/python/heterocl/schedule.py
@@ -408,6 +408,14 @@ class Schedule(object):
                 pass
         _api_internal._ScheduleReshape(self.sch, target, shape)
 
+    def dataflow(self):
+        """Pipeline the stages in the schedule
+
+        Parameters
+        ----------
+        """
+        _api_internal._ScheduleDataflow(self.sch)
+
 class Stage(object):
     """Create a stage in the algorithm.
 

--- a/python/heterocl/tvm/schedule.py
+++ b/python/heterocl/tvm/schedule.py
@@ -702,6 +702,16 @@ class _Stage(NodeBase):
             var = self.op.axis[var]
         _api_internal._StagePipeline(self, var, initiation_interval)
 
+    def dataflow(self, var):
+        """Pipeline the stage.
+
+        Parameters
+        ----------
+        var : IterVar
+            The iteration to be pipelined.
+        """
+        _api_internal._StageDataflow(self, var)
+
     def stencil(self, burst_width=512, unroll_factor=1, num_iteration=1):
         _api_internal._StageStencil(self, burst_width, unroll_factor, num_iteration)
 

--- a/python/heterocl/tvm/stmt.py
+++ b/python/heterocl/tvm/stmt.py
@@ -38,6 +38,7 @@ class For(Stmt):
     Vectorized = 2
     Unrolled = 3
     Pipelined = 4
+    Dataflow = 5
 
 @register_node
 class Store(Stmt):

--- a/tvm/HalideIR/src/ir/Expr.h
+++ b/tvm/HalideIR/src/ir/Expr.h
@@ -299,7 +299,8 @@ enum class ForType : int {
     Parallel = 1,
     Vectorized = 2,
     Unrolled = 3,
-    Pipelined = 4
+    Pipelined = 4,
+    Dataflow = 5
 };
 
 /** An enum describing the partition type */

--- a/tvm/include/tvm/expr.h
+++ b/tvm/include/tvm/expr.h
@@ -201,7 +201,8 @@ enum IterVarType : int {
    * \brief Marks boundary of tensorization intrinsic.
    */
   kTensorized = 8,
-  kPipelined = 9
+  kPipelined = 9,
+  kDataflow = 10
 };
 
 /*!
@@ -305,6 +306,7 @@ inline const char* IterVarType2String(IterVarType t) {
     case kParallelized: return "Parallelized";
     case kTensorized: return "Tensorized";
     case kPipelined: return "Pipelined";
+    case kDataflow: return "Dataflow";
   }
   return "Unknown";
 }

--- a/tvm/include/tvm/ir.h
+++ b/tvm/include/tvm/ir.h
@@ -226,6 +226,8 @@ constexpr const char* channel_write_advance = "channel_write_advance";
 constexpr const char* pipeline_stage_scope = "pipeline_stage_scope";
 /*! \brief pipeline execution scope, implies the scope can be pipelined. */
 constexpr const char* pipeline_exec_scope = "pipeline_exec_scope";
+/*! \brief dataflow scope, implies the stages in the scope can be pipelined. */
+constexpr const char* dataflow_scope = "dataflow_scope";
 /*!
  * \brief Mark that this stage is an OpenGL shader. Since OpenGL shader only
  * allows writing out to one element of the output texture, the Provide node

--- a/tvm/include/tvm/schedule.h
+++ b/tvm/include/tvm/schedule.h
@@ -210,6 +210,13 @@ class Stage : public NodeRef {
    */
   EXPORT Stage& pipeline(IterVar var, const Expr& initiation_interval);   // NOLINT(*)
 
+  /*!
+   * \brief Pipeline stage.
+   * \param var The axis to be pipelined.
+   * \return reference to self.
+   */
+  EXPORT Stage& dataflow(IterVar var); // NOLINT(*)
+
   EXPORT Stage& stencil(int burst_width, int unroll_factor, int num_iteration);   // NOLINT(*)
   /*!
    * \brief Annotate the iteration with pragma
@@ -393,6 +400,8 @@ class Schedule : public NodeRef {
 
   EXPORT Tensor partition(const Tensor& target, int dim, int factor,
                           ir::PartitionType partition_type);
+
+  EXPORT void dataflow();
 
   EXPORT void reshape(const Tensor& target, Array<Expr> new_shape);
   /*!

--- a/tvm/src/api/api_lang.cc
+++ b/tvm/src/api/api_lang.cc
@@ -384,6 +384,12 @@ TVM_REGISTER_API("_StagePipeline")
         .pipeline(args[1], args[2]);
   });
 
+TVM_REGISTER_API("_StageDataflow")
+  .set_body([](TVMArgs args, TVMRetValue* ret) {
+    args[0].operator Stage()
+        .dataflow(args[1]);
+  });
+
 TVM_REGISTER_API("_StageStencil")
   .set_body([](TVMArgs args, TVMRetValue* ret) {
     args[0].operator Stage()
@@ -459,6 +465,12 @@ TVM_REGISTER_API("_SchedulePartition")
     *ret = args[0].operator Schedule()
         .partition(args[1], args[2], args[3],
           static_cast<ir::PartitionType>(args[4].operator int()));
+  });
+
+TVM_REGISTER_API("_ScheduleDataflow")
+  .set_body([](TVMArgs args, TVMRetValue *ret) {
+    args[0].operator Schedule()
+      .dataflow();
   });
 
 TVM_REGISTER_API("_ScheduleMoveToStage")

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -400,6 +400,9 @@ void CodeGenVivadoHLS::VisitStmt_(const For* op) {
     if (II > 0) os << " II=" << II << "\n";
     else        os << "\n";
   }
+  else if (op->for_type == ForType::Dataflow) {
+    os << "#pragma HLS dataflow\n";
+  }
   GenForStmt(op, os.str(), false);
 }
 

--- a/tvm/src/schedule/compute_primitive.cc
+++ b/tvm/src/schedule/compute_primitive.cc
@@ -205,6 +205,7 @@ class IterVarAttrUpdater final : public IRMutator {
             case kVectorized: for_type = ForType::Vectorized; break;
             case kParallelized: for_type = ForType::Parallel; break;
             case kPipelined: for_type = ForType::Pipelined; break;
+            case kDataflow: for_type = ForType::Dataflow; break;
             case kDataPar: break;
             case kTensorized: break;
             default: LOG(FATAL) << "Unknown iter type" << node_->iter_type;

--- a/tvm/src/schedule/schedule_dataflow_rewrite.cc
+++ b/tvm/src/schedule/schedule_dataflow_rewrite.cc
@@ -1052,7 +1052,23 @@ Tensor Schedule::partition(const Tensor& target, int dim, int factor,
 }
 
 void Schedule::dataflow() {
-  LOG(INFO) << "dataflow";
+  size_t num_stage = (*this)->stages.size();
+  Stage top_stage = (*this)->stages[num_stage-1];
+  const ExternOpNode* op = top_stage->op.as<ExternOpNode>();
+  Stmt body = AttrStmt::make(
+      top_stage->op,
+      attr::dataflow_scope,
+      IntImm::make(Int(32), 1),
+      op->body);
+  top_stage->op = ExternOpNode::make(
+    op->name,
+    op->tag,
+    op->axis,
+    op->inputs,
+    op->input_placeholders,
+    op->output_placeholders,
+    body
+  );
 }
 
 // Do not support reshaping the placeholders for now

--- a/tvm/src/schedule/schedule_dataflow_rewrite.cc
+++ b/tvm/src/schedule/schedule_dataflow_rewrite.cc
@@ -1051,6 +1051,10 @@ Tensor Schedule::partition(const Tensor& target, int dim, int factor,
   return partition_tensor;
 }
 
+void Schedule::dataflow() {
+  LOG(INFO) << "dataflow";
+}
+
 // Do not support reshaping the placeholders for now
 void Schedule::reshape(const Tensor& target, Array<Expr> new_shape) {
   Stage target_stage = (*this)[target];

--- a/tvm/src/schedule/schedule_lang.cc
+++ b/tvm/src/schedule/schedule_lang.cc
@@ -489,6 +489,15 @@ Stage& Stage::pipeline(IterVar var,
   return *this;
 }
 
+Stage& Stage::dataflow(IterVar var) {
+  std::shared_ptr<IterVarAttrNode> node = std::make_shared<IterVarAttrNode>();
+  node->iter_type = kDataflow;
+  node->for_loop_annotate_keys.push_back(ir::StringImm::make("dataflow"));
+  node->for_loop_annotate_values.push_back(true);
+  SetIterVarAttr(operator->(), var, node.get());
+  return *this;
+}
+
 Stage& Stage::split_annotate(IterVar var, Expr factor) {  // NOLINT(*)
   std::shared_ptr<IterVarAttrNode> node = std::make_shared<IterVarAttrNode>();
   node->for_loop_annotate_keys.push_back(ir::StringImm::make("split_factor"));


### PR DESCRIPTION
This PR adds dataflow support for HeteroCL. Users can use the following APIs to insert dataflow pragmas inside a stage or a function.
* To add a dataflow primitive inside a stage, `s[<stage>].dataflow(<axis>)` can be called after a schedule `s` is created, which is similar to `.pipeline`.
* To pipeline all the stages in the top function, directly call `s.dataflow()`.

A detailed example is shown below.
```python
def test():
    hcl.init()
    A = hcl.placeholder((10, 10), "A")
    def kernel(A):
        B = hcl.compute(A.shape, lambda x, y: A[x][y] + 1, "B")
        return B
    s = hcl.create_schedule(A, kernel)
    s[kernel.B].dataflow(kernel.B.axis[0])
    f = hcl.build(s,"vhls")
    print(f)
```

Below is the generated code.
```cpp
void default_function(ap_int<32> A[10][10], ap_int<32> B[10][10]) {
  ap_int<32> _top;
  for (ap_int<32> x = 0; x < 10; ++x) {
  #pragma HLS dataflow
    for (ap_int<32> y = 0; y < 10; ++y) {
      B[x][y] = (A[x][y] + 1);
    }
  }
}
```

Another example pipelines the whole function.
```python
def test2():
    hcl.init()
    A = hcl.placeholder((10, 10), "A")
    def kernel(A):
        B = hcl.compute(A.shape, lambda x, y: A[x][y] + 1, "B")
        C = hcl.compute(A.shape, lambda x, y: B[x][y] + 1, "C")
        return C
    s = hcl.create_schedule(A, kernel)
    s[kernel.B].pipeline(kernel.B.axis[0])
    s[kernel.C].pipeline(kernel.C.axis[0])
    s.dataflow()
    f = hcl.build(s,"vhls")
    print(f)
```

And the generated code.
```cpp
void default_function(ap_int<32> A[10][10], ap_int<32> C[10][10]) {
  #pragma HLS dataflow
  ap_int<32> _top;
  ap_int<32> B[10][10];
  for (ap_int<32> x = 0; x < 10; ++x) {
  #pragma HLS pipeline
    for (ap_int<32> y = 0; y < 10; ++y) {
      B[x][y] = (A[x][y] + 1);
    }
  }
  for (ap_int<32> x1 = 0; x1 < 10; ++x1) {
  #pragma HLS pipeline
    for (ap_int<32> y1 = 0; y1 < 10; ++y1) {
      C[x1][y1] = (B[x1][y1] + 1);
    }
  }
}
```

However, there are several limitations now:
1. I'm not sure if the dataflow primitive inside a stage will conflict with other primitives. It seems only a very few cases in HeteroCL will use intra-stage dataflow since most of the nested loops are perfect.
2. The semantics of `s.dataflow()` is unclear, especially when combining with the `.to` primitive. Since `.to` does not support compute placement for a whole function now, the boundary of `dataflow` is hard to be determined. A better interface is needed for this case.