### PR TITLE
[API] Fix index casting issue

### DIFF
--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -148,6 +148,7 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
         if not isinstance(indices, tuple):
             indices = (indices,)
         indices = self.indices + indices
+        indices = util.CastRemover().mutate(indices)
         index, bit, _ = util.get_index(self.tensor.shape, indices, 0)
         if not Stage.get_len():
             raise TensorError("Cannot set tensor elements without compute APIs")
@@ -227,6 +228,7 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
     def asnode(self):
         if len(self.indices) < len(self.tensor.shape):
             raise TensorError("Accessing a slice of tensor is not allowed")
+        self.indices = util.CastRemover().mutate(self.indices)
         index, bit, _ = util.get_index(self.tensor.shape, self.indices, 0)
         if bit is None:
             return _make.Load(self._dtype, self.tensor.buf.data, index)

--- a/tests/issues/test_issue_311.py
+++ b/tests/issues/test_issue_311.py
@@ -1,0 +1,28 @@
+import heterocl as hcl
+import numpy as np
+
+def test_for_index_casting():
+
+    def kernel(A):
+        with hcl.for_(0, 10) as i:
+            with hcl.for_(i, 10) as j:
+                A[j] += i
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.zeros(10)
+    golden_A = np.zeros(10)
+
+    for i in range(0, 10):
+        for j in range(i, 10):
+            golden_A[j] += i
+
+    hcl_A = hcl.asarray(np_A)
+
+    f(hcl_A)
+
+    ret_A = hcl_A.asnumpy()
+    assert np.array_equal(golden_A, ret_A)
+

--- a/tests/test_dsl_basic.py
+++ b/tests/test_dsl_basic.py
@@ -244,6 +244,31 @@ def test_for_step_negative():
     ret_A = hcl_A.asnumpy()
     assert np.array_equal(golden_A, ret_A)
 
+def test_for_index_casting():
+
+    def kernel(A):
+        with hcl.for_(0, 10) as i:
+            with hcl.for_(i, 10) as j:
+                A[j] += i
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    f = hcl.build(s)
+
+    np_A = np.zeros(10)
+    golden_A = np.zeros(10)
+
+    for i in range(0, 10):
+        for j in range(i, 10):
+            golden_A[j] += i
+
+    hcl_A = hcl.asarray(np_A)
+
+    f(hcl_A)
+
+    ret_A = hcl_A.asnumpy()
+    assert np.array_equal(golden_A, ret_A)
+
 def test_while_basic():
 
     def kernel(A):


### PR DESCRIPTION
As mentioned in #311, there is index casting issue when inside irregular imperative for loops. Thus, the solution is to remove the casting for tensor indices.

Test case: tests/issues/test_issue_311.py