### PR TITLE
[CI] Upgrade CI Python Version to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build-hcl:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
       - restore_cache:
@@ -38,7 +38,7 @@ jobs:
             - ~/project/tvm/lib
   test-python-3:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     <<: *test
 workflows:
   version: 2


### PR DESCRIPTION
The latest version of SciPy requires Python 3.7 and Python 3.7 is also stable enough. We can have another test for the older Python version later on if needed.