### PR TITLE
[API][Backend] Add Support for Constant Tensors

### DIFF
--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -703,23 +703,9 @@ def const_tensor(values, name=None, dtype=None):
     """Create a constant tensor
     """
     name = get_name("const", name)
-    name = name if Stage.get_len() == 0 \
-                else Stage.get_current().name_with_prefix + "." + name
-    dtype = get_tvm_dtype(dtype, name)
 
     if not isinstance(values, np.ndarray):
         values = np.array(values)
-
-    def cast(val):
-        dtype_ = dtype_to_hcl(dtype)
-        if isinstance(dtype_, (Fixed, UFixed)):
-            bits = dtype_.bits
-            fracs = dtype_.fracs
-            val = int(val * (1 << fracs))
-        return val
-
-    vfunc = np.vectorize(cast)
-    values = vfunc(values)
     shape = values.shape
     values = values.flatten()
     values = values.tolist()

--- a/python/heterocl/compute_api.py
+++ b/python/heterocl/compute_api.py
@@ -699,6 +699,27 @@ def reduce_axis(lower, upper, name=None):
     name = get_name("ra", name)
     return _IterVar((lower, upper), name, 2)
 
+def const_tensor(values, name=None, dtype=None):
+    """Create a constant tensor
+    """
+    name = get_name("const", name)
+    if not isinstance(values, np.ndarray):
+        values = np.array(values)
+    shape = values.shape
+    values = values.flatten()
+    values = values.tolist()
+
+    tensor = None
+    with Stage(name, dtype, shape) as stage:
+        tensor = Tensor(shape, stage._hcl_dtype, name, stage._buf)
+        tensor.last_update = stage
+        stage.init_values = values
+        stage.is_const = True
+
+    tensor._tensor = stage._op
+    return tensor
+
+
 def reducer(init, freduce, dtype="int32", name=None):
     """Create a reducer for a reduction operation.
 

--- a/tests/test_compute_basic.py
+++ b/tests/test_compute_basic.py
@@ -256,24 +256,67 @@ def test_mutate_complex():
     for i in range(0, 10):
         assert ret_B[i] == gold_B[i]
 
-def test_const_tensor():
-    hcl.init()
+def test_const_tensor_int():
 
-    np_A = numpy.random.randint(10, size=(10, 8, 6))
-    py_A = np_A.tolist()
+    def test_kernel(dtype, size):
+        hcl.init(dtype)
 
-    def kernel():
-        cp1 = hcl.const_tensor(np_A)
-        cp2 = hcl.const_tensor(py_A)
-        return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x])
+        np_A = numpy.random.randint(10, size=size)
+        py_A = np_A.tolist()
 
-    O = hcl.placeholder(np_A.shape)
-    s = hcl.create_schedule([], kernel)
-    f = hcl.build(s)
+        def kernel():
+            cp1 = hcl.const_tensor(np_A)
+            cp2 = hcl.const_tensor(py_A)
+            return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x])
 
-    np_O = numpy.zeros(np_A.shape)
-    hcl_O = hcl.asarray(np_O, dtype=hcl.Int(32))
+        O = hcl.placeholder(np_A.shape)
+        s = hcl.create_schedule([], kernel)
+        f = hcl.build(s)
 
-    f(hcl_O)
+        np_O = numpy.zeros(np_A.shape)
+        hcl_O = hcl.asarray(np_O, dtype=dtype)
 
-    assert numpy.array_equal(hcl_O.asnumpy(), np_A*2)
+        f(hcl_O)
+
+        assert numpy.array_equal(hcl_O.asnumpy(), np_A*2)
+
+    for i in range(0, 5):
+        bit = numpy.random.randint(4, 60)
+        test_kernel(hcl.Int(bit), (8, 8))
+        test_kernel(hcl.UInt(bit), (8, 8))
+        test_kernel(hcl.Int(bit), (20, 20, 3))
+        test_kernel(hcl.UInt(bit), (20, 20, 3))
+
+def test_const_tensor_float():
+
+    def test_kernel(dtype, size):
+        hcl.init(dtype)
+
+        np_A = numpy.random.rand(*size)
+        py_A = np_A.tolist()
+
+        def kernel():
+            cp1 = hcl.const_tensor(np_A)
+            cp2 = hcl.const_tensor(py_A)
+            return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x])
+
+        O = hcl.placeholder(np_A.shape)
+        s = hcl.create_schedule([], kernel)
+        f = hcl.build(s)
+
+        np_O = numpy.zeros(np_A.shape)
+        hcl_O = hcl.asarray(np_O, dtype=dtype)
+
+        f(hcl_O)
+
+        np_A = hcl.cast_np(np_A, dtype)
+        assert numpy.allclose(hcl_O.asnumpy(), np_A*2)
+
+    test_kernel(hcl.Float(), (8, 8))
+    test_kernel(hcl.Float(), (20, 20, 3))
+    for i in range(0, 5):
+        bit = numpy.random.randint(10, 60)
+        test_kernel(hcl.Fixed(bit, bit-4), (8, 8))
+        test_kernel(hcl.UFixed(bit, bit-4), (8, 8))
+        test_kernel(hcl.Fixed(bit, bit-4), (20, 20, 3))
+        test_kernel(hcl.UFixed(bit, bit-4), (20, 20, 3))

--- a/tests/test_compute_basic.py
+++ b/tests/test_compute_basic.py
@@ -298,14 +298,14 @@ def test_const_tensor_float():
         def kernel():
             cp1 = hcl.const_tensor(np_A)
             cp2 = hcl.const_tensor(py_A)
-            return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x])
+            return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x], dtype=hcl.Float())
 
         O = hcl.placeholder(np_A.shape)
         s = hcl.create_schedule([], kernel)
         f = hcl.build(s)
 
         np_O = numpy.zeros(np_A.shape)
-        hcl_O = hcl.asarray(np_O, dtype=dtype)
+        hcl_O = hcl.asarray(np_O, dtype=hcl.Float())
 
         f(hcl_O)
 

--- a/tvm/HalideIR/src/arithmetic/Simplify.cpp
+++ b/tvm/HalideIR/src/arithmetic/Simplify.cpp
@@ -4867,7 +4867,8 @@ private:
             // else case must not use it.
             stmt = Allocate::make(op->buffer_var, op->type, new_extents,
                                   condition, body_if->then_case, op->attrs,
-                                  new_expr, op->free_function);
+                                  new_expr, op->free_function,
+                                  op->init_values, op->is_const);
             stmt = IfThenElse::make(body_if->condition, stmt, body_if->else_case);
         } else if (all_extents_unmodified &&
                    body.same_as(op->body) &&
@@ -4877,7 +4878,8 @@ private:
         } else {
             stmt = Allocate::make(op->buffer_var, op->type, new_extents,
                                   condition, body, op->attrs,
-                                  new_expr, op->free_function);
+                                  new_expr, op->free_function,
+                                  op->init_values, op->is_const);
         }
     }
 

--- a/tvm/HalideIR/src/ir/Expr.h
+++ b/tvm/HalideIR/src/ir/Expr.h
@@ -98,7 +98,7 @@ enum class IRNodeType : int {
     Stencil,
     /** for external module **/
     ExternModule,
-    /** for debuggin **/
+    /** for debugging **/
     Print
 };
 

--- a/tvm/HalideIR/src/ir/IR.h
+++ b/tvm/HalideIR/src/ir/IR.h
@@ -553,12 +553,16 @@ struct Allocate : public StmtNode<Allocate> {
     std::string free_function;
     Stmt body;
     Array<Stmt> attrs; 
+    // We can allocate with init values
+    Array<Expr> init_values;
+    bool is_const;
 
     EXPORT static Stmt make(VarExpr buffer_var,
                             Type type,
                             Array<Expr> extents,
                             Expr condition, Stmt body, Array<Stmt> attrs = Array<Stmt>(),
-                            Expr new_expr = Expr(), std::string free_function = std::string());
+                            Expr new_expr = Expr(), std::string free_function = std::string(),
+                            Array<Expr> init_values = Array<Expr>(), bool is_const = false);
 
     /** A routine to check if the extents are all constants, and if so verify
      * the total size is less than 2^31 - 1. If the result is constant, but
@@ -576,6 +580,9 @@ struct Allocate : public StmtNode<Allocate> {
         v->Visit("new_expr", &new_expr);
         v->Visit("free_function", &free_function);
         v->Visit("body", &body);
+        v->Visit("attrs", &attrs);
+        v->Visit("init_values", &init_values);
+        v->Visit("is_const", &is_const);
     }
     static const IRNodeType _type_info = IRNodeType::Allocate;
     static constexpr const char* _type_key = "Allocate";
@@ -606,12 +613,17 @@ struct Realize : public StmtNode<Realize> {
     Region bounds;
     Expr condition;
     Stmt body;
+    // Constant information
+    Array<Expr> init_values;
+    bool is_const;
 
     EXPORT static Stmt make(FunctionRef func,
                             int value_index,
                             Type type,
                             Region bounds,
-                            Expr condition, Stmt body);
+                            Expr condition, Stmt body,
+                            Array<Expr> init_values = Array<Expr>(),
+                            bool is_const = false);
 
     void VisitAttrs(IR::AttrVisitor* v) final {
         v->Visit("func", &func);
@@ -620,6 +632,8 @@ struct Realize : public StmtNode<Realize> {
         v->Visit("bounds", &bounds);
         v->Visit("condition", &condition);
         v->Visit("body", &body);
+        v->Visit("init_values", &init_values);
+        v->Visit("is_const", &is_const);
     }
     static const IRNodeType _type_info = IRNodeType::Realize;
     static constexpr const char* _type_key = "Realize";

--- a/tvm/HalideIR/src/ir/IRMutator.cpp
+++ b/tvm/HalideIR/src/ir/IRMutator.cpp
@@ -313,7 +313,8 @@ void IRMutator::visit(const Allocate *op, const Stmt &s) {
       stmt = s;
     } else {
       stmt = Allocate::make(op->buffer_var, op->type, new_extents, 
-                            condition, body, new_attrs, new_expr, op->free_function);
+                            condition, body, new_attrs, new_expr, op->free_function,
+                            op->init_values, op->is_const);
     }
 }
 
@@ -346,7 +347,8 @@ void IRMutator::visit(const Realize *op, const Stmt &s) {
     } else {
       stmt = Realize::make(op->func, op->value_index,
                            op->type, new_bounds,
-                           condition, body);
+                           condition, body,
+                           op->init_values, op->is_const);
     }
 }
 

--- a/tvm/HalideIR/src/ir/IRPrinter.cpp
+++ b/tvm/HalideIR/src/ir/IRPrinter.cpp
@@ -510,7 +510,9 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
 TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
 .set_dispatch<Allocate>([](const Allocate *op, IRPrinter* p) {
     p->do_indent();
-    p->stream << "allocate " << op->buffer_var << "[" << op->type;
+    p->stream << "allocate ";
+    if (op->is_const) p->stream << "const ";
+    p->stream << op->buffer_var << "[" << op->type;
     for (size_t i = 0; i < op->extents.size(); i++) {
         p->stream << " * ";
         p->print(op->extents[i]);

--- a/tvm/include/tvm/operation.h
+++ b/tvm/include/tvm/operation.h
@@ -246,6 +246,10 @@ class ExternOpNode : public OperationNode {
   Array<Buffer> output_placeholders;
   /*! \brief the statement that generates the computation. */
   Stmt body;
+  /*! \brief the values that can be used to initialize output tensor. */
+  Array<Expr> init_values;
+  /*! \brief whether the output tensor is const. */
+  bool is_const;
 
   Array<IterVar> axis;
 
@@ -283,6 +287,8 @@ class ExternOpNode : public OperationNode {
     v->Visit("axis", &axis);
     v->Visit("inputs", &inputs);
     v->Visit("body", &body);
+    v->Visit("init_values", &init_values);
+    v->Visit("is_const", &is_const);
   }
   EXPORT static Operation make(std::string name,
                         std::string tag,
@@ -290,7 +296,9 @@ class ExternOpNode : public OperationNode {
                         Array<Tensor> inputs,
                         Array<Buffer> input_placeholders,
                         Array<Buffer> output_placeholders,
-                        Stmt body);
+                        Stmt body,
+                        Array<Expr> init_values = Array<Expr>(),
+                        bool is_const = false);
 
   static constexpr const char* _type_key = "ExternOp";
   TVM_DECLARE_NODE_TYPE_INFO(ExternOpNode, OperationNode);

--- a/tvm/src/api/api_ir.cc
+++ b/tvm/src/api/api_ir.cc
@@ -66,17 +66,6 @@ TVM_REGISTER_API("make.Store")
     }
   });
 
-TVM_REGISTER_API("make.Realize")
-.set_body([](TVMArgs args,  TVMRetValue *ret) {
-    *ret = Realize::make(args[0],
-                         args[1],
-                         args[2],
-                         args[3],
-                         args[4],
-                         args[5]);
-  });
-
-
 TVM_REGISTER_API("make.Call")
 .set_body([](TVMArgs args,  TVMRetValue *ret) {
     *ret = Call::make(args[0],
@@ -232,6 +221,7 @@ REGISTER_MAKE3(Let);
 REGISTER_MAKE3(LetStmt);
 REGISTER_MAKE3(AssertStmt);
 REGISTER_MAKE3(ProducerConsumer);
+REGISTER_MAKE6(Realize);
 REGISTER_MAKE6(Allocate);
 REGISTER_MAKE4(Provide);
 REGISTER_MAKE4(Prefetch);

--- a/tvm/src/api/api_lang.cc
+++ b/tvm/src/api/api_lang.cc
@@ -221,13 +221,25 @@ TVM_REGISTER_API("_ComputeOp")
 
 TVM_REGISTER_API("_ExternOp")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
-    *ret = ExternOpNode::make(args[0],
-                              args[1],
-                              args[2],
-                              args[3],
-                              args[4],
-                              args[5],
-                              args[6]);
+    if (args.size() == 7) {
+      *ret = ExternOpNode::make(args[0],
+                                args[1],
+                                args[2],
+                                args[3],
+                                args[4],
+                                args[5],
+                                args[6]);
+    } else {
+      *ret = ExternOpNode::make(args[0],
+                                args[1],
+                                args[2],
+                                args[3],
+                                args[4],
+                                args[5],
+                                args[6],
+                                args[7],
+                                args[8]);
+    }
   });
 
 TVM_REGISTER_API("_OpGetOutput")

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -108,6 +108,29 @@ std::string getIndex(std::vector<int> shape) {
   return str;
 }
 
+void CodeGenC::PrintArray(const Array<Expr>& array, const std::vector<size_t>& extents, std::ostringstream& stream, size_t offset, size_t level) {
+  // check if is the last level
+  if (level == extents.size()-1) {
+    stream << "{";
+    for (size_t i = 0; i < extents[level]; i++) {
+      PrintExpr(array[offset+i], stream);
+      if (i != extents[level]-1) stream << ", ";
+    }
+    stream << "}";
+  } else {
+    stream << "{";
+    for (size_t i = 0; i < extents[level]; i++) {
+      size_t size = 1;
+      for (size_t j = level+1; j < extents.size(); j++) {
+        size *= extents[j];
+      }
+      PrintArray(array, extents, stream, offset + size*i, level+1);
+      if (i != extents[level]-1) stream << ", ";
+    }
+    stream << "}";
+  }
+}
+
 void CodeGenC::Init(bool output_ssa) {
   print_ssa_form_ = output_ssa;
 }
@@ -121,6 +144,76 @@ void CodeGenC::InitFuncState(LoweredFunc f) {
   CodeGenSourceBase::ClearFuncState();
 }
 
+class CodeGenC::ConstantsPrinter final : public IRVisitor {
+  public:
+    ConstantsPrinter(bool* create_file, CodeGenC* cg, bool multi_dim) 
+      : _create_file(create_file), _cg(cg), _multi_dim(multi_dim) {}
+    ~ConstantsPrinter() { if (_create_file) _const_header.close(); }
+
+    void Visit_(const Allocate* op) {
+      if (!op->init_values.empty() && op->is_const) {
+        if (!*_create_file) {
+          *_create_file = true;
+          _const_header.open("global_consts.h");
+        }
+
+        std::ostringstream stream;
+        std::string vid; 
+        if (!_cg->var_idmap_.count(op->buffer_var.get())) 
+          vid = _cg->AllocVarID(op->buffer_var.get());
+        else vid = _cg->GetVarID(op->buffer_var.get());
+        int32_t constant_size = op->constant_allocation_size();
+        CHECK_GT(constant_size, 0)
+          << "Can only handle constant size stack allocation for now";
+        const Variable* buffer = op->buffer_var.as<Variable>();
+        _cg->var_shape_map_[buffer] = op->extents;
+
+        stream << "const ";
+        _cg->PrintType(op->type, stream);
+        stream << ' '<< vid;
+        if (constant_size > 1) {// Transfer length one array to scalar
+          stream << "[";
+          for (size_t i = 0; i < op->extents.size(); i++) {
+            _cg->PrintExpr(op->extents[i], stream);
+            if (i != op->extents.size()-1) stream << (_multi_dim ? "][" : " * ");
+          }
+          stream << "]";
+        }
+        _cg->buf_length_map_[buffer] = constant_size;
+
+        stream << " = ";
+        if (constant_size == 1) _cg->PrintExpr(op->init_values[0], stream);
+        else {
+          std::vector<size_t> extents;
+          for (size_t i = 0; i < op->extents.size(); i++) {
+            const int64_t* extent = as_const_int(op->extents[i]);
+            CHECK(extent != nullptr) << "Extent of an init array cannot be a variable\n";
+            extents.push_back(*extent);
+          }
+          _cg->PrintArray(op->init_values, extents, stream, 0, 0);
+        }
+        stream << ";\n";
+
+        _const_header << stream.str() << std::endl;
+      }
+      this->Visit(op->body);
+    }
+
+  private:
+    bool* _create_file;
+    CodeGenC* _cg;
+    bool _multi_dim;
+    std::ofstream _const_header;
+};
+
+bool CodeGenC::PrintConstants(const Stmt& stmt, bool multi_dim=false) {
+  bool create_file = false;
+
+  ConstantsPrinter printer(&create_file, this, multi_dim);
+  printer.Visit(stmt);
+  return create_file;
+}
+
 void CodeGenC::AddFunction(LoweredFunc f,
         str2tupleMap<std::string, Type> map_arg_type) {
   // clear previous generated state.
@@ -131,6 +224,8 @@ void CodeGenC::AddFunction(LoweredFunc f,
     RegisterHandleType(kv.first.get(), kv.second.type());
   }
 
+  bool has_const = PrintConstants(f->body);
+  if (has_const) stream << "#include \"global_const.h\"";
   // generate top function signature 
   this->stream << "void " << f->name << "(";
   for (size_t i = 0; i < f->args.size(); ++i) {
@@ -1002,7 +1097,7 @@ void CodeGenC::VisitStmt_(const Allocate* op) {
     PrintType(op->type, stream);
     stream << "* "<< vid << '=' << new_data << ";\n";
 
-  } else {
+  } else if (!op->is_const) {
     this->PrintIndent();
     int32_t constant_size = op->constant_allocation_size();
     CHECK_GT(constant_size, 0)

--- a/tvm/src/codegen/codegen_c.h
+++ b/tvm/src/codegen/codegen_c.h
@@ -11,6 +11,7 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/codegen.h>
 #include <tvm/lowered_func.h>
+#include <fstream>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -203,6 +204,10 @@ class CodeGenC :
  protected:
   void SaveFuncState(LoweredFunc f);
   void RestoreFuncState(LoweredFunc f);
+  void PrintArray(const Array<Expr>& array, const std::vector<size_t>& extents, 
+                  std::ostringstream& stream, size_t offset, size_t level);
+  bool PrintConstants(const Stmt& stmt, bool multi_dim);
+  class ConstantsPrinter;
 
   // Print reference to struct location
   std::string GetStructRef(

--- a/tvm/src/codegen/hlsc/codegen_hlsc.cc
+++ b/tvm/src/codegen/hlsc/codegen_hlsc.cc
@@ -13,6 +13,29 @@
 namespace TVM {
 namespace codegen {
 
+void CodeGenHLSC::PrintArray(const Array<Expr>& array, const std::vector<size_t>& extents, std::ostringstream& stream, size_t offset, size_t level) {
+  // check if is the last level
+  if (level == extents.size()-1) {
+    stream << "{";
+    for (size_t i = 0; i < extents[level]; i++) {
+      PrintExpr(array[offset+i], stream);
+      if (i != extents[level]-1) stream << ", ";
+    }
+    stream << "}";
+  } else {
+    stream << "{";
+    for (size_t i = 0; i < extents[level]; i++) {
+      size_t size = 1;
+      for (size_t j = level+1; j < extents.size(); j++) {
+        size *= extents[j];
+      }
+      PrintArray(array, extents, stream, offset + size*i, level+1);
+      if (i != extents[level]-1) stream << ", ";
+    }
+    stream << "}";
+  }
+}
+
 void CodeGenHLSC::AddFunction(LoweredFunc f,
         str2tupleMap<std::string, Type> map_arg_type) {
   CodeGenC::AddFunction(f, map_arg_type);
@@ -152,7 +175,8 @@ void CodeGenHLSC::VisitStmt_(const Allocate* op) {
   PrintStorageScope(scope, stream);
 
   // hard fix alloc for channel 
-  if (vid.find("stream_") == std::string::npos) { 
+  if (vid.find("stream_") == std::string::npos) {
+    if (op->is_const) stream << "const ";
     PrintType(op->type, stream);
     stream << ' '<< vid;
     if (constant_size > 1) {// Transfer length one array to scalar
@@ -163,8 +187,21 @@ void CodeGenHLSC::VisitStmt_(const Allocate* op) {
       }
       stream << "]";
     }
-    stream << ";\n";
   }
+  if (!op->init_values.empty()) {
+    stream << " = ";
+    if (constant_size == 1) PrintExpr(op->init_values[0], stream);
+    else {
+      std::vector<size_t> extents;
+      for (size_t i = 0; i < op->extents.size(); i++) {
+        const int64_t* extent = as_const_int(op->extents[i]);
+        CHECK(extent != nullptr) << "Extent of an init array cannot be a variable\n";
+        extents.push_back(*extent);
+      }
+      PrintArray(op->init_values, extents, stream, 0, 0);
+    }
+  }
+  stream << ";\n";
   buf_length_map_[buffer] = constant_size;
   RegisterHandleType(op->buffer_var.get(), op->type);
   for (size_t i = 0; i < op->attrs.size(); i++) {

--- a/tvm/src/codegen/hlsc/codegen_hlsc.h
+++ b/tvm/src/codegen/hlsc/codegen_hlsc.h
@@ -31,8 +31,6 @@ class CodeGenHLSC : public CodeGenC {
   
  protected:
   std::string GetBufferRef(Type t, const Variable* buffer, Expr index);
-  void PrintArray(const Array<Expr>& array, const std::vector<size_t>& extents, 
-                  std::ostringstream& stream, size_t offset, size_t level);
 };
 
 }  // namespace codegen

--- a/tvm/src/codegen/hlsc/codegen_hlsc.h
+++ b/tvm/src/codegen/hlsc/codegen_hlsc.h
@@ -31,6 +31,8 @@ class CodeGenHLSC : public CodeGenC {
   
  protected:
   std::string GetBufferRef(Type t, const Variable* buffer, Expr index);
+  void PrintArray(const Array<Expr>& array, const std::vector<size_t>& extents, 
+                  std::ostringstream& stream, size_t offset, size_t level);
 };
 
 }  // namespace codegen

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -293,6 +293,7 @@ void CodeGenVivadoHLS::VisitStmt_(const Allocate* op) {
     if (!not_alloc) {
       alloc_set_.insert(vid);
       this->PrintIndent();
+      if (op->is_const) stream << "const ";
 
       // allocate stream channels
       if (vid.find("_channel") != std::string::npos ||
@@ -334,6 +335,19 @@ void CodeGenVivadoHLS::VisitStmt_(const Allocate* op) {
                 stream << '[';
                 PrintExpr(op->extents[i], stream);
                 stream << "]";
+              }
+              if (!op->init_values.empty()) {
+                stream << " = ";
+                if (constant_size == 1) PrintExpr(op->init_values[0], stream);
+                else {
+                  std::vector<size_t> extents;
+                  for (size_t i = 0; i < op->extents.size(); i++) {
+                    const int64_t* extent = as_const_int(op->extents[i]);
+                    CHECK(extent != nullptr) << "Extent of an init array cannot be a variable\n";
+                    extents.push_back(*extent);
+                  }
+                  PrintArray(op->init_values, extents, stream, 0, 0);
+                }
               }
             }
           }

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -1261,32 +1261,6 @@ void CodeGenLLVM::VisitStmt_(const Allocate* op) {
       AddAliasInfo(store, op->buffer_var.get(), index, dtype);
     }
   }
-  /*
-  LOG(INFO) << "HERE";
-  int test[3] = [1, 2, 3];
-  int addr = reinterpret_cast<int>(test);
-  llvm::Value* int_addr = ConstInt32(addr);
-  llvm::PointerType* ptr_type = LLVMType(dtype)->getPointerTo();
-  llvm::IntToPtrInst* ptr = builder_->CreateIntToPtr(int_addr, ptr_type);
-  std::vector<llvm::Value*> arg_value;
-  std::vector<llvm::Type*> sig_type;
-  arg_value.push_back(
-  for (size_t i = 2; i < op->args.size(); ++i) {
-    llvm::Value* arg = MakeValue(op->args[i]);
-    if (id == llvm::Intrinsic::pow ||
-        id == llvm::Intrinsic::sqrt ||
-        id == llvm::Intrinsic::log) {
-        arg = CreateCast(op->type, Float(64), arg);
-    }
-    arg_value.push_back(arg);
-    if (i - 2 < num_signature) {
-      sig_type.push_back(arg_value.back()->getType());
-    }
-  }
-  llvm::Function* f = llvm::Intrinsic::getDeclaration(
-      module_.get(), llvm::Intrinsic::memcpy, sig_type);
-  llvm::Value* call = builder_->CreateCall(f, arg_value);
-  */
   this->VisitStmt(op->body);
 }
 

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -1341,7 +1341,7 @@ void CodeGenLLVM::VisitStmt_(const Allocate* op) {
   // if it has init values, assign to it
   if (!op->init_values.empty()) {
     for (size_t i = 0; i < op->init_values.size(); i++) {
-      llvm::Value* value = MakeValue(op->init_values[i]);
+      llvm::Value* value = CreateCast(op->init_values[i].type(), dtype, MakeValue(op->init_values[i]));
       llvm::Value* ptr = CreateBufferPtr(dtype, buf, ConstInt32(i));
       bool is_volatile = volatile_buf_.count(op->buffer_var.get());
       int alignment, native_bits;

--- a/tvm/src/codegen/llvm/llvm_module.cc
+++ b/tvm/src/codegen/llvm/llvm_module.cc
@@ -157,7 +157,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
         llvm::MDString::get(*ctx_, target));
     target_ = target;
     mptr_ = module_.get();
-    this->SaveToFile("test.ll", "ll");
+    //this->SaveToFile("test.ll", "ll");
   }
 
   void LoadIR(const std::string& file_name) {

--- a/tvm/src/codegen/llvm/llvm_module.cc
+++ b/tvm/src/codegen/llvm/llvm_module.cc
@@ -157,7 +157,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
         llvm::MDString::get(*ctx_, target));
     target_ = target;
     mptr_ = module_.get();
-    //this->SaveToFile("test.ll", "ll");
+    this->SaveToFile("test.ll", "ll");
   }
 
   void LoadIR(const std::string& file_name) {

--- a/tvm/src/op/extern_op.cc
+++ b/tvm/src/op/extern_op.cc
@@ -47,7 +47,9 @@ Operation ExternOpNode::make(std::string name,
                              Array<Tensor> inputs,
                              Array<Buffer> input_placeholders,
                              Array<Buffer> output_placeholders,
-                             Stmt body) {
+                             Stmt body,
+                             Array<Expr> init_values,
+                             bool is_const) {
   auto n = std::make_shared<ExternOpNode>();
   n->name = name;
   n->tag = tag;
@@ -62,6 +64,8 @@ Operation ExternOpNode::make(std::string name,
   n->input_placeholders = input_placeholders;
   n->output_placeholders = output_placeholders;
   n->body = body;
+  n->init_values = init_values;
+  n->is_const = is_const;
   return Operation(n);
 }
 
@@ -154,7 +158,8 @@ Stmt ExternOpNode::BuildRealize(
     }
     realize_body = ir::Realize::make(
         t->op, t->value_index, t->dtype,
-        bounds, const_true(), realize_body);
+        bounds, const_true(), realize_body,
+        init_values, is_const);
   }
   return realize_body;
 }

--- a/tvm/src/pass/ir_mutator.cc
+++ b/tvm/src/pass/ir_mutator.cc
@@ -183,7 +183,8 @@ Stmt IRMutator::Mutate_(const Allocate* op, const Stmt& s) {
     return Allocate::make(
         op->buffer_var, op->type,
         new_extents, condition, body, new_attrs,
-        new_expr, op->free_function);
+        new_expr, op->free_function,
+        op->init_values, op->is_const);
   }
 }
 
@@ -261,7 +262,8 @@ Stmt IRMutator::Mutate_(const Realize* op, const Stmt& s) {
   } else {
     return Realize::make(op->func, op->value_index,
                          op->type, new_bounds,
-                         condition, body);
+                         condition, body,
+                         op->init_values, op->is_const);
   }
 }
 

--- a/tvm/src/pass/lift_allocate_attrs.cc
+++ b/tvm/src/pass/lift_allocate_attrs.cc
@@ -51,11 +51,13 @@ class PartitionLifter final : public IRMutator {
         attrs.push_back(allocate_attrs_[var]);
         return Allocate::make(op->buffer_var, op->type, op->extents,
                               op->condition, body, attrs,
-                              op->new_expr, op->free_function);
+                              op->new_expr, op->free_function,
+                              op->init_values, op->is_const);
       }
       return Allocate::make(op->buffer_var, op->type, op->extents,
                             op->condition, body, op->attrs,
-                            op->new_expr, op->free_function);
+                            op->new_expr, op->free_function,
+                            op->init_values, op->is_const);
     }
 
     Stmt Mutate_(const ProducerConsumer* op, const Stmt& s) {

--- a/tvm/src/pass/lift_attr_scope.cc
+++ b/tvm/src/pass/lift_attr_scope.cc
@@ -41,7 +41,8 @@ class AttrScopeLifter : public IRMutator {
       return Allocate::make(
         op->buffer_var, op->type,
         op->extents, op->condition, body, op->attrs,
-        op->new_expr, op->free_function);
+        op->new_expr, op->free_function,
+        op->init_values, op->is_const);
     } else {
       return stmt;
     }

--- a/tvm/src/pass/lower_tvm_builtin.cc
+++ b/tvm/src/pass/lower_tvm_builtin.cc
@@ -68,8 +68,9 @@ class BuiltinLower : public IRMutator {
     op = stmt.as<Allocate>();
     if (op->new_expr.defined()) return stmt;
     // Get constant allocation bound.
-    int64_t dev_type;
     int64_t nbytes = GetVectorBytes(op->type);
+    /* Don't use LLVM alloca
+    int64_t dev_type;
     if (device_type_.defined()) {
       if (arith::GetConst(device_type_, &dev_type)) {
         if (dev_type == kDLCPU) {
@@ -80,6 +81,7 @@ class BuiltinLower : public IRMutator {
         }
       }
     }
+    */
     Expr total_bytes = make_const(op->extents[0].type(), nbytes);
     for (size_t i = 0; i < op->extents.size(); ++i) {
       total_bytes = total_bytes * op->extents[i];
@@ -99,7 +101,7 @@ class BuiltinLower : public IRMutator {
 
     if (!op->init_values.empty()) {
       for (size_t i = 0; i < op->init_values.size(); i++) {
-        Stmt store = Store::make(op->buffer_var, op->init_values[i], UIntImm::make(UInt(32), i), const_true(1));
+        Stmt store = Store::make(op->buffer_var, Cast::make(op->type, op->init_values[i]), UIntImm::make(UInt(32), i), const_true(1));
         body = Block::make(store, body);
       }
     }

--- a/tvm/src/pass/lower_tvm_builtin.cc
+++ b/tvm/src/pass/lower_tvm_builtin.cc
@@ -62,9 +62,11 @@ class BuiltinLower : public IRMutator {
     return stmt;
   }
 
+  /*
   Stmt Mutate_(const Allocate* op, const Stmt& s) {
     // Lower allocate to device allocate when needed.
     Stmt stmt = IRMutator::Mutate_(op, s);
+    return stmt;
     op = stmt.as<Allocate>();
     if (op->new_expr.defined()) return stmt;
     // Get constant allocation bound.
@@ -123,6 +125,7 @@ class BuiltinLower : public IRMutator {
         body);
     return body;
   }
+  */
 
   Stmt Mutate_(const AttrStmt* op, const Stmt &s) final {
     if (op->attr_key == attr::device_context_id) {

--- a/tvm/src/pass/storage_flatten.cc
+++ b/tvm/src/pass/storage_flatten.cc
@@ -222,7 +222,8 @@ class StorageFlattener : public IRMutator {
         ret = Allocate::make(
             e.buffer->data, dtype,
             {arith::ComputeExpr<Mul>(e.buffer->strides[first_dim], e.buffer->shape[first_dim])},
-            make_const(Bool(e.buffer->dtype.lanes()), true), body);
+            make_const(Bool(e.buffer->dtype.lanes()), true), body, Array<Stmt>(),
+            Expr(), std::string(), op->init_values, op->is_const);
       } else {
         shape = e.buffer->shape;
         if (shape.size() == 0) {
@@ -230,7 +231,8 @@ class StorageFlattener : public IRMutator {
         }
         ret = Allocate::make(
             e.buffer->data, dtype, shape,
-            make_const(Bool(e.buffer->dtype.lanes()), true), body);
+            make_const(Bool(e.buffer->dtype.lanes()), true), body, Array<Stmt>(), 
+            Expr(), std::string(), op->init_values, op->is_const);
       }
       ret = AttrStmt::make(
           e.buffer->data, attr::storage_scope,

--- a/tvm/src/schedule/schedule_ops.cc
+++ b/tvm/src/schedule/schedule_ops.cc
@@ -242,7 +242,8 @@ class SchedulePostProc : public IRMutator {
       if (it->second.defined()) {
         Stmt ret = Realize::make(
             it->second->op, it->second->value_index,
-            op->type, op->bounds, op->condition, op->body);
+            op->type, op->bounds, op->condition, op->body,
+            op->init_values, op->is_const);
         return this->Mutate(ret);
       } else {
         return this->Mutate(op->body);


### PR DESCRIPTION
In this PR, we develop a new API `hcl.const_tensor` that allows users to declare a constant tensor. The initial values can be given from a Python list or a NumPy array. Example usage is as follows.

```python
def kernel():
    A = hcl.const_tensor([[2, 2], [3, 4], [1, 2]], "A")
    return hcl.compute(A.shape, lambda x, y: A[x, y]+1, "B")
s = hcl.create_schedule([], kernel)
f = hcl.build(s)
```
Or, with a NumPy array

```python
def kernel():
    A = hcl.const_tensor(np.array([[2, 2], [3, 4], [1, 2]]), "A")
    return hcl.compute(A.shape, lambda x, y: A[x, y]+1, "B")
s = hcl.create_schedule([], kernel)
f = hcl.build(s)
```

Since they are constant tensors, we do not allow users to initialize a constant tensor from another HeteroCL tensor. Moreover, in this PR, we also implement the codegen for HLS C. The above code will result in the following HLS codes. An extra header file that contains all constants will be generated.

```c++
// global_consts.h
const ap_int<32> A[3][2] = {{2, 2}, {3, 4}, {1, 2}};
```

```c++
// top.cpp
#include "global_consts.h"
void default_function(ap_int<32> B[3][2]) {
  for (ap_int<32> x = 0; x < 3; ++x) {
    for (ap_int<32> y = 0; y < 2; ++y) {
      B[x][y] = A[x][y] + 1;
    }
  }
}
```

**Unit Tests:** Please refer to `tests/test_compute_basic.py`. All data types with different shapes are tested.

**Known Issues:** Slow CPU execution due to current implementation. I haven't come up with a better solution yet. I'll file an issue to solve this separately. For now, we encourage people to use CSIM if they declare a large constant array (e.g., more than 1000 elements).