### PR TITLE
[API] Fix showing incorrect data types for bit slicing and struct

### DIFF
--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -235,10 +235,11 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
                 if bw_from != bw_to:
                     ty = util.get_type(self.tensor.dtype)[0] + str(bw_to)
                     load = _make.Cast(ty, load)
-                return _make.Call(self._dtype, "bitcast",
+                if (isinstance(self.tensor.type, types.Struct)
+                        and util.get_type(self._dtype)[0] != "uint"):
+                    load = _make.Call(self._dtype, "bitcast",
                                   [load], _expr.Call.PureIntrinsic, None, 0)
-            else:
-                return load
+            return load
         return _make.GetBit(_make.Load(self._dtype,
                                        self.tensor.buf.data,
                                        index), bit)

--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -2,6 +2,7 @@
 #pylint: disable=missing-docstring, too-many-instance-attributes
 from .tvm import make as _make
 from .tvm import expr as _expr
+from .tvm import ir_pass as _pass
 from .tvm.api import decl_buffer
 from .tvm._ffi.node import NodeGeneric
 from .debug import TensorError
@@ -119,6 +120,18 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
         self.tensor = tensor
         self.indices = indices
         self._dtype = dtype if dtype is not None else self.tensor.dtype
+        # check if we have bit slicing
+        index, bit, _ = util.get_index(self.tensor.shape, indices, 0)
+        if isinstance(bit, slice) and not isinstance(self.tensor.type, types.Struct):
+            diff = bit.stop - bit.start
+            if not isinstance(diff, int):
+                diff = _pass.Simplify(diff)
+                diff = util.CastRemover().mutate(diff)
+            try:
+                diff = int(diff)
+                self._dtype = util.get_type(self.tensor.dtype)[0] + str(diff)
+            except:
+                pass
 
     def __getitem__(self, indices):
         if not isinstance(indices, tuple):
@@ -142,7 +155,7 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
             # special handle for struct: we need to make sure the bitwidths
             # are the same before and after bitcast
             if (isinstance(self.tensor.type, types.Struct)
-                    and util.get_type(self._dtype) != "uint"):
+                    and util.get_type(self._dtype)[0] != "uint"):
                 ty = "uint" + str(util.get_type(self._dtype)[1])
                 expr = _make.Call(ty, "bitcast",
                                   [expr], _expr.Call.PureIntrinsic, None, 0)
@@ -203,7 +216,7 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
 
     @property
     def dtype(self):
-        return self.tensor.dtype
+        return self._dtype
 
     def asnode(self):
         if len(self.indices) < len(self.tensor.shape):

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -225,6 +225,7 @@ def test_dtype_struct():
         return E, F, G
 
     s = hcl.create_schedule([A, B, C], kernel)
+    print(hcl.lower(s))
     f = hcl.build(s)
     np_A = np.random.randint(0, 500, size=100) - 250
     np_B = np.random.rand(100) - 0.5

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -218,6 +218,10 @@ def test_dtype_struct():
         E = hcl.compute(A.shape, lambda x: D[x].fa, dtype=hcl.Int(8))
         F = hcl.compute(A.shape, lambda x: D[x].fb, dtype=hcl.Fixed(13, 11))
         G = hcl.compute(A.shape, lambda x: D[x].fc, dtype=hcl.Float())
+        # Check the data type
+        assert D[0].fa.dtype == "int8"
+        assert D[0].fb.dtype == "fixed13_11"
+        assert D[0].fc.dtype == "float32"
         return E, F, G
 
     s = hcl.create_schedule([A, B, C], kernel)
@@ -292,6 +296,23 @@ def test_dtye_strcut_complex():
     f(hcl_A, hcl_B, hcl_C, hcl_O)
 
     assert np.array_equal(hcl_O.asnumpy(), np_G)
+
+def test_dtype_bit_slice():
+
+    hcl.init(hcl.Int())
+
+    def kernel():
+        A = hcl.compute((10,), lambda x: x)
+        assert A[0][0:4].dtype == "int4"
+        assert A[0][A[0]:A[4]].dtype == "int32"
+        assert A[0][A[0]:A[0]+4].dtype == "int4"
+        return A
+
+    s = hcl.create_schedule([], kernel)
+    f = hcl.build(s)
+    np_A = np.zeros((10,))
+    hcl_A = hcl.asarray(np_A)
+    f(hcl_A)
 
 def test_dtype_const_long_int():
 


### PR DESCRIPTION
In this PR, we fix the data types for the following cases.

```python
# 1. Data type of a struct element
stype = hcl.Struct({"fa": hcl.Int(8), "fb": hcl.Fixed(13, 11), "fc": hcl.Float()})
D = hcl.compute(A.shape, lambda x: (x, x, x), dtype=stype)
print(D[0].fa.dtype) # => should be "int8"

# 2. Data type of a bit slice
# 2.1 If the length of the slice can be determined at compile time, we will show the updated data type
A = hcl.compute(..., dtype=hcl.Int(32))
print(A[0][0:2].dtype) # => should be "int2"
print(A[0][A[0]: A[0]+1].dtype) # => should be "int1"

# 2.2 If the length cannot be determined, we return the original data type
print(A[0][A[0] : A[3]].dtype) # => should be "int32"
```