### PR TITLE
[API] Add user-defined project folder support

### DIFF
--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -149,7 +149,7 @@ def create_scheme(inputs, func):
         func.__setattr__(op.name, op)
     return Scheme(inputs, func)
 
-def create_schedule(inputs, func=None):
+def create_schedule(inputs, func=None, name=""):
     """Create a schedule for compute optimizations.
 
     The first argument is a list of inputs to the second argument, which is a
@@ -217,9 +217,11 @@ def create_schedule(inputs, func=None):
             func.__setattr__(op.name, op)
     t = Schedule.last_stages
     ops = [t_._op.op for t_ in t]
-    return Schedule(_schedule.create_schedule(ops), inputs)
+    s = Schedule(_schedule.create_schedule(ops), inputs)
+    s.name = name
+    return s
 
-def create_schedule_from_scheme(scheme):
+def create_schedule_from_scheme(scheme, name=""):
     """Create a schedule from a scheme.
 
     Parameters
@@ -251,7 +253,7 @@ def create_schedule_from_scheme(scheme):
         if isinstance(i, Tensor):
             i.var_dict = {}
             i.last_update = i.first_update
-    return create_schedule(scheme.inputs, scheme.func)
+    return create_schedule(scheme.inputs, scheme.func, name=name)
 
 def lower(schedule):
     """Get the generated IR of a given schedule.
@@ -315,7 +317,7 @@ def build(schedule, target=None, name="default_function", stmt=None):
                 tpl = tuple(shapes)
                 stmt = _make.AttrStmt([i.buf, i.tensor], "buffer_bind_scope",
                         call_intrin('handle', 'tvm_tuple', *tpl), stmt)
-    return _build(schedule.sch, new_inputs, target=target, name=name, stmt=stmt)
+    return _build(schedule.sch, new_inputs, target=target, name=name, stmt=stmt, schedule_name=schedule.name)
 
 ##############################################################################
 # Other useful APIs

--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -217,8 +217,7 @@ def create_schedule(inputs, func=None, name=""):
             func.__setattr__(op.name, op)
     t = Schedule.last_stages
     ops = [t_._op.op for t_ in t]
-    s = Schedule(_schedule.create_schedule(ops), inputs)
-    s.name = name
+    s = Schedule(_schedule.create_schedule(ops), inputs, name)
     return s
 
 def create_schedule_from_scheme(scheme, name=""):

--- a/python/heterocl/devices.py
+++ b/python/heterocl/devices.py
@@ -266,6 +266,7 @@ class env(type):
         return cls(key, devs, host, xcel, tool)
 
 class Project():
+    project_name = "project"
     path = "project"
     
 class platform(with_metaclass(env, object)):
@@ -348,8 +349,9 @@ class platform(with_metaclass(env, object)):
             self.host.lang = "xocl"
 
         if project != None:
+            Project.project_name = project
             Project.path = project
-        self.project = Project.path
+        self.project = Project.project_name
 
     def __getattr__(self, key):
         """ return tool options """

--- a/python/heterocl/devices.py
+++ b/python/heterocl/devices.py
@@ -264,7 +264,10 @@ class env(type):
             raise DeviceError(key + " not supported")
         tool = tool_table[key]
         return cls(key, devs, host, xcel, tool)
-           
+
+class Project():
+    path = "project"
+    
 class platform(with_metaclass(env, object)):
 
     def __init__(self, name, devs, host, xcel, tool):
@@ -290,7 +293,9 @@ class platform(with_metaclass(env, object)):
             self.xcel.storage["plram"] = PLRAM()
             self.xcel.storage["ssd"]   = SSD()
 
-    def config(self, compile=None, mode=None, backend=None, script=None):
+    def config(self, compile=None, mode=None,
+                     backend=None, script=None,
+                     project=None):
         if compile: # check the backend 
             assert compile in option_table.keys(), \
                 "not support tool " + compile
@@ -341,6 +346,10 @@ class platform(with_metaclass(env, object)):
         # check correctness of device attribute
         if self.host.lang == "":
             self.host.lang = "xocl"
+
+        if project != None:
+            Project.path = project
+        self.project = Project.path
 
     def __getattr__(self, key):
         """ return tool options """

--- a/python/heterocl/report.py
+++ b/python/heterocl/report.py
@@ -65,8 +65,8 @@ def parse_xml(path, print_flag=False):
         print(table)
     return profile
 
-def report_stats(target):
-    path = target.project
+def report_stats(target, folder):
+    path = folder
     if target.tool.name == "vivado_hls":
         if os.path.isdir(os.path.join(path, "out.prj")):
             return parse_xml(path)

--- a/python/heterocl/report.py
+++ b/python/heterocl/report.py
@@ -68,7 +68,8 @@ def parse_xml(path, print_flag=False):
         print(table)
     return profile
 
-def report_stats(target, path):
+def report_stats(target):
+    path = target.project
     if target.tool.name == "vivado_hls":
         if os.path.isdir(os.path.join(path, "out.prj")):
             return parse_xml(path)

--- a/python/heterocl/schedule.py
+++ b/python/heterocl/schedule.py
@@ -36,6 +36,7 @@ class Schedule(object):
         self.sch = sch
         self.inputs = inputs
         self.placement = dict()
+        self.name = ""
 
     def __getitem__(self, stage):
         try:

--- a/python/heterocl/schedule.py
+++ b/python/heterocl/schedule.py
@@ -14,6 +14,7 @@ from .tvm._api_internal import _ExternOp
 from .debug import DSLError, APIError
 from . import util
 from .devices import Device, DevMediaPair 
+from itertools import count
 
 class Schedule(object):
     """Create a compute schedule.
@@ -31,12 +32,17 @@ class Schedule(object):
 
     stage_ops = []
     last_stages = OrderedSet([])
+    _ids = count(0)
 
-    def __init__(self, sch, inputs):
+    def __init__(self, sch, inputs, name=""):
+        self.id = next(self._ids)
         self.sch = sch
         self.inputs = inputs
         self.placement = dict()
-        self.name = ""
+        if self.id > 0 and name == "":
+            self.name = "s{}".format(self.id)
+        else:
+            self.name = name
 
     def __getitem__(self, stage):
         try:

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -476,8 +476,6 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
             builder = getattr(codegen, "build_{0}".format(host))
             host_code = builder(fdevice, 1, target_tool)
             builder = getattr(codegen, "build_{0}".format(xcel))
-            # TODO: It would be better to pass dict to builder,
-            #       similar to sim/impl: builder(fdevice, keys, vals)
             xcel_code = builder(fdevice, 2, target_tool)
             return "------ Host Code ------\n\n" + host_code + \
                    "------ Xcel Code ------\n\n" + xcel_code
@@ -499,6 +497,10 @@ def build_fpga_kernel(sch, args, target, name="default_function"):
                 vals.insert(3, target.tool.script)
             else:
                 vals.insert(3, "")
+            keys.insert(4, "project")
+            vals.insert(4, target.project)
+            # make the project folder first
+            os.makedirs(target.project, exist_ok=True)
             return builder(fdevice, keys, vals)
 
     except AttributeError:

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -507,7 +507,8 @@ def build_fpga_kernel(sch, args, target, name="default_function", schedule_name=
             # make the project folder first
             os.makedirs(folder, exist_ok=True)
             f = builder(fdevice, keys, vals)
-            f.target = target # attach target to Module
+            f.attach_target(target)
+            f.set_name(folder)
             return f
 
     except AttributeError:

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -499,7 +499,7 @@ def build_fpga_kernel(sch, args, target, name="default_function", schedule_name=
                 vals.insert(3, "")
             keys.insert(4, "project")
             if schedule_name != "":
-                folder = "{}-{}".format(target.project,schedule_name)
+                folder = "{}-{}".format(schedule_name,target.project)
             else:
                 folder = target.project
             Project.path = folder

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -54,7 +54,7 @@ class Module(ModuleBase):
         if target.tool.name == "vivado_hls":
             if "csyn" not in target.tool.mode:
                 raise RuntimeError("Not supported mode {}".format(mode))
-        return report_stats(target, "project")
+        return report_stats(target)
 
     def save(self, file_name, fmt=""):
         """Save the module to file.

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -50,14 +50,40 @@ class Module(ModuleBase):
         nmod = _ImportsSize(self)
         return [_GetImport(self, i) for i in range(nmod)]
 
+    def set_name(self, name):
+        """Create name for Module
+
+        Parameters
+        ----------
+        name : string
+        """
+        self.name = name
+
+    def attach_target(self, target):
+        """Attach target to Module
+
+        Parameters
+        ----------
+        target : hcl.platform
+        """
+        self.target = target
+
     def report(self):
+        """Get tool report
+
+        Returns
+        ----------
+        report : dictionary
+        """
         if "target" not in self.__dict__.keys():
             raise RuntimeError("No attached target!")
+        if "name" not in self.__dict__.keys():
+            raise RuntimeError("No module name specified!")
         target = self.target
         if target.tool.name == "vivado_hls":
             if "csyn" not in target.tool.mode:
                 raise RuntimeError("Not supported mode {}. Use csyn mode to retrieve the report instead.".format(target.tool.mode))
-        return report_stats(target)
+        return report_stats(target, self.name)
 
     def save(self, file_name, fmt=""):
         """Save the module to file.

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -2,6 +2,7 @@ from . import api
 from ._ffi.function import register_func
 import os, subprocess, time, re, glob
 from ..report import parse_xml
+from ..devices import Project
 debug = True
 
 def replace_text(f_name, prev, new):
@@ -24,32 +25,32 @@ def run_process(cmd, pattern=None, env=None):
 @register_func
 def exec_init(dev_hash, tool, mode):
     # check whether pre-compiled bitstream exitsts
-    kernel = "project/kernel.cpp"
+    kernel = os.path.join(Project.path,"kernel.cpp")
     pre_compiled = False
 
     # check the cache 
     if mode == "hw_exe": mode = "hw"
     elif mode == "sw_sim": mode = "sw_emu"
     elif mode == "hw_sim": mode = "hw_emu"
-    cache = glob.glob('project/save/*.xclbin')
-    target = "project/save/{}-{}.xclbin".format(mode, dev_hash)
-    if target in cache: 
+    cache = glob.glob(os.path.join(Project.path,"save/*.xclbin"))
+    target = os.path.join(Project.path,"save/{}-{}.xclbin".format(mode, dev_hash))
+    if target in cache:
         pre_compiled = True
         print("[{}] Skip codogen. Found pre-built in cache".format(
             time.strftime("%H:%M:%S", time.gmtime())))
-        cmd = "cp -f {} project/kernel.xclbin".format(target)
+        cmd = "cp -f {} ".format(target) + os.path.join(Project.path,"kernel.xclbin")
         run_process(cmd)
 
     # check whether compiled binary exists 
     # re-compile if not. otherwise only compile host
     if pre_compiled:
-        out = run_process("cd project; make host")
+        out = run_process("cd {}; make host".format(Project.path))
 
     # clean up the workspace
     else:
-        if not os.path.exists("project"):
-            out = run_process("mkdir -p project/save")
-        out = run_process("cd project; make clean")
+        if not os.path.exists(os.path.join(Project.path,"save")):
+            out = run_process("mkdir -p " + os.path.join(Project.path,"save"))
+        out = run_process("cd {}; make clean".format(Project.path))
 
     return pre_compiled
 
@@ -67,11 +68,11 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
             "g++ version too old {}.{}.{}".format(ver[0], ver[1], ver[2])
 
         # for host only mode
-        if not os.path.isfile("project/kernel.cpp"):
-            replace_text("project/Makefile", "kernel.cpp", "")
-            replace_text("project/host.cpp", "#include \"kernel.h\"", "")
+        if not os.path.isfile(os.path.join(Project.path,"kernel.cpp")):
+            replace_text(os.path.join(Project.path,"Makefile"), "kernel.cpp", "")
+            replace_text(os.path.join(Project.path,"host.cpp"), "#include \"kernel.h\"", "")
 
-        cmd = "cd project; make "
+        cmd = "cd {}; make ".format(Project.path)
         if mode == "csim":
             cmd += "csim"
             out = run_process(cmd + " 2>&1")
@@ -85,7 +86,7 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
                 time.strftime("%H:%M:%S", time.gmtime())))
             subprocess.Popen(cmd, shell=True).wait()
             if mode != "custom":
-                out = parse_xml("project", print_flag=True)
+                out = parse_xml(Project.path, print_flag=True)
 
         else:
             raise RuntimeError("{} does not support {} mode".format(platform, mode))
@@ -93,27 +94,27 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
     elif platform == "sdsoc":
         assert os.system("which sds++ >> /dev/null") == 0, \
             "cannot find sds++ on system path"
-        out = run_process("cd project; make sdsoc")
+        out = run_process("cd {}; make sdsoc".format(Project.path))
 
     elif platform == "sdaccel":
         assert os.system("which xocc >> /dev/null") == 0, \
             "cannot find xocc on system path"
 
         if mode == "sw_sim":
-            cmd = "cd project; " +\
+            cmd = "cd {}; ".format(Project.path) +\
                   "export XCL_EMULATION_MODE=sw_emu; " +\
                   "./top_function_0_host.exe -f top_function_0.sw_emu.xclbin"
             out = run_process(cmd)
 
         elif mode == "hw_sim":
-            cmd = "cd project; " +\
+            cmd = "cd {}; ".format(Project.path) +\
                   "export XCL_EMULATION_MODE=hw_emu; " +\
                   "./top_function_0_host.exe -f top_function_0.hw_emu.xclbin"
             out = run_process(cmd)
-            os.system("cat project/profile_summary.csv")
+            os.system("cat " + os.path.join(Project.path,"profile_summary.csv"))
 
         elif mode == "hw_exe":
-            cmd = "cd project; " +\
+            cmd = "cd {}; ".format(Project.path) +\
                   "export XCL_EMULATION_MODE=hw; " +\
                   "./top_function_0_host.exe -f top_function_0.hw.xclbin"
             out = run_process(cmd)
@@ -121,7 +122,7 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
     elif platform == "vitis":
         assert os.system("which v++ >> /dev/null") == 0, \
             "cannot find v++ on system path"
-        cmd = "cd project; "
+        cmd = "cd {}; ".format(Project.path)
 
         if mode == "hw_exe" or mode == "hw_sim":
             cmd += "./host kernel.xclbin"
@@ -129,17 +130,17 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
             cmd += "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
 
         if host_only:
-            cmd = "cd project; ./host"
+            cmd = "cd {}; ./host".format(Project.path)
         out = run_process(cmd)
 
     elif platform == "aocl":
         if mode == "sw_sim":
-            cmd = "cd project; " + \
+            cmd = "cd {}; ".format(Project.path) + \
                   "env CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA=1 ./host " + \
                   " kernel.aocx"
             out = run_process(cmd)
         elif mode == "hw_sim":
-            cmd = "cd project; " + \
+            cmd = "cd {}; ".format(Project.path) + \
                   "env CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./host"
             out = run_process(cmd)
 
@@ -180,8 +181,8 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
 
     # copy tcl and testbench  
     elif platform == "vivado_hls":
-        os.system("cp " + path + "vivado/* project/")
-        os.system("cp " + path + "harness.mk project/")
+        os.system("cp " + path + "vivado/* " + Project.path)
+        os.system("cp " + path + "harness.mk " + Project.path)
         if mode != "custom":
             removed_mode = ["csyn","csim","cosim","impl"]
             selected_mode = mode.split("|")
@@ -189,7 +190,7 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
                 removed_mode.remove(s_mode)
 
             new_tcl = ""
-            with open("project/run.tcl","r") as tcl_file:
+            with open(os.path.join(Project.path,"run.tcl"),"r") as tcl_file:
                 for line in tcl_file:
                     if ("csim_design" in line and "csim" in removed_mode) \
                     or ("csynth_design" in line and "csyn" in removed_mode) \
@@ -202,25 +203,25 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
             print("Warning: custom Tcl file is used, and target mode becomes invalid.")
             new_tcl = script
 
-        with open("project/run.tcl","w") as tcl_file:
+        with open(os.path.join(Project.path,"run.tcl"),"w") as tcl_file:
             tcl_file.write(new_tcl)
         return "success"
 
     # copy sdsoc makefile
     elif platform == "sdsoc":
-        os.system("cp " + path + "sdsoc/* project/")
-        os.system("cp " + path + "harness.mk project/")
+        os.system("cp " + path + "sdsoc/* " + Project.path)
+        os.system("cp " + path + "harness.mk " + Project.path)
         return "success"
 
     elif platform == "sdaccel":
-        os.system("cp " + path + "sdaccel/* project/")
-        os.system("cp " + path + "harness.mk project/")
-        replace_text("project/Makefile", "App", "top_function_0")
-        replace_text("project/utils.h", 
+        os.system("cp " + path + "sdaccel/* " + Project.path)
+        os.system("cp " + path + "harness.mk " + Project.path)
+        replace_text(os.path.join(Project.path,"Makefile"), "App", "top_function_0")
+        replace_text(os.path.join(Project.path,"utils.h"), 
                      "xilinx_aws-vu9p-f1-04261818_dynamic_5_0", 
                      "xilinx_vcu1525_dynamic_5_1")
         if backend == "vhls":
-          replace_text("project/Makefile", "kernel.cl", "kernel.cpp")
+          replace_text(os.path.join(Project.path,"Makefile"), "kernel.cl", "kernel.cpp")
 
         # compile the program 
         assert os.system("which xocc >> /dev/null") == 0, \
@@ -233,16 +234,16 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
 
             # re-compile host only (reuse context ?) 
             if False and os.path.isfile("top_function_0.sw_emu.xclbin"):
-              run_process("cd project; make clean; make host")
-              run_process("cp top_function_0.sw_emu.xclbin project/")
+              run_process("cd {}; make clean; make host".format(Project.path))
+              run_process("cp top_function_0.sw_emu.xclbin " + Project.path)
 
             else: # config & compile
               env["XCL_EMULATION_MODE"] = "sw_emu"
-              cmd = "cd project; make clean;"
+              cmd = "cd {}; make clean;".format(Project.path)
               cmd += "emconfigutil --platform=$AWS_PLATFORM;"
               cmd += "make ocl OCL_TARGET=sw_emu \
                       OCL_PLATFORM=$AWS_PLATFORM \
-                      APPLICATION_DIR=" + os.getcwd() + "/project/"
+                      APPLICATION_DIR=" + os.path.join(os.getcwd(),Project.path)
               out = run_process(cmd, env=env)
 
         # enable profiler 
@@ -252,11 +253,11 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
                    "aws platform info missing" 
 
             env["XCL_EMULATION_MODE"] = "hw_emu"
-            cmd = "cd project; make clean;"
+            cmd = "cd {}; make clean;".format(Project.path)
             cmd += "emconfigutil --platform=$AWS_PLATFORM;"
             cmd += "make ocl OCL_TARGET=hw_emu \
                     OCL_PLATFORM=$AWS_PLATFORM \
-                    APPLICATION_DIR=" + os.getcwd() + "/project/"
+                    APPLICATION_DIR=" + os.path.join(os.getcwd(),Project.path)
             out = run_process(cmd, env=env)
 
         elif mode == "hw":
@@ -265,11 +266,11 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
                    "aws platform info missing" 
 
             env["XCL_EMULATION_MODE"] = "hw"
-            cmd = "cd project; make clean;"
+            cmd = "cd {}; make clean;".format(Project.path)
             cmd += "emconfigutil --platform=$AWS_PLATFORM;"
             cmd += "make ocl OCL_TARGET=hw \
                     OCL_PLATFORM=$AWS_PLATFORM \
-                    APPLICATION_DIR=" + os.getcwd() + "/project/"
+                    APPLICATION_DIR=" + os.path.join(os.getcwd(),Project.path)
             out = run_process(cmd, env=env)
           
         return "success"
@@ -278,15 +279,15 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
         env = os.environ.copy()
         assert "XDEVICE" in os.environ, \
                "vitis platform info missing" 
-        os.system("cp " + path + "vitis/* project/")
-        cmd = "cd project; make clean; "
+        os.system("cp " + path + "vitis/* " + Project.path)
+        cmd = "cd {}; make clean; ".format(Project.path)
 
         if mode == "hw_exe": mode = "hw"
         elif mode == "sw_sim": mode = "sw_emu"
         elif mode == "hw_sim": mode = "hw_emu"
 
         # create connecivity config 
-        with open("project/config.ini", "w") as fp:
+        with open(os.path.join(Project.path,"config.ini"), "w") as fp:
             fp.write(cfg)
 
         if not host_only:
@@ -297,17 +298,17 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
         # mv combined binary to root and save
         device = os.environ["XDEVICE"].split("/")[-1]
         device = device.replace(".xpfm", "")
-        path = "project/build_dir.{}.{}/kernel.xclbin".format(mode, device)
+        path = os.path.join(Project.path,"build_dir.{}.{}/kernel.xclbin".format(mode, device))
         assert os.path.exists(path), "Not found {}".format(path)
-        run_process("cp {} project/kernel.xclbin".format(path))
+        run_process("cp {} ".format(path) + os.path.join(Project.path,"kernel.xclbin"))
 
-        kernel = "project/kernel.cpp"
+        kernel = os.path.join(Project.path,"kernel.cpp")
         with open(kernel, "r") as fp:
             regex = "HASH:(\d+)\n"
             hash_v = re.findall(regex, fp.read())[0]
 
-        cache = "project/save/{}-{}.xclbin".format(mode, hash_v)
-        run_process("cp project/kernel.xclbin {}".format(cache))
+        cache = os.path.join(Project.path,"save/{}-{}.xclbin".format(mode, hash_v))
+        run_process("cp " + os.path.join(Project.path,"kernel.xclbin") + "{}".format(cache))
         return "success"
 
     elif platform == "aocl":
@@ -321,8 +322,8 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
         assert "INTELFPGAOCLSDKROOT" in os.environ, \
                "cannot find aocl sdk for fpga on path" 
 
-        os.system("cp " + path + "aocl/* project/")
-        cmd = "cd project; make clean; make;"
+        os.system("cp " + path + "aocl/* " + Project.path)
+        cmd = "cd {}; make clean; make;".format(Project.path)
 
         # compile kernel for xcel device
         cmd += " aoc"
@@ -341,10 +342,10 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
             mk = re.findall(r"makefiles: {(.+?)}", cfg)[0]
 
             # copy dependency files
-            out = run_process("cp -r " + deps + " project/") 
+            out = run_process("cp -r " + deps + " " + Project.path) 
             print("[{}] Running custom commands: {}".format(
                 time.strftime("%H:%M:%S", time.gmtime()), custom_cmds))
-            out = run_process("cd project; " + custom_cmds) 
+            out = run_process("cd {}; ".format(Project.path) + custom_cmds) 
             cmd += " " + mk + " "
 
         cmd += " -I $INTELFPGAOCLSDKROOT/include/kernel_headers"

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -124,10 +124,12 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
             "cannot find v++ on system path"
         cmd = "cd {}; ".format(Project.path)
 
-        if mode == "hw_exe" or mode == "hw_sim":
+        if mode == "hw_exe":
             cmd += "./host kernel.xclbin"
         elif mode == "sw_sim":
             cmd += "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
+        elif mode == "hw_sim":
+            cmd += "XCL_EMULATION_MODE=hw_emu ./host kernel.xclbin"
 
         if host_only:
             cmd = "cd {}; ./host".format(Project.path)
@@ -298,9 +300,9 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
         # mv combined binary to root and save
         device = os.environ["XDEVICE"].split("/")[-1]
         device = device.replace(".xpfm", "")
-        path = os.path.join(Project.path,"build_dir.{}.{}/kernel.xclbin".format(mode, device))
+        path = os.path.join(Project.path, "build_dir.{}.{}/kernel.xclbin".format(mode, device))
         assert os.path.exists(path), "Not found {}".format(path)
-        run_process("cp {} ".format(path) + os.path.join(Project.path,"kernel.xclbin"))
+        run_process("cp {} ".format(path) + os.path.join(Project.path, "kernel.xclbin"))
 
         kernel = os.path.join(Project.path,"kernel.cpp")
         with open(kernel, "r") as fp:
@@ -308,7 +310,7 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
             hash_v = re.findall(regex, fp.read())[0]
 
         cache = os.path.join(Project.path,"save/{}-{}.xclbin".format(mode, hash_v))
-        run_process("cp " + os.path.join(Project.path,"kernel.xclbin") + "{}".format(cache))
+        run_process("cp " + os.path.join(Project.path, "kernel.xclbin") + " {}".format(cache))
         return "success"
 
     elif platform == "aocl":

--- a/tests/test_runtime_build.py
+++ b/tests/test_runtime_build.py
@@ -144,7 +144,7 @@ def test_vitis():
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.B, target.xcel)
         s.to(kernel.C, target.host)
-        target.config(compile="vitis", mode="sw_sim")
+        target.config(compile="vitis", mode="hw_sim")
         f = hcl.build(s, target)
 
         np_A = np.random.randint(10, size=(10,32))

--- a/tvm/src/codegen/build_common.cc
+++ b/tvm/src/codegen/build_common.cc
@@ -86,7 +86,7 @@ class SimModuleNode final : public ModuleNode {
           GenSharedMem(args, shmids, arg_sizes);
 
           GenHostCode(args, shmids, arg_types, func_, 
-                      platform_, host_, arg_names_, empty);
+                      platform_, host_, arg_names_, empty, options_["project"]);
           // If project directory exists, check the 
           // HASH of generated device program 
           auto pre_compiled = false;
@@ -103,7 +103,7 @@ class SimModuleNode final : public ModuleNode {
 
           if (!pre_compiled) {
             LOG(CLEAN) << "Generating harness files ...";
-            GenKernelCode(dev_, arg_names_, platform_, options_["backend"]);
+            GenKernelCode(dev_, arg_names_, platform_, options_["backend"], options_["project"]);
 
             // Copy files and compile tp binary  
             LOG(CLEAN) << "Compiling the program ...";

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -326,14 +326,14 @@ void PrintCopyBack(TVMArray* arr,
 
 // generate kernel code into files 
 void GenKernelCode(std::string& test_file, std::vector<std::string> arg_names, 
-                   std::string platform, std::string backend) {
+                   std::string platform, std::string backend, std::string project) {
   if (test_file.find_first_not_of(" \t\n") == std::string::npos) return;
   std::ofstream stream;
 
   std::string kernel_ext = "cpp";
   if (platform == "sdaccel" && backend == "sdaccel") kernel_ext = "cl";
   if (platform == "aocl") kernel_ext = "cl";
-  stream.open("project/kernel." + kernel_ext);
+  stream.open(project + "/kernel." + kernel_ext);
 
   // generate hash
   std::hash<std::string> hasher;
@@ -361,7 +361,7 @@ void GenKernelCode(std::string& test_file, std::vector<std::string> arg_names,
 
     // generate header file
     std::ofstream header;
-    header.open("project/kernel.h");
+    header.open(project + "/kernel.h");
     header << "#ifndef __KERNEL_H__\n" 
            << "#define __KERNEL_H__\n\n";
     header << "#include <ap_int.h>\n";
@@ -504,10 +504,12 @@ void GenHostCode(TVMArgs& args,
                  LoweredFunc lowered_func,std::string platform,
                  std::string host_code, 
                  std::vector<std::string> arg_names,
-                 bool kernel_is_empty) {
+                 bool kernel_is_empty,
+                 std::string project) {
   int indent = 0;
   std::ofstream stream;
-  stream.open("project/host.cpp");
+  LOG(INFO) << project << " host.cpp";
+  stream.open(project + "/host.cpp");
 
   std::string include;
   auto code = SplitHostCode(host_code, include); 

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -537,11 +537,9 @@ void GenHostCode(TVMArgs& args,
              << shmids[i] << ", nullptr, 0);\n";
       PrintIndent(stream, indent);
 
-      // allocate multi-dim array
       TVMArray* arr = args[i];
-      stream << Type2Byte(arg_types[i]) << " ";
-      stream << arg_names[i];
-      // stream << " = new " << Type2Byte(arg_types[i]);
+      stream << "auto " << arg_names[i];
+      stream << " = new " << Type2Byte(arg_types[i]);
 
       stream << "[";
       for (int j = 0; j < arr->ndim; j++) {

--- a/tvm/src/codegen/build_util.h
+++ b/tvm/src/codegen/build_util.h
@@ -50,7 +50,8 @@ void PrintCopyBack(TVMArray* arr,
 void GenKernelCode(std::string& test_file, 
                    std::vector<std::string> arg_names,
                    std::string platform,
-                   std::string backend);
+                   std::string backend,
+                   std::string project);
 
 void GenHostCode(TVMArgs& args,
                  const std::vector<int>& shmids,
@@ -59,7 +60,8 @@ void GenHostCode(TVMArgs& args,
                  std::string platform,
                  std::string host_code,
                  std::vector<std::string> arg_names,
-                 bool kernel_is_empty);
+                 bool kernel_is_empty,
+                 std::string project);
 } // namespace runtime
 } // namespace TVM
 #endif  // TVM_CODEGEN_BUILD_HELPER_H_

--- a/tvm/src/codegen/opencl/codegen_xocl_host.cc
+++ b/tvm/src/codegen/opencl/codegen_xocl_host.cc
@@ -40,9 +40,15 @@ std::string CodeGenXOCLHost::GetBufferRef(Type t, const Variable* buffer, Expr i
     if (is_scalar) {
       os << vid;
     } else { 
-      os << vid << "[";
-      PrintExpr(index, os);
-      os << "]";
+      os << vid;
+      CHECK(var_shape_map_.count(buffer)) 
+        << "buffer " << buffer->name_hint << " not found in var_shape_map";
+      std::vector<Expr> indices = ExtractIndices(index, var_shape_map_[buffer], range_);
+      for (size_t i = 0; i < indices.size(); i++) {
+        os << '[';
+        PrintExpr(indices[i], os);
+        os << ']';
+      }
     }
   }  
   return os.str();
@@ -220,7 +226,9 @@ void CodeGenXOCLHost::VisitStmt_(const Allocate* op) {
       stream << "[";
       for (size_t i = 0; i < op->extents.size(); i++) {
         PrintExpr(op->extents[i], stream);
-        if (i != op->extents.size()-1) stream << " * ";
+        if (i != op->extents.size()-1) {
+            stream << "][ ";
+        }
       }
       stream << "]";
     }

--- a/tvm/src/template/vivado/Makefile
+++ b/tvm/src/template/vivado/Makefile
@@ -26,6 +26,6 @@ vivado_hls:
 	vivado_hls -f run.tcl
 
 clean:
-	rm -rf out *.txt *.dat *.prj *.log
-	rm -rf zedboard_project* xillydemo.bit
+	-rm -rf out *.txt *.dat *.prj *.log
+	-rm -rf zedboard_project* xillydemo.bit
 


### PR DESCRIPTION
This PR will fix #252 . Users can specify where they want to store and execute their projects by `target.config(project="path/to/project")`.

Following is a full example generating two programs of different schedules and also retaining their results in different folders.
```python
def gemm():
    dtype = hcl.Float()
    M = 64
    K = 64
    N = 64
    A = hcl.placeholder((M, K), "A", dtype=dtype)
    B = hcl.placeholder((K, N), "B", dtype=dtype)
    k = hcl.reduce_axis(0, K)
    def kernel(A, B):
        C = hcl.compute((M, N), lambda x, y: hcl.sum(A[x, k] * B[k, y], axis=k, dtype=dtype), "C", dtype=dtype)
        return C
    
    def make_schedule(opt=False,project="gemm"):
        s = hcl.create_schedule([A, B], kernel)
        target = hcl.platform.zc706
        target.config(compile="vivado_hls", mode="csyn", project=project) # note this line
        s.to([A, B],target.xcel)
        s.to(kernel.C,target.host)

        def optimization():
            s[kernel.C].pipeline(kernel.C.axis[1])
            s.partition(A,hcl.Partition.Block,dim=2,factor=16)
            s.partition(B,hcl.Partition.Block,dim=1,factor=16)

        if opt:
            optimization()
        f = hcl.build(s, target)

        np_A = np.random.randint(0, 10, (M, K))
        np_B = np.random.randint(0, 10, (K, N))
        np_C = np.zeros((M, N))
        hcl_A = hcl.asarray(np_A)
        hcl_B = hcl.asarray(np_B)
        hcl_C = hcl.asarray(np_C)
        f(hcl_A, hcl_B, hcl_C)

    make_schedule(opt=False, project="gemm")
    make_schedule(opt=True, project="gemm-opt")
```
