### PR TITLE
[Backend][Testing] Fix codegen with Print stmt; Restructure codegen tests

### DIFF
--- a/tests/__test_codegen_harness.py
+++ b/tests/__test_codegen_harness.py
@@ -1,0 +1,80 @@
+import heterocl as hcl
+
+def test_dtype(target, strings, test_fixed_point=True):
+    def test_int():
+        hcl.init()
+        A = hcl.placeholder((1, 32), dtype=hcl.Int(3))
+        B = hcl.placeholder((1, 32), dtype=hcl.UInt(3))
+        C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j], dtype=hcl.Int(8))
+        s = hcl.create_schedule([A, B, C])
+        code = hcl.build(s, target=target)
+        assert strings[0] in code
+        assert strings[1] in code
+        assert strings[2] in code
+
+    def test_fixed():
+        hcl.init()
+        A = hcl.placeholder((1, 32), dtype=hcl.Fixed(5, 3))
+        B = hcl.placeholder((1, 32), dtype=hcl.UFixed(5, 3))
+        C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j], dtype=hcl.Fixed(7, 4))
+        s = hcl.create_schedule([A, B, C])
+        code = hcl.build(s, target=target)
+        assert strings[3] in code
+        assert strings[4] in code
+        assert strings[5] in code
+
+    test_int()
+    if test_fixed_point:
+        test_fixed()
+
+def test_print(target):
+    hcl.init()
+    A = hcl.placeholder((10, 32))
+    def kernel(A):
+        hcl.print(A[0])
+        return hcl.compute(A.shape, lambda *args: A[args])
+    s = hcl.create_schedule([A], kernel)
+    code = hcl.build(s, target=target)
+
+def test_pragma(target, strings, test_partition=True):
+    hcl.init()
+    A = hcl.placeholder((10, 32), "A")
+    B = hcl.placeholder((10, 32))
+    C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j])
+    # unroll
+    s1 = hcl.create_schedule([A, B, C])
+    s1[C].unroll(C.axis[1], factor=4)
+    code1 = hcl.build(s1, target=target)
+    assert strings[0] in code1
+    # pipeline
+    s2 = hcl.create_schedule([A, B, C])
+    s2[C].pipeline(C.axis[0], initiation_interval=2)
+    code2 = hcl.build(s2, target=target)
+    assert strings[1] in code2
+    if test_partition:
+        # partition
+        s3 = hcl.create_schedule([A, B, C])
+        s3.partition(A, hcl.Partition.Block, dim=2, factor=2)
+        code3 = hcl.build(s3, target=target)
+        assert strings[2] in code3
+
+def test_set_bit(target, string):
+    hcl.init()
+    A = hcl.placeholder((10,), "A")
+    def kernel(A):
+        with hcl.Stage("S"):
+            A[0][4] = 1
+    s = hcl.create_schedule([A], kernel)
+    code = hcl.build(s, target=target)
+    assert string in code
+
+def test_set_slice(target, string):
+    hcl.init()
+    A = hcl.placeholder((10,), "A")
+    def kernel(A):
+        with hcl.Stage("S"):
+            A[0][5:1] = 1
+    s = hcl.create_schedule([A], kernel)
+    code = hcl.build(s, target=target)
+    assert string in code
+

--- a/tests/test_codegen_aocl.py
+++ b/tests/test_codegen_aocl.py
@@ -1,33 +1,19 @@
 import heterocl as hcl
+import tests.__test_codegen_harness as harness
 
-def test_ap_int():
-	hcl.init();
-	A = hcl.placeholder((1, 32), dtype=hcl.Int(3))
-	B = hcl.placeholder((1, 32), dtype=hcl.UInt(3))
-	C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j], dtype=hcl.Int(8))
-	s = hcl.create_schedule([A, B, C])
-	code = hcl.build(s, target='aocl')
-	assert "ap_int<3>" in code
-	assert "ap_uint<3>" in code
-	assert "int8" in code 
+target="aocl"
+
+def test_dtype():
+    harness.test_dtype(target, ["ap_int<3>", "ap_uint<3>", "int8"], False)
+
+def test_print():
+    harness.test_print(target)
 
 def test_pragma():
-	hcl.init()
-	A = hcl.placeholder((10, 32), "A")
-	B = hcl.placeholder((10, 32))
-	C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j])
-
-	# unroll
-	s1 = hcl.create_schedule([A, B, C])
-	s1[C].unroll(C.axis[1], factor=4)
-	code1 = hcl.build(s1, target='aocl')
-	assert "#pragma unroll 4" in code1
-	
-	# pipeline
-	s2 = hcl.create_schedule([A, B, C])
-	s2[C].pipeline(C.axis[0], initiation_interval=2)
-	code2 = hcl.build(s2, target='aocl')
-	assert "#pragma ii 2" in code2
+    harness.test_pragma(target,
+                        ["#pragma unroll 4",
+                         "#pragma ii 2"],
+                        False)
 
 def test_reorder():
 	hcl.init()
@@ -86,5 +72,3 @@ if __name__ == '__main__':
     test_reorder()
     test_split_fuse()
     test_binary_conv()
-
-

--- a/tests/test_codegen_ihls.py
+++ b/tests/test_codegen_ihls.py
@@ -1,60 +1,30 @@
 import heterocl as hcl
+import tests.__test_codegen_harness as harness
 
-def test_ac_int():
-    hcl.init()
-    A = hcl.placeholder((1, 32), dtype=hcl.Int(3))
-    B = hcl.placeholder((1, 32), dtype=hcl.UInt(3))
-    C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j], dtype=hcl.Int(8))
-    s = hcl.create_schedule([A, B, C])
-    code = hcl.build(s, target='ihls')
-    assert "ac_int<3, true>" in code
-    assert "ac_int<3, false>" in code
-    assert "ac_int<8, true>" in code
+target="ihls"
 
-def test_ac_fixed():
-    hcl.init()
-    A = hcl.placeholder((1, 32), dtype=hcl.Fixed(5, 3))
-    B = hcl.placeholder((1, 32), dtype=hcl.UFixed(5, 3))
-    C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j], dtype=hcl.Fixed(7, 4))
-    s = hcl.create_schedule([A, B, C])
-    code = hcl.build(s, target='ihls')
-    assert "ac_fixed<5, 2, true>" in code
-    assert "ac_fixed<5, 2, false>" in code
-    assert "ac_fixed<7, 3, true>" in code
+def test_dtype():
+    harness.test_dtype(target, ["ac_int<3, true>",
+                                "ac_int<3, false>",
+                                "ac_int<8, true>",
+                                "ac_fixed<5, 2, true>",
+                                "ac_fixed<5, 2, false>",
+                                "ac_fixed<7, 3, true>"])
+
+def test_print():
+    harness.test_print(target)
 
 def test_pragma():
-    hcl.init()
-    A = hcl.placeholder((10, 32), "A")
-    B = hcl.placeholder((10, 32))
-    C = hcl.compute(A.shape, lambda i, j: A[i][j] + B[i][j])
-    # unroll
-    s1 = hcl.create_schedule([A, B, C])
-    s1[C].unroll(C.axis[1], factor=4)
-    code1 = hcl.build(s1, target='ihls')
-    assert "#pragma unroll 4" in code1
-    # pipeline
-    s2 = hcl.create_schedule([A, B, C])
-    s2[C].pipeline(C.axis[0], initiation_interval=2)
-    code2 = hcl.build(s2, target='ihls')
-    assert "#pragma ii 2" in code2
+    harness.test_pragma(target,
+                        ["#pragma unroll 4",
+                         "#pragma ii 2"],
+                        False)
 
 def test_set_bit():
-    A = hcl.placeholder((10,), "A")
-    def kernel(A):
-        with hcl.Stage("S"):
-            A[0][4] = 1
-    s = hcl.create_schedule([A], kernel)
-    code = hcl.build(s, target="ihls")
-    assert "A[0][4] = 1" in code
+    harness.test_set_bit(target, "A[0][4] = 1")
 
 def test_set_slice():
-    A = hcl.placeholder((10,), "A")
-    def kernel(A):
-        with hcl.Stage("S"):
-            A[0][5:1] = 1
-    s = hcl.create_schedule([A], kernel)
-    code = hcl.build(s, target="ihls")
-    assert "A[0].set_slc(1, ((ac_int<4, false>)1))" in code
+    harness.test_set_slice(target, "A[0].set_slc(1, ((ac_int<4, false>)1))")
 
 def test_get_slice():
 

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -26,6 +26,15 @@ def test_dtype():
     test_ap_int()
     test_ap_fixed()
 
+def test_print():
+    hcl.init()
+    A = hcl.placeholder((10, 32))
+    def kernel(A):
+        hcl.print(A[0])
+        return hcl.compute(A.shape, lambda *args: A[args])
+    s = hcl.create_schedule([A], kernel)
+    code = hcl.build(s, target='vhls')
+
 def test_pragma():
     hcl.init()
     A = hcl.placeholder((10, 32), "A")
@@ -139,7 +148,7 @@ def test_select_type_cast():
     def test_imm_ops():
         A = hcl.placeholder((10, 10), "A")
         def kernel(A):
-            return hcl.compute((8, 8), lambda y, x: 
+            return hcl.compute((8, 8), lambda y, x:
                 hcl.select(x < 4, A[y][x] + A[y+2][x+2], 0), "B")
         s = hcl.create_scheme(A, kernel)
         s = hcl.create_schedule_from_scheme(s)
@@ -150,7 +159,7 @@ def test_select_type_cast():
     def test_uint_imm_ops():
         A = hcl.placeholder((10, 10), "A", dtype=hcl.UInt(1))
         def kernel(A):
-            return hcl.compute((8, 8), lambda y, x: 
+            return hcl.compute((8, 8), lambda y, x:
                 hcl.select(x < 4, A[y][x], 0), "B")
         s = hcl.create_scheme(A, kernel)
         s = hcl.create_schedule_from_scheme(s)
@@ -161,7 +170,7 @@ def test_select_type_cast():
         A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))
         B = hcl.placeholder((8, 8), "B", dtype=hcl.Fixed(16,12))
         def kernel(A, B):
-            return hcl.compute((8, 8), lambda y, x: 
+            return hcl.compute((8, 8), lambda y, x:
                 hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
         s = hcl.create_scheme([A, B], kernel)
         s = hcl.create_schedule_from_scheme(s)
@@ -172,7 +181,7 @@ def test_select_type_cast():
         A = hcl.placeholder((8, 8), "A", dtype=hcl.Fixed(20,12))
         B = hcl.placeholder((8, 8), "B", dtype=hcl.UFixed(16,12))
         def kernel(A, B):
-            return hcl.compute((8, 8), lambda y, x: 
+            return hcl.compute((8, 8), lambda y, x:
                 hcl.select(x < 4, A[y][x], B[y][x]), "C", dtype=hcl.Int(8))
         s = hcl.create_scheme([A, B], kernel)
         s = hcl.create_schedule_from_scheme(s)

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -1375,6 +1375,8 @@ void CodeGenC::VisitStmt_(const While* op) {
 
 void CodeGenC::VisitStmt_(const Partition* op) {}
 
+void CodeGenC::VisitStmt_(const Print* op) {}
+
 void CodeGenC::SaveFuncState(LoweredFunc f) {
   // clear save info copy
   alloc_set_save.clear();

--- a/tvm/src/codegen/codegen_c.h
+++ b/tvm/src/codegen/codegen_c.h
@@ -153,6 +153,7 @@ class CodeGenC : public ExprFunctor<void(const Expr&, std::ostream&)>,
   void VisitStmt_(const Break* op) override;
   void VisitStmt_(const While* op) override;
   void VisitStmt_(const Partition* op) override;
+  void VisitStmt_(const Print* op) override;
   /*!
    * Print Type represetnation of type t.
    * \param t The type representation.

--- a/tvm/src/codegen/merlinc/codeanalys_merlinc.cc
+++ b/tvm/src/codegen/merlinc/codeanalys_merlinc.cc
@@ -975,5 +975,7 @@ void CodeAnalysMerlinC::VisitStmt_(const StreamStmt* op) {}
 
 void CodeAnalysMerlinC::VisitStmt_(const Stencil* op) { PrintStmt(op->body); }
 
+void CodeAnalysMerlinC::VisitStmt_(const Print* op) {}
+
 }  // namespace codegen
 }  // namespace TVM

--- a/tvm/src/codegen/merlinc/codeanalys_merlinc.h
+++ b/tvm/src/codegen/merlinc/codeanalys_merlinc.h
@@ -133,6 +133,7 @@ class CodeAnalysMerlinC : public ExprFunctor<void(const Expr&, std::ostream&)>,
   void VisitStmt_(const Partition* op) override;
   void VisitStmt_(const Stencil* op) override;
   void VisitStmt_(const StreamStmt* op) override;
+  void VisitStmt_(const Print* op) override;
   /*!
    * Print Type represetnation of type t.
    * \param t The type representation.


### PR DESCRIPTION
This PR does two things.

1. Add a default method for `Print` stmt in codegen. For now, we simply skip the stmt. In the future, we can customize the print messages for each backend.
2. Restructure the codegen tests. Extract common test patterns into `__test_codegen_harness.py`.