### PR TITLE
[Pass] Introduce new IR node: MultiBlock

### DIFF
--- a/python/heterocl/tvm/stmt.py
+++ b/python/heterocl/tvm/stmt.py
@@ -124,3 +124,7 @@ class StreamStmt(Stmt):
 @register_node
 class Print(Stmt):
     pass
+
+@register_node
+class MultiBlock(Stmt):
+    pass

--- a/tvm/HalideIR/src/ir/Expr.h
+++ b/tvm/HalideIR/src/ir/Expr.h
@@ -99,7 +99,9 @@ enum class IRNodeType : int {
     /** for external module **/
     ExternModule,
     /** for debuggin **/
-    Print
+    Print,
+    /** for extensibility **/
+    MultiBlock
 };
 
 /** The abstract base classes for a node in the Halide IR. */

--- a/tvm/HalideIR/src/ir/IR.cpp
+++ b/tvm/HalideIR/src/ir/IR.cpp
@@ -923,6 +923,16 @@ Stmt Print::make(Array<Expr> values, std::string format) {
   return Stmt(node);
 }
 
+Stmt MultiBlock::make(Array<Stmt> stmts) {
+  for (size_t i = 0; i < stmts.size(); i++) {
+    internal_assert(stmts[i].defined()) << "MultiBlock of undefined Stmt\n";
+  }
+
+  std::shared_ptr<MultiBlock> node = std::make_shared<MultiBlock>();
+  node->stmts = std::move(stmts);
+  return Stmt(node);
+}
+
 namespace {
 
 // Helper function to determine if a sequence of indices is a
@@ -1025,6 +1035,7 @@ template<> void StmtNode<Stencil>::accept(IRVisitor *v, const Stmt &s) const { v
 template<> void StmtNode<StreamStmt>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const StreamStmt *)this, s); }
 template<> void ExprNode<StreamExpr>::accept(IRVisitor *v, const Expr &e) const { v->visit((const StreamExpr *)this, e); }
 template<> void StmtNode<Print>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const Print *)this, s); }
+template<> void StmtNode<MultiBlock>::accept(IRVisitor *v, const Stmt &s) const { v->visit((const MultiBlock *)this, s); }
 
 Call::ConstString Call::debug_to_file = "debug_to_file";
 Call::ConstString Call::reinterpret = "reinterpret";

--- a/tvm/HalideIR/src/ir/IR.h
+++ b/tvm/HalideIR/src/ir/IR.h
@@ -1328,6 +1328,19 @@ struct Print : public StmtNode<Print> {
   static constexpr const char* _type_key = "Print";
 };
 
+struct MultiBlock : public StmtNode<MultiBlock> {
+  Array<Stmt> stmts;
+  
+  EXPORT static Stmt make(Array<Stmt> stmts);
+
+  void VisitAttrs(IR::AttrVisitor* v) final {
+    v -> Visit("stmts", &stmts);
+  }
+
+  static const IRNodeType _type_info = IRNodeType::MultiBlock;
+  static constexpr const char* _type_key = "MultiBlock";
+};
+
 }
 
 // inline functions

--- a/tvm/HalideIR/src/ir/IRMutator.cpp
+++ b/tvm/HalideIR/src/ir/IRMutator.cpp
@@ -621,6 +621,25 @@ void IRMutator::visit(const Print *op, const Stmt &s) {
   }
 }
 
+void IRMutator::visit(const MultiBlock *op, const Stmt &s) {
+  vector<Stmt> new_stmts(op->stmts.size());
+  bool changed = false;
+
+  for (size_t i = 0; i < op->stmts.size(); i++) {
+    Stmt old_stmt = op->stmts[i];
+    Stmt new_stmt = mutate(old_stmt);
+    if (!new_stmt.same_as(old_stmt)) changed = true;
+    new_stmts[i] = new_stmt;
+  }
+
+  if (!changed) {
+    stmt = s;
+  }
+  else {
+    stmt = MultiBlock::make(new_stmts);
+  }
+}
+
 Stmt IRGraphMutator::mutate(Stmt s) {
     auto iter = stmt_replacements.find(s);
     if (iter != stmt_replacements.end()) {

--- a/tvm/HalideIR/src/ir/IRMutator.h
+++ b/tvm/HalideIR/src/ir/IRMutator.h
@@ -103,6 +103,7 @@ protected:
     EXPORT virtual void visit(const StreamExpr *, const Expr &);
     EXPORT virtual void visit(const StreamStmt *, const Stmt &);
     EXPORT virtual void visit(const Print *, const Stmt &);
+    EXPORT virtual void visit(const MultiBlock *, const Stmt &);
 };
 
 

--- a/tvm/HalideIR/src/ir/IRPrinter.cpp
+++ b/tvm/HalideIR/src/ir/IRPrinter.cpp
@@ -899,5 +899,12 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
     p->stream << "\n";
 });
 
+TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
+.set_dispatch<MultiBlock>([](const MultiBlock *op, IRPrinter* p) {
+    for (size_t i = 0; i < op->stmts.size(); i++) {
+      p->print(op->stmts[i]);
+    }
+});
+
 }
 }

--- a/tvm/HalideIR/src/ir/IRVisitor.cpp
+++ b/tvm/HalideIR/src/ir/IRVisitor.cpp
@@ -324,6 +324,11 @@ void IRVisitor::visit(const Print *op, const Stmt &) {
   }
 }
 
+void IRVisitor::visit(const MultiBlock *op, const Stmt &) {
+  for (size_t i = 0; i < op->stmts.size(); i++) {
+    op->stmts[i].accept(this);
+  }
+}
 
 void IRGraphVisitor::include(const Expr &e) {
     if (visited.count(e.get())) {
@@ -645,6 +650,12 @@ void IRGraphVisitor::visit(const Stencil *op, const Stmt &) {
 void IRGraphVisitor::visit(const Print *op, const Stmt &) {
   for (size_t i = 0; i < op->values.size(); i++) {
     include(op->values[i]);
+  }
+}
+
+void IRGraphVisitor::visit(const MultiBlock *op, const Stmt &) {
+  for (size_t i = 0; i < op->stmts.size(); i++) {
+    include(op->stmts[i]);
   }
 }
 

--- a/tvm/HalideIR/src/ir/IRVisitor.h
+++ b/tvm/HalideIR/src/ir/IRVisitor.h
@@ -83,6 +83,7 @@ public:
     EXPORT virtual void visit(const StreamStmt *, const Stmt &);
     EXPORT virtual void visit(const StreamExpr *, const Expr &);
     EXPORT virtual void visit(const Print *, const Stmt &);
+    EXPORT virtual void visit(const MultiBlock *, const Stmt &);
 };
 
 /** A base class for algorithms that walk recursively over the IR
@@ -166,6 +167,7 @@ public:
     EXPORT virtual void visit(const StreamExpr *, const Expr &);
     EXPORT virtual void visit(const StreamStmt *, const Stmt &);
     EXPORT virtual void visit(const Print *, const Stmt &);
+    EXPORT virtual void visit(const MultiBlock *, const Stmt &);
     // @}
 };
 

--- a/tvm/include/tvm/ir.h
+++ b/tvm/include/tvm/ir.h
@@ -516,6 +516,7 @@ using Halide::Internal::Partition;
 using Halide::Internal::Stencil;
 using Halide::Internal::ExternModule;
 using Halide::Internal::Print;
+using Halide::Internal::MultiBlock;
 // ir functions
 using Halide::Internal::is_const_power_of_two_integer;
 

--- a/tvm/include/tvm/ir_functor_ext.h
+++ b/tvm/include/tvm/ir_functor_ext.h
@@ -255,6 +255,7 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
   virtual R VisitStmt_(const Partition* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const Stencil* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const Print* op, Args... args) STMT_FUNCTOR_DEFAULT;
+  virtual R VisitStmt_(const MultiBlock* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmtDefault_(const Node* op, Args ...) {
     LOG(FATAL) << "Do not have a default for " << op->type_key();
     return R();
@@ -289,6 +290,7 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
     IR_STMT_FUNCTOR_DISPATCH(Partition);
     IR_STMT_FUNCTOR_DISPATCH(Stencil);
     IR_STMT_FUNCTOR_DISPATCH(Print);
+    IR_STMT_FUNCTOR_DISPATCH(MultiBlock);
     return vtable;
   }
 };

--- a/tvm/include/tvm/ir_mutator.h
+++ b/tvm/include/tvm/ir_mutator.h
@@ -80,6 +80,7 @@ class TVM_DLL IRMutator {
   virtual Stmt Mutate_(const Stencil* op, const Stmt& s);
   virtual Stmt Mutate_(const StreamStmt* op, const Stmt& s);
   virtual Stmt Mutate_(const Print* op, const Stmt& s);
+  virtual Stmt Mutate_(const MultiBlock* op, const Stmt& s);
 
   virtual Expr Mutate_(const Variable* op, const Expr& e);
   virtual Expr Mutate_(const Load* op, const Expr& e);

--- a/tvm/include/tvm/ir_visitor.h
+++ b/tvm/include/tvm/ir_visitor.h
@@ -141,6 +141,7 @@ class TVM_DLL IRVisitor {
   virtual void Visit_(const Partition* op);
   virtual void Visit_(const Stencil* op);
   virtual void Visit_(const Print* op);
+  virtual void Visit_(const MultiBlock* op);
 };
 
 /*!

--- a/tvm/src/api/api_ir.cc
+++ b/tvm/src/api/api_ir.cc
@@ -253,6 +253,7 @@ REGISTER_MAKE2(Reuse);
 REGISTER_MAKE6(Stencil);
 REGISTER_MAKE5(ExternModule);
 REGISTER_MAKE2(Print);
+REGISTER_MAKE1(MultiBlock);
 
 }  // namespace ir
 }  // namespace TVM

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -1540,6 +1540,12 @@ void CodeGenLLVM::VisitStmt_(const Print* op) {
   builder_->CreateCall(printf_call, printf_args);
 }
 
+void CodeGenLLVM::VisitStmt_(const MultiBlock* op) {
+  for (size_t i = 0; i < op->stmts.size(); i++) {
+    this->VisitStmt(op->stmts[i]);
+  }
+}
+
 }  // namespace codegen
 }  // namespace TVM
 #endif  // TVM_LLVM_VERSION

--- a/tvm/src/codegen/llvm/codegen_llvm.h
+++ b/tvm/src/codegen/llvm/codegen_llvm.h
@@ -138,6 +138,7 @@ class CodeGenLLVM :
   void VisitStmt_(const Partition* op) override {};
   void VisitStmt_(const Stencil* op) override;
   void VisitStmt_(const Print* op) override;
+  void VisitStmt_(const MultiBlock* op) override;
 
  protected:
   /*! \brief The storage information */

--- a/tvm/src/lang/ir.cc
+++ b/tvm/src/lang/ir.cc
@@ -159,6 +159,7 @@ TVM_REGISTER_NODE_TYPE(Partition);
 TVM_REGISTER_NODE_TYPE(Stencil);
 TVM_REGISTER_NODE_TYPE(ExternModule);
 TVM_REGISTER_NODE_TYPE(Print);
+TVM_REGISTER_NODE_TYPE(MultiBlock);
 
 }  // namespace ir
 }  // namespace TVM

--- a/tvm/src/pass/ir_mutator.cc
+++ b/tvm/src/pass/ir_mutator.cc
@@ -75,6 +75,10 @@ inline Array<Expr> MutateArray(Array<Expr> arr, IRMutator *m) {
   return UpdateArray(arr, [&m] (const Expr& e) { return m->Mutate(e); });
 }
 
+inline Array<Stmt> MutateStmtArray(Array<Stmt> arr, IRMutator *m) {
+  return UpdateArray(arr, [&m] (const Stmt& s) { return m->Mutate(s); });
+}
+
 inline Array<IterVar> MutateIterVarArr(Array<IterVar> rdom, IRMutator *m) {
   std::vector<IterVar> new_dom(rdom.size());
   bool changed = false;
@@ -420,6 +424,16 @@ Stmt IRMutator::Mutate_(const Print *op, const Stmt &s) {
   }
 }
 
+Stmt IRMutator::Mutate_(const MultiBlock *op, const Stmt &s) {
+  auto new_stmts = MutateStmtArray(op->stmts, this);
+
+  if (op->stmts.same_as(new_stmts)) {
+    return s;
+  } else {
+    return MultiBlock::make(new_stmts);
+  }
+}
+
 TVM_STATIC_IR_FUNCTOR(IRMutator, vtable_stmt)
 .DISPATCH_TO_MUTATE_STMT(LetStmt)
 .DISPATCH_TO_MUTATE_STMT(AttrStmt)
@@ -445,7 +459,8 @@ TVM_STATIC_IR_FUNCTOR(IRMutator, vtable_stmt)
 .DISPATCH_TO_MUTATE_STMT(Reuse)
 .DISPATCH_TO_MUTATE_STMT(Partition)
 .DISPATCH_TO_MUTATE_STMT(Stencil)
-.DISPATCH_TO_MUTATE_STMT(Print);
+.DISPATCH_TO_MUTATE_STMT(Print)
+.DISPATCH_TO_MUTATE_STMT(MultiBlock);
 
 // Mutate Expr
 

--- a/tvm/src/pass/ir_visitor.cc
+++ b/tvm/src/pass/ir_visitor.cc
@@ -291,6 +291,12 @@ void IRVisitor::Visit_(const Print *op) {
   }
 }
 
+void IRVisitor::Visit_(const MultiBlock *op) {
+  for (size_t i = 0; i < op->stmts.size(); i++) {
+    this->Visit(op->stmts[i]);
+  }
+}
+
 #define DEFINE_OP_NO_VISIT_(OP)                     \
   void IRVisitor::Visit_(const OP* op) {}
 
@@ -365,7 +371,8 @@ TVM_STATIC_IR_FUNCTOR(IRVisitor, vtable)
 .DISPATCH_TO_VISIT(Partition)
 .DISPATCH_TO_VISIT(Stencil)
 .DISPATCH_TO_VISIT(ExternModule)
-.DISPATCH_TO_VISIT(Print);
+.DISPATCH_TO_VISIT(Print)
+.DISPATCH_TO_VISIT(MultiBlock);
 
 }  // namespace ir
 }  // namespace TVM


### PR DESCRIPTION
With this PR, a new IR node is introduced. **This PR does not modify any existing logic.** 

The goal of introducing this node is to solve the potential stack-overflow problem. With the current Halide node `Block`, since it only has two body statements, to create a serial of N consecutive statements, we will generate an IR tree of depth N-1. To solve that, a new IR node, `MultiBlock`, is introduced. Instead of building it as a deep tree, this node allows users to create a wide tree with an array of statements. In the future, we should try to replace `Block` with `MultiBlock` as much as possible.