### PR TITLE
[API] Fix out-of-date HLS reports

### DIFF
--- a/hlib/python/setup.py
+++ b/hlib/python/setup.py
@@ -42,8 +42,8 @@ setup(
       'matplotlib',
       'backports.functools_lru_cache',
       'ordered_set',
-      'keras',
-      'tensorflow',
+      'keras==2.3.1',
+      'tensorflow==2.2.0',
       'tvm',
       ],
   **setup_kwargs)

--- a/hlib/tests/test_extern_ip.py
+++ b/hlib/tests/test_extern_ip.py
@@ -239,7 +239,7 @@ def test_byte_swap_rtl():
         x_hcl = hcl.asarray(x_np)
         y_hcl = hcl.asarray(np.zeros((length)))
         f(x_hcl, y_hcl)
-        f.report(target)
+        f.report()
 
         for i in range(length):
             y_np[i] = np.bitwise_and((1 << 32) - 1, np.bitwise_or(x_np[i] << 16, x_np[i] >> 16)) 

--- a/python/heterocl/report.py
+++ b/python/heterocl/report.py
@@ -29,13 +29,10 @@ def parse_xml(path, print_flag=False):
     if not os.path.isfile(xml_file):
         raise RuntimeError("Cannot find {}, run csyn first".format(xml_file))
     json_file = os.path.join(path,"profile.json")
-    if os.path.isfile(json_file):
-        profile = json.loads(open(json_file,"r").read())
-    else:
-        outfile = open(json_file, "w")
-        with open(xml_file, "r") as xml:
-            profile = xmltodict.parse(xml.read())["profile"]
-            json.dump(profile, outfile, indent=2)
+    outfile = open(json_file, "w")
+    with open(xml_file, "r") as xml:
+        profile = xmltodict.parse(xml.read())["profile"]
+        json.dump(profile, outfile, indent=2)
     res = {}
     res["HLS Version"] = "Vivado HLS " + profile["ReportVersion"]["Version"]
     res["Product family"] = profile["UserAssignments"]["ProductFamily"]

--- a/python/heterocl/report.py
+++ b/python/heterocl/report.py
@@ -28,7 +28,7 @@ def parse_xml(path, print_flag=False):
     xml_file = os.path.join(path, "out.prj", "solution1/syn/report/test_csynth.xml")
     if not os.path.isfile(xml_file):
         raise RuntimeError("Cannot find {}, run csyn first".format(xml_file))
-    json_file = os.path.join(path,"profile.json")
+    json_file = os.path.join(path,"report.json")
     outfile = open(json_file, "w")
     with open(xml_file, "r") as xml:
         profile = xmltodict.parse(xml.read())["profile"]

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -499,7 +499,9 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
                 vals.insert(3, target.tool.script)
             else:
                 vals.insert(3, "")
-            return builder(fdevice, keys, vals)
+            f = builder(fdevice, keys, vals)
+            f.target = target # attach target to Module
+            return f
 
     except AttributeError:
         raise AttributeError("Cannot find the target builder %s" % target)

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -53,7 +53,7 @@ class Module(ModuleBase):
     def report(self, target):
         if target.tool.name == "vivado_hls":
             if "csyn" not in target.tool.mode:
-                raise RuntimeError("Not supported mode {}".format(mode))
+                raise RuntimeError("Not supported mode {}. Use csyn mode to retrieve the report instead.".format(target.tool.mode))
         return report_stats(target, "project")
 
     def save(self, file_name, fmt=""):

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -50,7 +50,10 @@ class Module(ModuleBase):
         nmod = _ImportsSize(self)
         return [_GetImport(self, i) for i in range(nmod)]
 
-    def report(self, target):
+    def report(self):
+        if "target" not in self.__dict__.keys():
+            raise RuntimeError("No attached target!")
+        target = self.target
         if target.tool.name == "vivado_hls":
             if "csyn" not in target.tool.mode:
                 raise RuntimeError("Not supported mode {}. Use csyn mode to retrieve the report instead.".format(target.tool.mode))

--- a/tests/test_runtime_build.py
+++ b/tests/test_runtime_build.py
@@ -84,7 +84,7 @@ def test_vivado_hls():
         ret_B = hcl_B.asnumpy()
 
         if "csyn" in target_mode:
-            report = f.report(target)
+            report = f.report()
             assert "ReportVersion" in report
         elif "csim" in target_mode:
             np.testing.assert_array_equal(ret_B, (np_A+2)*2)

--- a/tvm/src/template/vivado/Makefile
+++ b/tvm/src/template/vivado/Makefile
@@ -26,6 +26,6 @@ vivado_hls:
 	vivado_hls -f run.tcl
 
 clean:
-	rm -rf out *.txt *.dat *.prj *.log
+	rm -rf out *.txt *.dat *.prj *.log *.json
 	rm -rf zedboard_project* xillydemo.bit
 


### PR DESCRIPTION
This PR fixes #246 that HeteroCL outputs out-of-date HLS reports when the program is synthesized several times. By enforcing HeteroCL to regenerate json output, the retrieved HLS report will be up-to-date.