### PR TITLE
[API] Fix bit slicing operations & Introduce reverse slicing

### DIFF
--- a/tests/issues/test_issue_289.py
+++ b/tests/issues/test_issue_289.py
@@ -1,3 +1,6 @@
+import heterocl as hcl
+import numpy as np
+
 def test_slice_op():
 
     hcl.init()

--- a/tests/issues/test_issue_289.py
+++ b/tests/issues/test_issue_289.py
@@ -1,0 +1,21 @@
+def test_slice_op():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: A[x][8:0] + A[x][16:8])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = (np_A & 0xFF) + ((np_A >> 8) & 0xFF)
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -471,6 +471,35 @@ def test_get_slice_tensor():
     ret = hcl_B.asnumpy()
     assert np.array_equal(golden, ret)
 
+def test_get_slice_tensor_reverse():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: A[x][0:8])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = np_A & 0xFF
+    golden = golden.astype('uint8')
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    ret = ret.astype('uint8')
+
+    for i in range(0, 10):
+        x = np.unpackbits(golden[i])
+        x = np.flip(x)
+        y = np.unpackbits(ret[i])
+        assert np.array_equal(x, y)
+
 def test_set_slice_expr():
 
     hcl.init()
@@ -511,6 +540,36 @@ def test_set_slice_tensor():
 
     ret = hcl_B.asnumpy()
     assert np.array_equal(golden, ret)
+
+def test_set_slice_tensor_reverse():
+
+    hcl.init(hcl.UInt(8))
+
+    def kernel(A, B):
+        with hcl.for_(0, 10) as i:
+            B[i][0:8] = A[i]
+
+    A = hcl.placeholder((10,))
+    B = hcl.placeholder((10,))
+    s = hcl.create_schedule([A, B], kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(1, size=(10,))
+    np_B = np.random.randint(10, size=(10,))
+    np_A = np_A.astype('uint8')
+    np_B = np_B.astype('uint8')
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    ret = ret.astype('uint8')
+
+    for i in range(0, 10):
+        a = np.flip(np.unpackbits(np_A[i]))
+        b = np.unpackbits(ret[i])
+        assert np.array_equal(a, b)
 
 def test_slice_op():
 

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -511,3 +511,25 @@ def test_set_slice_tensor():
 
     ret = hcl_B.asnumpy()
     assert np.array_equal(golden, ret)
+
+def test_slice_op():
+
+    hcl.init()
+
+    def kernel(A):
+        return hcl.compute(A.shape, lambda x: A[x][8:0] + A[x][16:8])
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.random.randint(10, size=(10,))
+    np_B = np.zeros(10)
+    golden = (np_A & 0xFF) + ((np_A >> 8) & 0xFF)
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B)
+
+    f(hcl_A, hcl_B)
+
+    ret = hcl_B.asnumpy()
+    assert np.array_equal(golden, ret)

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -345,9 +345,9 @@ def test_dtype_bit_slice():
 
     def kernel():
         A = hcl.compute((10,), lambda x: x)
-        assert A[0][0:4].dtype == "int4"
+        assert A[0][0:4].dtype == "uint4"
         assert A[0][A[0]:A[4]].dtype == "int32"
-        assert A[0][A[0]:A[0]+4].dtype == "int4"
+        assert A[0][A[0]:A[0]+4].dtype == "uint4"
         return A
 
     s = hcl.create_schedule([], kernel)

--- a/tvm/HalideIR/src/arithmetic/Simplify.cpp
+++ b/tvm/HalideIR/src/arithmetic/Simplify.cpp
@@ -559,7 +559,6 @@ private:
             return;
         }
 
-
         // Rearrange a few patterns to cut down on the number of cases
         // to check later.
         if ((is_simple_const(a) && !is_simple_const(b)) ||
@@ -619,7 +618,6 @@ private:
         const Select *select_a = a.as<Select>();
         const Select *select_b = b.as<Select>();
 
-
         if (const_int(a, &ia) &&
             const_int(b, &ib)) {
             if (no_overflow(a.type()) &&
@@ -637,7 +635,7 @@ private:
             // const float + const float
             expr = FloatImm::make(a.type(), fa + fb);
         } else if (is_zero(b)) {
-           expr = a;
+            expr = a;
         } else if (is_zero(a)) {
             expr = b;
         } else if (equal(a, b)) {
@@ -934,7 +932,6 @@ private:
         } else {
             expr = Add::make(a, b);
         }
-
     }
 
     void visit(const Sub *op, const Expr &self) {

--- a/tvm/HalideIR/src/arithmetic/Simplify.cpp
+++ b/tvm/HalideIR/src/arithmetic/Simplify.cpp
@@ -559,6 +559,7 @@ private:
             return;
         }
 
+
         // Rearrange a few patterns to cut down on the number of cases
         // to check later.
         if ((is_simple_const(a) && !is_simple_const(b)) ||
@@ -618,6 +619,7 @@ private:
         const Select *select_a = a.as<Select>();
         const Select *select_b = b.as<Select>();
 
+
         if (const_int(a, &ia) &&
             const_int(b, &ib)) {
             if (no_overflow(a.type()) &&
@@ -635,7 +637,7 @@ private:
             // const float + const float
             expr = FloatImm::make(a.type(), fa + fb);
         } else if (is_zero(b)) {
-            expr = a;
+           expr = a;
         } else if (is_zero(a)) {
             expr = b;
         } else if (equal(a, b)) {
@@ -932,6 +934,7 @@ private:
         } else {
             expr = Add::make(a, b);
         }
+
     }
 
     void visit(const Sub *op, const Expr &self) {

--- a/tvm/src/codegen/llvm/codegen_llvm.h
+++ b/tvm/src/codegen/llvm/codegen_llvm.h
@@ -221,6 +221,10 @@ class CodeGenLLVM :
                        const VarExpr& loop_var, const Stmt& body);
   // add alias information.
   void AddAliasInfo(llvm::Instruction* load, const Variable* buffer, Expr index, Type type);
+  // Getting the bit slice
+  llvm::Value* GetSliceValue(Expr op_a, Expr op_index_left, Expr op_index_right, bool reverse);
+  // Setting the bit slice
+  llvm::Value* SetSliceValue(Expr op_a, Expr op_index_left, Expr op_index_right, Expr op_value, bool reverse);
   // The IRBuilder.
   using IRBuilder = llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter>;
   // The current function


### PR DESCRIPTION
**Issue**: #289 

**Root cause**: The IR equality pass does not handle the bit slicing cases, which leads to segfault.

**Solution**: Make sure all IR nodes are handled correctly in the IR equality pass.

**Test**: `tests/issues/test_issue_289.py`

**Other comments**: We also change the returned data type for bit slicing. It should always be `uint` if the bitwidth can be inferred. In this PR, we also introduce the reverse bit slicing. Following is an example:

```python
a = 0b10010010
# a[4:0] => 0b0010
# a[0:4] => 0b0100
```
Similarly, we can also set bit slices in reverse.

```python
a = 0b10010010
# a[4:0] = 0b1101 => a = 0b10011101
# a[0:4] = 0b1101 => a = 0b10010111
```