### PR TITLE
[Backend] Add Support for Total Bitwidth up to 2047 bits

### DIFF
--- a/python/heterocl/tvm/_ffi/runtime_ctypes.py
+++ b/python/heterocl/tvm/_ffi/runtime_ctypes.py
@@ -35,8 +35,8 @@ class TVMByteArray(ctypes.Structure):
 
 class TVMType(ctypes.Structure):
     """TVM datatype structure"""
-    _fields_ = [("type_code", ctypes.c_uint8),
-                ("bits", ctypes.c_uint8),
+    _fields_ = [("type_code", ctypes.c_uint8, 5),
+                ("bits", ctypes.c_uint16, 11),
                 ("lanes", ctypes.c_uint8),
                 ("fracs", ctypes.c_uint8)]
     CODE2STR = {

--- a/python/heterocl/types.py
+++ b/python/heterocl/types.py
@@ -21,6 +21,10 @@ class Type(object):
             raise DTypeError("Bitwidth must be an integer.")
         if not isinstance(fracs, numbers.Integral):
             raise DTypeError("Number of fractional bits must be an integer.")
+        if bits > 2047:
+            raise DTypeError("The maximum supported total bitwidth is 2047 bits.")
+        if fracs > 255:
+            raise DTypeError("The maximum supported fractional bitwidth is 255 bits.")
         self.bits = bits
         self.fracs = fracs
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -229,23 +229,36 @@ def test_dtype_cast():
 
 
 def test_dtype_long_int():
-    # the longest we can support right now is 255-bit
-    hcl.init(hcl.UInt(32))
-    A = hcl.placeholder((100,))
+    # the longest we can support right now is 2047-bit
 
-    def kernel(A):
-        B = hcl.compute(A.shape, lambda x: hcl.cast(hcl.UInt(255), A[x]) << 200, dtype=hcl.UInt(255))
-        C = hcl.compute(A.shape, lambda x: B[x] >> 200)
-        return C
+    def test_kernel(bw, sl):
+        hcl.init(hcl.UInt(32))
+        A = hcl.placeholder((100,))
+        B = hcl.placeholder((100,))
 
-    s = hcl.create_schedule(A, kernel)
-    f = hcl.build(s)
-    np_A = np.random.randint(0, 1<<31, 100)
-    hcl_A = hcl.asarray(np_A)
-    hcl_C = hcl.asarray(np.zeros(A.shape))
-    f(hcl_A, hcl_C)
+        def kernel(A, B):
+            C = hcl.compute(A.shape, lambda x: hcl.cast(hcl.UInt(bw), A[x]) << sl, dtype=hcl.UInt(bw))
+            D = hcl.compute(A.shape, lambda x: B[x] + C[x], dtype=hcl.UInt(bw))
+            E = hcl.compute(A.shape, lambda x: A[x])
+            return E
 
-    assert np.array_equal(np_A, hcl_C.asnumpy())
+        s = hcl.create_schedule([A, B], kernel)
+        f = hcl.build(s)
+        np_A = np.random.randint(0, 1<<31, 100)
+        np_B = np.random.randint(0, 1<<31, 100)
+        hcl_A = hcl.asarray(np_A)
+        hcl_B = hcl.asarray(np_B)
+        hcl_E = hcl.asarray(np.zeros(A.shape))
+        f(hcl_A, hcl_B, hcl_E)
+
+        assert np.array_equal(np_A, hcl_E.asnumpy())
+
+    test_kernel(64, 30)
+    test_kernel(100, 60)
+    test_kernel(250, 200)
+    test_kernel(500, 400)
+    test_kernel(1000, 750)
+    test_kernel(2000, 1800)
 
 def test_dtype_struct():
     hcl.init()
@@ -405,3 +418,5 @@ def test_dtype_large_array():
     test_kernel(hcl.Fixed(11, 9))
     test_kernel(hcl.Fixed(18, 16))
     test_kernel(hcl.Fixed(37, 35))
+
+test_dtype_long_int()

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,5 +1,6 @@
 import heterocl as hcl
 import numpy as np
+import pytest
 
 def test_dtype_basic_uint():
 
@@ -259,6 +260,19 @@ def test_dtype_long_int():
     test_kernel(500, 400)
     test_kernel(1000, 750)
     test_kernel(2000, 1800)
+
+def test_dtype_too_long_int():
+    # the longest we can support right now is 2047-bit
+
+    def test_kernel_total():
+        A = hcl.placeholder((100,), dtype=hcl.Int(2048))
+
+    def test_kernel_fracs():
+        A = hcl.placeholder((100,), dtype=hcl.Fixed(1000, 800))
+
+    for func in [test_kernel_total, test_kernel_fracs]:
+        with pytest.raises(hcl.debug.DTypeError):
+            func()
 
 def test_dtype_struct():
     hcl.init()

--- a/tvm/HalideIR/src/base/Type.h
+++ b/tvm/HalideIR/src/base/Type.h
@@ -323,7 +323,7 @@ struct Type {
      * lanes: The number of vector elements in the type. */
     Type(halideir_type_code_t code, int bits, int lanes, int fracs = 0, QuanMode qmode = RND, OverMode omode = SAT,
         const halideir_handle_cplusplus_type *handle_type = nullptr)
-        : type(code, (uint8_t)bits, (uint8_t)lanes, (uint8_t)fracs), qmode(RND), omode(SAT), handle_type(handle_type) {
+        : type(code, (uint16_t)bits, (uint8_t)lanes, (uint8_t)fracs), qmode(RND), omode(SAT), handle_type(handle_type) {
     }
 
     /** Trivial copy constructor. */

--- a/tvm/HalideIR/src/base/TypeBase.h
+++ b/tvm/HalideIR/src/base/TypeBase.h
@@ -46,11 +46,11 @@ struct halideir_type_t {
 #if __cplusplus >= 201103L
     HALIDEIR_ATTRIBUTE_ALIGN(1) halideir_type_code_t code; // halideir_type_code_t
 #else
-    HALIDEIR_ATTRIBUTE_ALIGN(1) uint8_t code; // halideir_type_code_t
+    HALIDEIR_ATTRIBUTE_ALIGN(1) uint8_t code : 5; // halideir_type_code_t
 #endif
 
     /** The number of bits of precision of a single scalar value of this type. */
-    HALIDEIR_ATTRIBUTE_ALIGN(1) uint8_t bits;
+    HALIDEIR_ATTRIBUTE_ALIGN(1) uint16_t bits : 11;
 
     /** How many elements in a vector. This is 1 for scalar types. */
     HALIDEIR_ATTRIBUTE_ALIGN(1) uint8_t lanes;
@@ -63,7 +63,7 @@ struct halideir_type_t {
      * code: The fundamental type from an enum.
      * bits: The bit size of one element.
      * lanes: The number of vector elements in the type. */
-    halideir_type_t(halideir_type_code_t code, uint8_t bits, uint8_t lanes = 1, uint8_t fracs = 0)
+    halideir_type_t(halideir_type_code_t code, uint16_t bits, uint8_t lanes = 1, uint8_t fracs = 0)
         : code(code), bits(bits), lanes(lanes), fracs(fracs) {
     }
 

--- a/tvm/dlpack/include/dlpack/dlpack.h
+++ b/tvm/dlpack/include/dlpack/dlpack.h
@@ -79,11 +79,11 @@ typedef struct {
    * We keep it uint8_t instead of DLDataTypeCode for minimal memory
    * footprint, but the value should be one of DLDataTypeCode enum values.
    * */
-  uint8_t code;
+  uint8_t code : 5;
   /*!
    * \brief Number of bits, common choices are 8, 16, 32.
    */
-  uint8_t bits;
+  uint16_t bits : 11;
   /*! \brief Number of lanes in the type, used for vector types. */
   uint8_t lanes;
   uint8_t fracs;

--- a/tvm/include/tvm/expr.h
+++ b/tvm/include/tvm/expr.h
@@ -65,7 +65,7 @@ inline TVMType Type2TVMType(Type t) {
     else ret.code = kUFixed;
   }
   else ret.code = static_cast<uint8_t>(t.code());
-  ret.bits = static_cast<uint8_t>(t.bits());
+  ret.bits = static_cast<uint16_t>(t.bits());
   ret.lanes = static_cast<uint8_t>(t.lanes());
   ret.fracs = static_cast<uint8_t>(t.fracs());
   return ret;
@@ -78,12 +78,11 @@ inline int GetVectorBytes(Type dtype) {
   //CHECK_EQ(data_bits % 8, 0U)
   //    << "Need to load/store by multiple of bytes";
   int nbytes = (data_bits+7) / 8;
-  if (nbytes > 2) {
-    if (nbytes <= 4) nbytes = 4;
-    else if (nbytes <= 8) nbytes = 8;
-    else nbytes = 16;
+  int new_nbytes = 1;
+  while (new_nbytes < nbytes) {
+    new_nbytes <<= 1;
   }
-  return nbytes;
+  return new_nbytes;
 }
 
 /*! \brief a named variable in TVM */

--- a/tvm/include/tvm/runtime/c_runtime_api.h
+++ b/tvm/include/tvm/runtime/c_runtime_api.h
@@ -88,12 +88,9 @@ typedef enum {
   // To make sure each framework's id do not conflict, use first and
   // last sections to mark ranges.
   // Open an issue at the repo if you need a section of code.
-  kExtBegin = 15U,
-  kNNVMFirst = 16U,
-  kNNVMLast = 20U,
+  kExtBegin = 16U,
   // The following section of code is used for non-reserved types.
-  kExtReserveEnd = 64U,
-  kExtEnd = 128U
+  kExtEnd = 31U
 } TVMTypeCode;
 
 /*!

--- a/tvm/include/tvm/runtime/packed_func.h
+++ b/tvm/include/tvm/runtime/packed_func.h
@@ -701,7 +701,7 @@ inline TVMType String2TVMType(std::string s) {
   }
   char* xdelim;  // emulate sscanf("%ux%u", bits, lanes)
   unsigned bits = strtoul(scan, &xdelim, 10);
-  if (bits != 0) t.bits = static_cast<uint8_t>(bits);
+  if (bits != 0) t.bits = static_cast<uint16_t>(bits);
   if (*xdelim == '_') {
     unsigned fracs = strtoul(xdelim + 1, &xdelim, 10);
     if (fracs > bits) LOG(FATAL) << "fraction bits cannot be greater than totoal bits: " << fracs << " > " << bits;

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -44,12 +44,11 @@ void PrintIndent(std::ofstream& stream, int indent) {
 
 inline size_t GetTypeSize(TVMType t) {
   size_t byte = (t.bits + 7) / 8;
-  if (byte > 2){
-    if (byte <= 4) byte = 4;
-    else if (byte <= 8) byte = 8;
-    else byte = 16;
+  size_t new_byte = 1;
+  while (new_byte < byte) {
+    new_byte <<= 1;
   }
-  return byte;
+  return new_byte;
 }
 
 inline std::vector<int> GetShape(TVMArray* arr) {

--- a/tvm/src/pass/arg_binder.cc
+++ b/tvm/src/pass/arg_binder.cc
@@ -160,10 +160,10 @@ void ArgBinder::BindDLTensor(const Buffer& buffer,
   Type dtype = buffer->dtype;
   std::ostringstream type_err_msg;
   type_err_msg << arg_name << ".dtype is expected to be " << dtype;
-  Expr cond = (TVMArrayGet(UInt(8), handle, intrinsic::kArrTypeCode) ==
-               UIntImm::make(UInt(8), dtype.code()) &&
-               TVMArrayGet(UInt(8), handle, intrinsic::kArrTypeBits) ==
-               UIntImm::make(UInt(8), dtype.bits()) &&
+  Expr cond = (TVMArrayGet(UInt(16), handle, intrinsic::kArrTypeCode) ==
+               UIntImm::make(UInt(16), dtype.code()) &&
+               TVMArrayGet(UInt(16), handle, intrinsic::kArrTypeBits) ==
+               UIntImm::make(UInt(16), dtype.bits()) &&
                TVMArrayGet(UInt(8), handle, intrinsic::kArrTypeFracs) ==
                UIntImm::make(UInt(8), dtype.fracs()) &&
                TVMArrayGet(UInt(8), handle, intrinsic::kArrTypeLanes) ==

--- a/tvm/src/runtime/c_runtime_api.cc
+++ b/tvm/src/runtime/c_runtime_api.cc
@@ -159,12 +159,11 @@ inline size_t GetDataSize(TVMArray* arr) {
     size *= arr->shape[i];
   }
   size_t byte = (arr->dtype.bits + 7) / 8;
-  if (byte > 2){
-    if (byte <= 4) byte = 4;
-    else if (byte <= 8) byte = 8;
-    else byte = 16;
+  size_t new_byte = 1;
+  while (new_byte < byte) {
+    new_byte <<= 1;
   }
-  size *= (byte * 8 * arr->dtype.lanes + 7) / 8;
+  size *= (new_byte * 8 * arr->dtype.lanes + 7) / 8;
   return size;
 }
 
@@ -386,7 +385,7 @@ int TVMArrayAlloc(const tvm_index_t* shape,
   // dtype
   // VerifyType(dtype_code, dtype_bits, dtype_lanes); TODO: FIX THIS!!
   arr->dtype.code = static_cast<uint8_t>(dtype_code);
-  arr->dtype.bits = static_cast<uint8_t>(dtype_bits);
+  arr->dtype.bits = static_cast<uint16_t>(dtype_bits);
   arr->dtype.lanes = static_cast<uint8_t>(dtype_lanes);
   arr->dtype.fracs = static_cast<uint8_t>(dtype_fracs);
   if (ndim != 0) {


### PR DESCRIPTION
In this PR, we increase our bitwidth support to 2047 bits. Following is the new maximum allowed values.

- Total bitwidth: 2047
- Fractional: 255

For tests, please refer to `test_dtype.py/test_dtype_long_int`.