### PR TITLE
[Runtime] Improve HCL runtime system 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,10 @@ project-*
 python/heterocl/harness/include/
 MANIFEST.in
 .Xil
-build_dir.*.xilinx
+build_dir.*
+_x.*
+rapidjson
+inputs.json
+*.err
+*.out
+reports

--- a/hlib/tests/test_extern_ip.py
+++ b/hlib/tests/test_extern_ip.py
@@ -49,7 +49,7 @@ def test_vector_add():
             ret = hlib.ip.vadd(A, B, length, name="ret")
             return hcl.compute(A.shape, lambda *args: ret[args] * 2, "out")
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         target.config(compile="vitis", mode="debug")
         s = hcl.create_schedule([A, B], math_func)
         s.to([A, B, math_func.ret], target.xcel)
@@ -114,7 +114,7 @@ def test_fft_hls():
                     hcl.sqrt(real[x] * real[x] + imag[x] * imag[x]), name="abs")
 
         s = hcl.create_schedule([X_real, X_imag], math_func)
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         target.config(compile="vitis", mode="debug")
 
         s.to([X_real, X_imag, math_func.F_real, math_func.F_imag], target.xcel)
@@ -172,7 +172,7 @@ def test_byte_swap_rtl():
             return hcl.compute(input_vec.shape, lambda *args: new_vec[args] + 1, name="ret")
 
         s = hcl.create_schedule([input_vec], math_func)
-        target = hcl.platform.vlab
+        target = hcl.Platform.vlab
         target.config(compile="aocl", mode="debug")
 
         s.to(input_vec, target.xcel)

--- a/python/heterocl/__init__.py
+++ b/python/heterocl/__init__.py
@@ -4,6 +4,7 @@ from .compute_api import *
 from .dsl import *
 from .types import *
 from .devices import *
+from .platforms import *
 from .nparray import *
 from .debug import hcl_excepthook
 from .tvm.intrin import *

--- a/python/heterocl/autosa.py
+++ b/python/heterocl/autosa.py
@@ -1,0 +1,24 @@
+import re
+
+# reinterpret cast orginal pointers to target type
+def autosa_infer_types(header, ret_code):
+    assert header.find("autosa_func") > 0
+    outer = re.compile("autosa_func\((.*?)\)")
+    m = outer.search(header)
+    inner_str = m.group(1)
+
+    # find inner pairs
+    target_dtype = dict()
+    pairs = inner_str.split(", ")
+    for pair in pairs:
+        _ = pair.split(" *")
+        dtype, tensor = _
+        target_dtype[tensor] = dtype
+    
+    # replace the original pointers
+    new_ret_code = ret_code
+    for k, v in target_dtype.items():
+        new_ret_code = new_ret_code.\
+            replace("buffer_{}[0]".format(k), \
+            "reinterpret_cast<{}*>({})".format(v, k))
+    return new_ret_code

--- a/python/heterocl/devices.py
+++ b/python/heterocl/devices.py
@@ -254,6 +254,7 @@ class Platform(object):
         self.to_codegen = False
         self.to_compile = False
         self.to_execute = False
+        self.execute_arguments = dict()
 
         if isinstance(host, CPU):
             self.cpu = host
@@ -376,6 +377,12 @@ class Platform(object):
     
     def copy_utility(self, path):
         raise HCLError("Platform.copy_utility() undefined")
+
+    def compile(self, *args, **kwargs):
+        raise HCLError("Platform.compile() undefined")
+
+    def execute(self, *args, **kwargs):
+        raise HCLError("Platform.execute() undefined")
 
 class dev(object):
     def __init__(self, types, vendor, model):

--- a/python/heterocl/devices.py
+++ b/python/heterocl/devices.py
@@ -254,6 +254,7 @@ class Platform(object):
         self.to_codegen = False
         self.to_compile = False
         self.to_execute = False
+        self.execute_status = False
         self.execute_arguments = dict()
 
         if isinstance(host, CPU):

--- a/python/heterocl/devices.py
+++ b/python/heterocl/devices.py
@@ -251,10 +251,10 @@ dev_table = {
 }
 
 class env(type):
-    """The platform class for compute environment setups
+    """The Platform class for compute environment setups
     
      serves as meta-class for attr getting
-     default platform: aws_f1, zynq, ppac
+     default Platform: aws_f1, zynq, ppac
 
     Parameters
     ----------
@@ -289,12 +289,14 @@ class env(type):
         tool = tool_table[key]
         return cls(key, devs, host, xcel, tool)
 
+# Save the (static) project information
+# This information will be updated and used in runtime
 class Project():
     project_name = "project"
     path = "project"
+    platfrom = None
     
-class platform(with_metaclass(env, object)):
-
+class Platform(with_metaclass(env, object)):
     def __init__(self, name, devs, host, xcel, tool):
         self.name = name
         self.devs = devs

--- a/python/heterocl/platforms.py
+++ b/python/heterocl/platforms.py
@@ -1,10 +1,38 @@
-import os, subprocess
+import os, subprocess, json
 from .devices import Platform, dev_table, tool_table
+from os.path import expanduser
+
+# Save information to HOME
+def save_cache_info(fname, key, value):
+    path = os.path.join(expanduser("~"), ".hcl")
+    if not os.path.exists(path):
+        os.mkdir(path)
+    path = os.path.join(path, fname)
+    with open(path) as fp:
+        data = json.load(fp)
+        data.update({key: value})
+        json.dump(data, fp)
+
+def get_cache_info(fname, key):
+    path = os.path.join(expanduser("~"), ".hcl")
+    path = os.path.join(path, fname)
+    assert os.path.exists(path)
+    with open(path) as fp:    
+        data = json.load(fp)
+        try:
+            return data[key]
+        except:
+            return None
+
+def clean_cache(fname):
+    path = os.path.join(expanduser("~"), ".hcl")
+    path = os.path.join(path, fname)
+    os.remove(path)
 
 def run_shell_script(command):
     with open("temp.sh", "w") as fp:
         fp.write(command)
-    ret = subprocess.run(['sh', 'temp.sh'], 
+    ret = subprocess.run(command, 
         stdout=subprocess.PIPE, check=True, shell=True)
     return ret.stdout.decode('utf-8')
 
@@ -32,20 +60,50 @@ class AWS_F1(Platform):
         pass
 
     def create_instance(self, aws_key, instance):
-        command = "aws ec2 run-instances --image-id {} \
-            --security-group-ids sg-08111c9462c75f193 \
-            --block-device-mapping DeviceName=/dev/sda1,Ebs={VolumeSize=100} \
-            --instance-type {} --key-name {};".format(self.AMI_ID, instance, aws_key)
-        out = run_shell_script(command)
+        instance_id = get_cache_info("aws.json", "instance_id")
+        if instance_id is None:
+            command = "aws ec2 run-instances --image-id {} \
+                --security-group-ids sg-08111c9462c75f193 \
+                --block-device-mapping DeviceName=/dev/sda1,Ebs={{VolumeSize=100}} \
+                --instance-type {} --key-name {};".format(self.AMI_ID, instance, aws_key)
+            out = run_shell_script(command)
+            ret = json.loads(out)
+            instance_id = ret["Instances"][0]["InstanceId"]
+            save_cache_info("aws.json", "instance_id", instance_id)
+        return instance_id
+    
+    def get_ip_addr(instance_id):
+        command = "aws ec2 describe-instances --instance-ids {} \
+            --query 'Reservations[0].Instances[0].PublicIpAddress' | sed 's/\"//g'".format(instance_id)
+        ip_addr = run_shell_script(command)
+        save_cache_info("aws.json", "ip_addr", ip_addr)
+        return ip_addr
 
     # Used for bitstream compiling (if remote is true, 
     # then we compile on remote AWS machines)
     def compile(self, remote=False, aws_key_path=None, instance="t2.micro"):
+        # Generate project and utility files
+
+        sys.exit()
         if remote:
             assert os.path.exists(aws_key_path)
-            aws_key = None
+            aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
+
+            # Create instances
+            instance_id = self.create_instance(aws_key, instance)
+            ip_addr = self.get_ip_addr(instance_id)
+
+            # Upload to S3
+            self.upload()
+
+        else:
+            # Compile locally
+            self.tool.compile()
     
     def download(self):
+        pass
+    
+    def delete_instance(self):
         pass
 
 class ZC706(Platform):

--- a/python/heterocl/platforms.py
+++ b/python/heterocl/platforms.py
@@ -1,6 +1,15 @@
-import os, subprocess, json
-from .devices import Platform, dev_table, tool_table
+import os, subprocess, json, time
+from .devices import Platform, CPU, FPGA, PIM, Project
+from .tools import *
 from os.path import expanduser
+
+dev_table = {
+  "aws_f1"       : [CPU("intel", "e5"), FPGA("xilinx", "xcvu19p")],
+  "vlab"         : [CPU("intel", "e5"), FPGA("intel", "arria10")],
+  "zc706"        : [CPU("arm", "a9"), FPGA("xilinx", "xc7z045")],
+  "rocc-ppac"    : [CPU("riscv", "riscv"), PIM("ppac", "ppac")],
+  "stratix10_sx" : [CPU("arm", "a53"), FPGA("intel", "stratix10_gx")]
+}
 
 # Save information to HOME
 def save_cache_info(fname, key, value):
@@ -8,21 +17,27 @@ def save_cache_info(fname, key, value):
     if not os.path.exists(path):
         os.mkdir(path)
     path = os.path.join(path, fname)
-    with open(path) as fp:
+    if not os.path.isfile(path):
+        with open(path, 'w') as f:
+            json.dump({}, f)
+    with open(path, 'r+') as fp:
         data = json.load(fp)
+        fp.seek(0)
+        fp.truncate()
         data.update({key: value})
         json.dump(data, fp)
+
 
 def get_cache_info(fname, key):
     path = os.path.join(expanduser("~"), ".hcl")
     path = os.path.join(path, fname)
-    assert os.path.exists(path)
-    with open(path) as fp:    
-        data = json.load(fp)
-        try:
+    try:
+        assert os.path.exists(path)
+        with open(path) as fp:    
+            data = json.load(fp)
             return data[key]
-        except:
-            return None
+    except:
+        return None
 
 def clean_cache(fname):
     path = os.path.join(expanduser("~"), ".hcl")
@@ -36,6 +51,18 @@ def run_shell_script(command):
         stdout=subprocess.PIPE, check=True, shell=True)
     return ret.stdout.decode('utf-8')
 
+
+def run_shell_remote(command, inputs, ssh):
+    command = command.format(**inputs)
+    with open("run.sh", "w") as fp:
+        fp.write(command)
+    command = "{} 'bash -s' < run.sh".format(ssh)
+    ret = subprocess.run(command, 
+        stdout=subprocess.PIPE, check=True, shell=True)
+    os.remove("run.sh")
+    return ret.stdout.decode('utf-8')
+
+
 # define some built-in platforms in HCL
 class AWS_F1(Platform):
     def __init__(self):
@@ -43,21 +70,24 @@ class AWS_F1(Platform):
         devs = dev_table[name]
         host = devs[0].set_lang("xocl")
         xcel = devs[1].set_lang("vhls")
-        tool = tool_table[name]
+        tool = Tool.vitis
         self.AMI_ID = "ami-0a7b98fdb062be15f"
         super(AWS_F1, self).__init__(name, devs, host, xcel, tool)
-    
-    # check if the bitstream compiled before + clean up
-    def initialize(self, dev_hash, path):
-        pass
+
+    # copt tool specific utility files
+    def copy_utility(self, path, source):
+        self.tool.copy_utility(path, source)
 
     # upload the work project to AWS
-    def upload(self):
-        pass
-
-    # register AFI image
-    def register(self):
-        pass
+    def upload(self, work_path, project_name):
+        base = "test-hcl-" + os.getlogin()
+        command = "aws s3 rm s3://{base}/{project_name}; \
+            aws s3 mb s3://{base}/{project_name}; \
+            aws s3 cp --recursive {work_path} s3://{base}/{project_name}/".\
+                format(project_name=project_name, 
+                    work_path=work_path, base=base)
+        save_cache_info("aws.json", "s3", project_name)
+        run_shell_script(command)
 
     def create_instance(self, aws_key, instance):
         instance_id = get_cache_info("aws.json", "instance_id")
@@ -72,36 +102,100 @@ class AWS_F1(Platform):
             save_cache_info("aws.json", "instance_id", instance_id)
         return instance_id
     
-    def get_ip_addr(instance_id):
+    def get_ip_addr(self, instance_id):
         command = "aws ec2 describe-instances --instance-ids {} \
             --query 'Reservations[0].Instances[0].PublicIpAddress' | sed 's/\"//g'".format(instance_id)
-        ip_addr = run_shell_script(command)
+        ip_addr = run_shell_script(command).replace('\n','')
         save_cache_info("aws.json", "ip_addr", ip_addr)
         return ip_addr
+    
+    # Pull back aws-fpga and run syn
+    def remote_compile(self, ip_addr, project_name):
+        key_path = get_cache_info("aws.json", "key_path")
+        base = "test-hcl-" + os.getlogin()
+        inputs = {
+            "key_path": key_path,
+            "ip_addr" : ip_addr,
+            "project_name": project_name,
+            "base": base
+        }
+        ssh = "ssh -i {key_path} centos@{ip_addr} ".format(**inputs)
+        print("[{}] Log in with {}".format(time.strftime("%H:%M:%S", time.gmtime()), ssh))
+
+        command = "ssh -i {key_path} -o \"StrictHostKeyChecking no\" \
+            centos@{ip_addr} uptime".format(**inputs)
+        run_shell_script(command)
+        command = "scp -i {key_path} -r ~/.aws centos@{ip_addr}:~".format(**inputs)
+        run_shell_script(command)
+                
+        # clone aws-fpga to HOME
+        command = """
+cd ~; 
+if [ ! -d "aws-fpga" ]; then
+    git clone https://github.com/aws/aws-fpga.git;
+    echo "source $HOME/aws-fpga/vitis_setup.sh" >> ~/.bashrc
+    echo "source $HOME/aws-fpga/vitis_runtime_setup.sh" >> ~/.bashrc
+fi
+"""
+        print("[ INFO ] Initializing AWS environment...")
+        run_shell_remote(command, inputs, ssh)
+
+        command = """
+cd ~; 
+if [ ! -d "{project_name}" ]; then
+    mkdir {project_name}; 
+    aws s3 cp --recursive s3://{base}/{project_name} {project_name}; 
+fi
+cd {project_name}; 
+make all TARGET=hw DEVICE=$AWS_PLATFORM
+"""
+        run_shell_remote(command, inputs, ssh)
+        save_cache_info("aws.json", "status", "running")
+
+        # Register the AFI image
+        command = """
+cd ~/{project_name};
+cp build_dir.hw.*/kernel.xclbin .
+if [ ! -f *afi_id.txt ]; then
+    aws s3 rm s3://{base}/{project_name}/afi
+    aws s3 mb s3://{base}/{project_name}/afi
+    $VITIS_DIR/tools/create_vitis_afi.sh -xclbin=kernel.xclbin \
+        -s3_bucket=hcl-test-afi -s3_dcp_key=$TARGET
+    aws s3 cp host s3://{base}/{project_name}/
+    aws s3 cp kernel.awsxclbin s3://{base}/{project_name}/
+fi
+AFI_ID=$(cat *afi_id.txt | grep -Eo '(afi-.+)' | sed 's/",//g')
+aws ec2 describe-fpga-images --fpga-image-ids $AFI_ID
+"""
 
     # Used for bitstream compiling (if remote is true, 
     # then we compile on remote AWS machines)
-    def compile(self, remote=False, aws_key_path=None, instance="t2.micro"):
-        # Generate project and utility files
-
-        sys.exit()
+    def compile(self, args, remote=False, aws_key_path=None, instance="t2.micro"):
+        work_path = Project.path
+        project_name = Project.project_name
         if remote:
             assert os.path.exists(aws_key_path)
+            save_cache_info("aws.json", "key_path", aws_key_path)
             aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
 
             # Create instances
             instance_id = self.create_instance(aws_key, instance)
             ip_addr = self.get_ip_addr(instance_id)
 
-            # Upload to S3
-            self.upload()
+            # Upload to S3 bucket
+            if get_cache_info("aws.json", "status") is None:
+                self.upload(work_path, project_name)
+                print("[ INFO ] Uploaded source code to AWS S3. Start compiling")
+                # Do we want to make this compilation running background?
+                self.remote_compile(ip_addr, project_name)
+                
+            else:
+                print("[ INFO ] Compilation running on AWS. Check status with \
+                    ssh -i {} centos@{}...".format(aws_key_path, ip_addr))
 
         else:
-            # Compile locally
-            self.tool.compile()
-    
-    def download(self):
-        pass
+            # Compile locally using the same tool chain
+            self.tool.compile(work_path)
     
     def delete_instance(self):
         pass
@@ -112,7 +206,7 @@ class ZC706(Platform):
         devs = dev_table[name]
         host = devs[0].set_lang("vhls")
         xcel = devs[1].set_lang("vhls")
-        tool = tool_table[name]
+        tool = Tool.vivado_hls
         super(ZC706, self).__init__(name, devs, host, xcel, tool)
 
 class VLAB(Platform):
@@ -121,7 +215,7 @@ class VLAB(Platform):
         devs = dev_table[name]
         host = devs[0].set_lang("aocl")
         xcel = devs[1].set_lang("aocl")
-        tool = tool_table[name]
+        tool = Tool.aocl
         super(VLAB, self).__init__(name, devs, host, xcel, tool)
     
     # Used for bitstream compiling (if remote is true, 

--- a/python/heterocl/platforms.py
+++ b/python/heterocl/platforms.py
@@ -3,13 +3,6 @@ from .devices import Platform, CPU, FPGA, PIM, Project
 from .tools import *
 from os.path import expanduser
 
-dev_table = {
-  "aws_f1"       : [CPU("intel", "e5"), FPGA("xilinx", "xcvu19p")],
-  "vlab"         : [CPU("intel", "e5"), FPGA("intel", "arria10")],
-  "zc706"        : [CPU("arm", "a9"), FPGA("xilinx", "xc7z045")],
-  "rocc-ppac"    : [CPU("riscv", "riscv"), PIM("ppac", "ppac")],
-  "stratix10_sx" : [CPU("arm", "a53"), FPGA("intel", "stratix10_gx")]
-}
 
 # Save information to HOME
 def save_cache_info(fname, key, value):
@@ -39,10 +32,12 @@ def get_cache_info(fname, key):
     except:
         return None
 
+
 def clean_cache(fname):
     path = os.path.join(expanduser("~"), ".hcl")
     path = os.path.join(path, fname)
     os.remove(path)
+
 
 def run_shell_script(command):
     with open("temp.sh", "w") as fp:
@@ -67,12 +62,20 @@ def run_shell_remote(command, inputs, ssh):
 class AWS_F1(Platform):
     def __init__(self):
         name = "aws_f1"
-        devs = dev_table[name]
+        devs = [
+            CPU("intel", "e5"), 
+            FPGA("xilinx", "xcvu19p")
+            ]
         host = devs[0].set_lang("xocl")
         xcel = devs[1].set_lang("vhls")
         tool = Tool.vitis
+
         self.AMI_ID = "ami-0a7b98fdb062be15f"
+        self.XPFM = "xilinx_aws-vu9p-f1_shell-v04261818_201920_2.xpfm"
         super(AWS_F1, self).__init__(name, devs, host, xcel, tool)
+
+        self.cache = None
+        self.tool = tool
 
     # copt tool specific utility files
     def copy_utility(self, path, source):
@@ -86,11 +89,11 @@ class AWS_F1(Platform):
             aws s3 cp --recursive {work_path} s3://{base}/{project_name}/".\
                 format(project_name=project_name, 
                     work_path=work_path, base=base)
-        save_cache_info("aws.json", "s3", project_name)
+        save_cache_info(self.cache, "s3", project_name)
         run_shell_script(command)
 
     def create_instance(self, aws_key, instance):
-        instance_id = get_cache_info("aws.json", "instance_id")
+        instance_id = get_cache_info(self.cache, "instance_id")
         if instance_id is None:
             command = "aws ec2 run-instances --image-id {} \
                 --security-group-ids sg-08111c9462c75f193 \
@@ -99,28 +102,38 @@ class AWS_F1(Platform):
             out = run_shell_script(command)
             ret = json.loads(out)
             instance_id = ret["Instances"][0]["InstanceId"]
-            save_cache_info("aws.json", "instance_id", instance_id)
+            save_cache_info(self.cache, "instance_id", instance_id)
         return instance_id
     
     def get_ip_addr(self, instance_id):
         command = "aws ec2 describe-instances --instance-ids {} \
             --query 'Reservations[0].Instances[0].PublicIpAddress' | sed 's/\"//g'".format(instance_id)
         ip_addr = run_shell_script(command).replace('\n','')
-        save_cache_info("aws.json", "ip_addr", ip_addr)
+        save_cache_info(self.cache, "ip_addr", ip_addr)
         return ip_addr
     
     # Pull back aws-fpga and run syn
     def remote_compile(self, ip_addr, project_name):
-        key_path = get_cache_info("aws.json", "key_path")
+        key_path = get_cache_info(self.cache, "key_path")
         base = "test-hcl-" + os.getlogin()
+
+        # Get compilation mode
+        mode = self.tool.mode
+        if mode == "hw_exe": tool_mode = "hw"
+        elif mode == "sw_sim": tool_mode = "sw_emu"
+        elif mode == "hw_sim": tool_mode = "hw_emu"
+
         inputs = {
             "key_path": key_path,
             "ip_addr" : ip_addr,
             "project_name": project_name,
-            "base": base
+            "base": base,
+            "tool_mode": tool_mode
         }
         ssh = "ssh -i {key_path} centos@{ip_addr} ".format(**inputs)
-        print("[{}] Log in with {}".format(time.strftime("%H:%M:%S", time.gmtime()), ssh))
+        curr_time = time.strftime("%H:%M:%S", time.gmtime())
+        print("[{}] Log in with {}".format(curr_time, ssh))
+        print("[{}] Mode ({}). Project name ({})".format(mode, project_name))
 
         command = "ssh -i {key_path} -o \"StrictHostKeyChecking no\" \
             centos@{ip_addr} uptime".format(**inputs)
@@ -147,10 +160,10 @@ if [ ! -d "{project_name}" ]; then
     aws s3 cp --recursive s3://{base}/{project_name} {project_name}; 
 fi
 cd {project_name}; 
-make all TARGET=hw DEVICE=$AWS_PLATFORM
+make all TARGET={tool_mode} DEVICE=$AWS_PLATFORM
 """
         run_shell_remote(command, inputs, ssh)
-        save_cache_info("aws.json", "status", "running")
+        save_cache_info(self.cache, "status", "finished")
 
         # Register the AFI image
         command = """
@@ -166,16 +179,25 @@ if [ ! -f *afi_id.txt ]; then
 fi
 AFI_ID=$(cat *afi_id.txt | grep -Eo '(afi-.+)' | sed 's/",//g')
 aws ec2 describe-fpga-images --fpga-image-ids $AFI_ID
+echo $AFI_ID
 """
+        out = run_shell_remote(command, inputs, ssh)
+        print(out)
+        afi_id = out.split("\n")[-1]
+        save_cache_info(self.cache, "status", "registering")
+        save_cache_info(self.cache, "afi_id", afi_id)
 
     # Used for bitstream compiling (if remote is true, 
     # then we compile on remote AWS machines)
-    def compile(self, args, remote=False, aws_key_path=None, instance="t2.micro"):
+    def compile(self, args, remote=False, 
+            aws_key_path=None, instance="t2.micro", xpfm=None):
+
         work_path = Project.path
         project_name = Project.project_name
+        self.cache = "{}-aws.json".format(project_name)
         if remote:
             assert os.path.exists(aws_key_path)
-            save_cache_info("aws.json", "key_path", aws_key_path)
+            save_cache_info(self.cache, "key_path", aws_key_path)
             aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
 
             # Create instances
@@ -183,7 +205,8 @@ aws ec2 describe-fpga-images --fpga-image-ids $AFI_ID
             ip_addr = self.get_ip_addr(instance_id)
 
             # Upload to S3 bucket
-            if get_cache_info("aws.json", "status") is None:
+            status = get_cache_info(self.cache, "status")
+            if status is None:
                 self.upload(work_path, project_name)
                 print("[ INFO ] Uploaded source code to AWS S3. Start compiling")
                 # Do we want to make this compilation running background?
@@ -195,7 +218,43 @@ aws ec2 describe-fpga-images --fpga-image-ids $AFI_ID
 
         else:
             # Compile locally using the same tool chain
-            self.tool.compile(work_path)
+            if xpfm is not None:
+                self.XPFM = xpfm
+            self.tool.compile(work_path, self.XPFM)
+    
+    def wait_afi_register(self):
+        afi_id = get_cache_info(self.cache, "afi_id")
+        command = "aws ec2 describe-fpga-images --fpga-image-ids {}".format(afi_id)
+        out = run_shell_script(command)
+        print(out); sys.exit()
+
+    # Execute the program and fetch JSON
+    def execute(self, work_path, mode, remote=False, 
+            aws_key_path=None, instance="f1.2xlarge"):
+
+        if remote:
+            aws_key_path = get_cache_info(self.cache, "key_path")
+            assert aws_key_path is not None
+            aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
+
+            # Run the host program
+            mode = self.tool.mode         
+            if mode == "hw_exe":
+                run_cmd = "./host kernel.xclbin"
+            elif mode == "sw_sim":
+                run_cmd = "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
+            elif mode == "hw_sim":
+                run_cmd = "XCL_EMULATION_MODE=hw_emu ./host kernel.xclbin"
+
+            # Check if the AFI image is registered
+            if mode == "hw_exe":
+                while self.wait_afi_register():
+                    sleep(10 * 60)
+                
+                # Create F1 instance and start running  
+        else:
+            pass
+
     
     def delete_instance(self):
         pass
@@ -203,7 +262,10 @@ aws ec2 describe-fpga-images --fpga-image-ids $AFI_ID
 class ZC706(Platform):
     def __init__(self):
         name = "zc706"
-        devs = dev_table[name]
+        devs = [
+            CPU("arm", "a9"), 
+            FPGA("xilinx", "xc7z045")
+        ]
         host = devs[0].set_lang("vhls")
         xcel = devs[1].set_lang("vhls")
         tool = Tool.vivado_hls
@@ -212,7 +274,10 @@ class ZC706(Platform):
 class VLAB(Platform):
     def __init__(self):
         name = "vlab"
-        devs = dev_table[name]
+        devs = [
+            CPU("intel", "e5"), 
+            FPGA("intel", "arria10")
+            ]
         host = devs[0].set_lang("aocl")
         xcel = devs[1].set_lang("aocl")
         tool = Tool.aocl
@@ -223,6 +288,38 @@ class VLAB(Platform):
     def compile(self, remote=False):
         pass
 
+class U280(Platform):
+    def __init__(self):
+        name = "u280"
+        devs = [
+            CPU("intel", "e5"), 
+            FPGA("xilinx", "xcvu19p")
+            ]
+        host = devs[0].set_lang("xocl")
+        xcel = devs[1].set_lang("vhls")
+        tool = Tool.vitis
+
+        self.XFPM = "xilinx_u280_xdma_201920_3.xpfm"
+        super(U280, self).__init__(name, devs, host, xcel, tool)
+
+        self.cache = None
+        self.tool = tool
+
+    # Only support compiling locally
+    def compile(self, args, xpfm=None):
+        if xpfm is not None:
+            self.XFPM = xpfm
+        work_path = Project.path
+        mode = self.tool.mode
+        self.tool.compile(work_path, mode, self.XFPM)
+    
+    def copy_utility(self, path, source):
+        self.tool.copy_utility(path, source)
+        
+    def execute(self, work_path, mode, **kwargs):
+        self.tool.execute(work_path, mode)
+
 Platform.aws_f1 = AWS_F1()
 Platform.zc706  = ZC706()
 Platform.vlab   = VLAB()
+Platform.u280   = U280()

--- a/python/heterocl/platforms.py
+++ b/python/heterocl/platforms.py
@@ -1,0 +1,76 @@
+import os, subprocess
+from .devices import Platform, dev_table, tool_table
+
+def run_shell_script(command):
+    with open("temp.sh", "w") as fp:
+        fp.write(command)
+    ret = subprocess.run(['sh', 'temp.sh'], 
+        stdout=subprocess.PIPE, check=True, shell=True)
+    return ret.stdout.decode('utf-8')
+
+# define some built-in platforms in HCL
+class AWS_F1(Platform):
+    def __init__(self):
+        name = "aws_f1"
+        devs = dev_table[name]
+        host = devs[0].set_lang("xocl")
+        xcel = devs[1].set_lang("vhls")
+        tool = tool_table[name]
+        self.AMI_ID = "ami-0a7b98fdb062be15f"
+        super(AWS_F1, self).__init__(name, devs, host, xcel, tool)
+    
+    # check if the bitstream compiled before + clean up
+    def initialize(self, dev_hash, path):
+        pass
+
+    # upload the work project to AWS
+    def upload(self):
+        pass
+
+    # register AFI image
+    def register(self):
+        pass
+
+    def create_instance(self, aws_key, instance):
+        command = "aws ec2 run-instances --image-id {} \
+            --security-group-ids sg-08111c9462c75f193 \
+            --block-device-mapping DeviceName=/dev/sda1,Ebs={VolumeSize=100} \
+            --instance-type {} --key-name {};".format(self.AMI_ID, instance, aws_key)
+        out = run_shell_script(command)
+
+    # Used for bitstream compiling (if remote is true, 
+    # then we compile on remote AWS machines)
+    def compile(self, remote=False, aws_key_path=None, instance="t2.micro"):
+        if remote:
+            assert os.path.exists(aws_key_path)
+            aws_key = None
+    
+    def download(self):
+        pass
+
+class ZC706(Platform):
+    def __init__(self):
+        name = "zc706"
+        devs = dev_table[name]
+        host = devs[0].set_lang("vhls")
+        xcel = devs[1].set_lang("vhls")
+        tool = tool_table[name]
+        super(ZC706, self).__init__(name, devs, host, xcel, tool)
+
+class VLAB(Platform):
+    def __init__(self):
+        name = "vlab"
+        devs = dev_table[name]
+        host = devs[0].set_lang("aocl")
+        xcel = devs[1].set_lang("aocl")
+        tool = tool_table[name]
+        super(VLAB, self).__init__(name, devs, host, xcel, tool)
+    
+    # Used for bitstream compiling (if remote is true, 
+    # then we compile on remote AWS machines)
+    def compile(self, remote=False):
+        pass
+
+Platform.aws_f1 = AWS_F1()
+Platform.zc706  = ZC706()
+Platform.vlab   = VLAB()

--- a/python/heterocl/platforms.py
+++ b/python/heterocl/platforms.py
@@ -1,8 +1,7 @@
-import os, subprocess, json, time
+import os, subprocess, json, time, sys
 from .devices import Platform, CPU, FPGA, PIM, Project
 from .tools import *
 from os.path import expanduser
-
 
 # Save information to HOME
 def save_cache_info(fname, key, value):
@@ -54,7 +53,7 @@ def run_shell_remote(command, inputs, ssh):
     command = "{} 'bash -s' < run.sh".format(ssh)
     ret = subprocess.run(command, 
         stdout=subprocess.PIPE, check=True, shell=True)
-    os.remove("run.sh")
+    # os.remove("run.sh")
     return ret.stdout.decode('utf-8')
 
 
@@ -103,6 +102,7 @@ class AWS_F1(Platform):
             ret = json.loads(out)
             instance_id = ret["Instances"][0]["InstanceId"]
             save_cache_info(self.cache, "instance_id", instance_id)
+            time.sleep(10)
         return instance_id
     
     def get_ip_addr(self, instance_id):
@@ -131,9 +131,11 @@ class AWS_F1(Platform):
             "tool_mode": tool_mode
         }
         ssh = "ssh -i {key_path} centos@{ip_addr} ".format(**inputs)
+        save_cache_info(self.cache, "ssh", ssh)
+
         curr_time = time.strftime("%H:%M:%S", time.gmtime())
         print("[{}] Log in with {}".format(curr_time, ssh))
-        print("[{}] Mode ({}). Project name ({})".format(mode, project_name))
+        print("[{}] Mode ({}). Project name ({})".format(curr_time, mode, project_name))
 
         command = "ssh -i {key_path} -o \"StrictHostKeyChecking no\" \
             centos@{ip_addr} uptime".format(**inputs)
@@ -146,27 +148,127 @@ class AWS_F1(Platform):
 cd ~; 
 if [ ! -d "aws-fpga" ]; then
     git clone https://github.com/aws/aws-fpga.git;
-    echo "source $HOME/aws-fpga/vitis_setup.sh" >> ~/.bashrc
-    echo "source $HOME/aws-fpga/vitis_runtime_setup.sh" >> ~/.bashrc
 fi
 """
         print("[ INFO ] Initializing AWS environment...")
         run_shell_remote(command, inputs, ssh)
 
+        # Start the compilation (in the background)
         command = """
+source $HOME/aws-fpga/vitis_setup.sh
+source $HOME/aws-fpga/vitis_runtime_setup.sh
 cd ~; 
 if [ ! -d "{project_name}" ]; then
     mkdir {project_name}; 
     aws s3 cp --recursive s3://{base}/{project_name} {project_name}; 
 fi
 cd {project_name}; 
-make all TARGET={tool_mode} DEVICE=$AWS_PLATFORM
+make all TARGET={tool_mode} DEVICE=$AWS_PLATFORM &> output.log &
+echo "$!" > PID.txt
 """
         run_shell_remote(command, inputs, ssh)
-        save_cache_info(self.cache, "status", "finished")
+        save_cache_info(self.cache, "status", "running")
 
+
+    def check_process_liveness(self, ip_addr, project_name):
+        ssh = get_cache_info(self.cache, "ssh")
+        inputs = {"project_name": project_name}
+        command = """
+cd ~/{project_name}; 
+PID=$(cat PID.txt)
+if [ -n "$PID" -a -e /proc/$PID ]; then
+    echo "process exists"
+    ps -p $PID -o etime    
+fi
+"""     
+        out = run_shell_remote(command, inputs, ssh)
+        is_live = False
+        run_time = 0
+        if "process exists" in out:
+            is_live = True
+            run_time = out.split("ELAPSED")[-1].replace("\n", "").lstrip()
+        else:
+            mode = self.tool.mode
+            if mode == "hw_exe": tool_mode = "hw"
+            elif mode == "sw_sim": tool_mode = "sw_emu"
+            elif mode == "hw_sim": tool_mode = "hw_emu"
+            command = """
+cd ~/{project_name};
+cp build_dir.{tool_mode}*/kernel.xclbin .
+"""
+            inputs = {"project_name": project_name, "tool_mode": tool_mode}
+            run_shell_remote(command, inputs, ssh)
+
+        return is_live, run_time
+
+    # Used for bitstream compiling (if remote is true, 
+    # then we compile on remote AWS machines)
+    def compile(self, args, remote=False, 
+            aws_key_path=None, instance="t2.micro", xpfm=None):
+
+        work_path = Project.path
+        project_name = Project.project_name
+        self.cache = "{}-aws.json".format(project_name)
+
+        if remote:
+            assert os.path.exists(aws_key_path)
+            save_cache_info(self.cache, "key_path", aws_key_path)
+            aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
+
+            # Create instances (return IP addr if it is running)
+            instance_id = self.create_instance(aws_key, instance)
+            ip_addr = self.get_ip_addr(instance_id)
+
+            # Upload to S3 bucket if instance does not exists
+            status = get_cache_info(self.cache, "status")
+            if status is None:
+                self.upload(work_path, project_name)
+                print("[  INFO  ] Uploaded source code to AWS S3. Start compiling...")
+                self.remote_compile(ip_addr, project_name)
+                sys.exit()
+
+            elif status == "running":
+                ssh = "ssh -i {} centos@{}".format(aws_key_path, ip_addr)
+                # Check process runtime (PID saved in project folder)
+                is_live, runtime = self.check_process_liveness(ip_addr, project_name)
+
+                if is_live:
+                    print("[  INFO  ] Compiling (Elaspsed {})".format(runtime))
+                    print("[  INFO  ] SSH {}".format(ssh))
+                    sys.exit()
+                
+                else:
+                    mode = self.tool.mode
+                    if mode == "hw_exe": 
+                        # Start AFI registeration
+                        self.register_afi(ip_addr, project_name)
+                        # Waiting for AFI registration
+                        self.wait_afi_register()
+                    else:
+                        print("[  INFO  ] Compilation done. Start Emulation")
+                        save_cache_info(self.cache, "status", "done")
+
+            else:
+                print("[  INFO  ] Compilation running on AWS. Check status with \
+                    ssh -i {} centos@{}...".format(aws_key_path, ip_addr))
+
+        else:
+            # Compile locally using the same tool chain
+            if xpfm is not None:
+                self.XPFM = xpfm
+            self.tool.compile(work_path, self.XPFM)
+    
+    def register_afi(ip_addr, project_name):
+        ssh = get_cache_info(self.cache, "ssh")
+        base = "test-hcl-" + os.getlogin()
+        inputs = {
+            "base": base,
+            "project_name": project_name
+        }
         # Register the AFI image
         command = """
+source $HOME/aws-fpga/vitis_setup.sh
+source $HOME/aws-fpga/vitis_runtime_setup.sh
 cd ~/{project_name};
 cp build_dir.hw.*/kernel.xclbin .
 if [ ! -f *afi_id.txt ]; then
@@ -179,49 +281,14 @@ if [ ! -f *afi_id.txt ]; then
 fi
 AFI_ID=$(cat *afi_id.txt | grep -Eo '(afi-.+)' | sed 's/",//g')
 aws ec2 describe-fpga-images --fpga-image-ids $AFI_ID
-echo $AFI_ID
+echo $AFI_ID > AFI_ID.txt
 """
         out = run_shell_remote(command, inputs, ssh)
-        print(out)
         afi_id = out.split("\n")[-1]
+        print("[  INFO  ] AFI ID registered {}".format(afi_id))
         save_cache_info(self.cache, "status", "registering")
         save_cache_info(self.cache, "afi_id", afi_id)
 
-    # Used for bitstream compiling (if remote is true, 
-    # then we compile on remote AWS machines)
-    def compile(self, args, remote=False, 
-            aws_key_path=None, instance="t2.micro", xpfm=None):
-
-        work_path = Project.path
-        project_name = Project.project_name
-        self.cache = "{}-aws.json".format(project_name)
-        if remote:
-            assert os.path.exists(aws_key_path)
-            save_cache_info(self.cache, "key_path", aws_key_path)
-            aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
-
-            # Create instances
-            instance_id = self.create_instance(aws_key, instance)
-            ip_addr = self.get_ip_addr(instance_id)
-
-            # Upload to S3 bucket
-            status = get_cache_info(self.cache, "status")
-            if status is None:
-                self.upload(work_path, project_name)
-                print("[ INFO ] Uploaded source code to AWS S3. Start compiling")
-                # Do we want to make this compilation running background?
-                self.remote_compile(ip_addr, project_name)
-                
-            else:
-                print("[ INFO ] Compilation running on AWS. Check status with \
-                    ssh -i {} centos@{}...".format(aws_key_path, ip_addr))
-
-        else:
-            # Compile locally using the same tool chain
-            if xpfm is not None:
-                self.XPFM = xpfm
-            self.tool.compile(work_path, self.XPFM)
-    
     def wait_afi_register(self):
         afi_id = get_cache_info(self.cache, "afi_id")
         command = "aws ec2 describe-fpga-images --fpga-image-ids {}".format(afi_id)
@@ -237,24 +304,48 @@ echo $AFI_ID
             assert aws_key_path is not None
             aws_key = aws_key_path.split("/")[-1].replace(".pem", "")
 
-            # Run the host program
-            mode = self.tool.mode         
-            if mode == "hw_exe":
-                run_cmd = "./host kernel.xclbin"
-            elif mode == "sw_sim":
-                run_cmd = "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
-            elif mode == "hw_sim":
-                run_cmd = "XCL_EMULATION_MODE=hw_emu ./host kernel.xclbin"
+            status = get_cache_info(self.cache, "status")
+            if status == "done":
+                # Run the host program
+                mode = self.tool.mode   
+                project_name = Project.project_name
+                run_cmd = """
+source $HOME/aws-fpga/vitis_setup.sh
+source $HOME/aws-fpga/vitis_runtime_setup.sh
+cd {project_name}
+{execute_cmd}
+"""    
+                ssh = get_cache_info(self.cache, "ssh")
+                if mode == "sw_sim":
+                    execute_cmd = "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
+                    inputs = {"project_name": project_name, "execute_cmd": execute_cmd}
+                    out = run_shell_remote(run_cmd, inputs, ssh)
+                    self.copy_data_back(project_name)
 
-            # Check if the AFI image is registered
-            if mode == "hw_exe":
-                while self.wait_afi_register():
-                    sleep(10 * 60)
-                
-                # Create F1 instance and start running  
+                elif mode == "hw_sim":
+                    execute_cmd = "XCL_EMULATION_MODE=hw_emu ./host kernel.xclbin"
+                    inputs = {"project_name": project_name, "execute_cmd": execute_cmd}
+                    out = run_shell_remote(run_cmd, inputs, ssh)
+                    self.copy_data_back(project_name)
+
+                # Check if the AFI image is registered
+                elif mode == "hw_exe":
+                    while self.wait_afi_register():
+                        sleep(10 * 60)
+
+                    # Create F1 instance and start running  
+            else:
+                print("[  INFO  ] Instance not done yet. Status {}".format(status))
         else:
             pass
 
+    def copy_data_back(self, project_name):
+        print("[  INFO  ] Copying result back...")
+        aws_key_path = get_cache_info(self.cache, "key_path")
+        ip_addr = get_cache_info(self.cache, "ip_addr")
+        assert aws_key_path is not None
+        command = "scp -i {aws_key_path} centos@{ip_addr}:~/{project_name}/inputs.json ."
+        run_shell_script(command)
     
     def delete_instance(self):
         pass
@@ -283,10 +374,253 @@ class VLAB(Platform):
         tool = Tool.aocl
         super(VLAB, self).__init__(name, devs, host, xcel, tool)
     
+    def remote_compile(self, project_name, instance):
+        ssh = get_cache_info(self.cache, "ssh")
+    
+        mode = self.tool.mode
+        compile_mode = ""
+        if mode == "sw_sim":
+            compile_mpde = "-march=emulator"
+        elif mode == "hw_sim":
+            raise RuntimeError("-march=simulator only supported for AOC > 19")
+
+        if instance == "fpga-pac-a10":
+            target = "pac_a10"
+            AOC = "/export/fpga/tools/quartus_pro/17.1.1/hld"
+
+        elif instance == "fpga-pac-s10":
+            target = "pac_s10_dc"
+            AOC = "/export/fpga/tools/quartus_pro/18.1.2_patches_202_203_206/hld" 
+        
+        elif instance == "fpga-bdx-opencl":
+            target = "bdw_fpga_v1.0"
+            AOC = "/export/fpga/tools/quartus_pro/16.0.2/hld/"
+
+        inputs = {
+            "project_name": project_name,
+            "target": target,
+            "AOC": AOC,
+            "compile_mode": compile_mode,
+        }
+
+        aoc_command = """
+cd $HOME/{project_name}
+aoc -board={target} -time time.out \
+    -time-passes {compile_mode} \
+    -regtest_mode -v -fpc \
+    -fp-relaxed -opt-arg -nocaching -report \
+    -profile=all -I {AOC}/include/kernel_headers \
+    kernel.cl
+" >> qsub-run.sh
+""".format(**inputs)
+
+        # Patches for old version AOC
+        if instance == "fpga-bdx-opencl":
+            aoc_command = """
+cd $HOME/{project_name}
+aoc --board {target} --time time.out \
+    --time-passes {compile_mode} \
+    --regtest_mode -v --fpc \
+    --fp-relaxed --opt-arg --nocaching --report \
+    --profile all -I {AOC}/include/kernel_headers \
+    kernel.cl
+" >> qsub-run.sh
+""".format(**inputs)            
+
+        inputs = {
+            "instance": instance,
+            "project_name": project_name,
+            "aoc_command": aoc_command
+        }
+
+        command = """
+cd $HOME/{project_name}
+if [ -f qsub-run.sh ]; then
+    rm qsub-run.sh
+fi
+
+echo "#!/bin/bash
+#PBS -l select=1:ncpus=24 -q xeon
+source /export/fpga/bin/setup-fpga-env {instance}
+{aoc_command}
+
+qsub -v "path=$PWD" -l walltime=36:00:00 -N {project_name} -o aocl.out \
+    -e aocl.err qsub-run.sh
+"""
+        out = run_shell_remote(command, inputs, ssh)
+        save_cache_info(self.cache, "status", "running")
+    
+    def upload(self, work_path, project_name):
+        key_path = get_cache_info(self.cache, "key_path")
+        ssh = get_cache_info(self.cache, "ssh")
+        command = """
+cd $HOME
+if [ ! -d {project_name} ]; then
+    mkdir {project_name}
+fi
+"""
+        inputs = {"project_name": project_name}
+        run_shell_remote(command, inputs, ssh)
+        command = "scp -i {} -r {}/* sx233@ssh-iam.intel-research.net:~/{}/".\
+            format(key_path, project_name, project_name)
+        run_shell_script(command)
+    
+
+    def check_process_liveness(self, project_name):
+        command = "/opt/pbs/default/bin/qstat -u sx233"
+        ssh = get_cache_info(self.cache, "ssh")
+        out = run_shell_remote(command, {}, ssh)
+        if project_name[:10] in out:
+            print("[  INFO  ] Compilation running...")
+            print(out)
+            return True, 0
+        else:
+            return False, 0
+
     # Used for bitstream compiling (if remote is true, 
-    # then we compile on remote AWS machines)
-    def compile(self, remote=False):
-        pass
+    # then we compile on remote VLAB machines)
+    def compile(self, args, remote=False, 
+            ssh_key_path=None, instance="fpga-pac-s10"):
+
+        work_path = Project.path
+        project_name = Project.project_name
+        self.cache = "{}-vlab.json".format(project_name)
+
+        if remote:
+            assert os.path.exists(ssh_key_path)
+            save_cache_info(self.cache, "key_path", ssh_key_path)
+            ssh = "ssh -i {} sx233@ssh-iam.intel-research.net".format(ssh_key_path)
+            save_cache_info(self.cache, "ssh", ssh)
+
+            # Upload to S3 bucket if instance does not exists
+            status = get_cache_info(self.cache, "status")
+            if status is None:
+                self.upload(work_path, project_name)
+                print("[  INFO  ] Uploaded source code to VLAB. Start compiling...")
+                self.remote_compile(project_name, instance)
+
+            elif status == "running":
+                is_live, runtime = self.check_process_liveness(project_name)
+                if is_live:
+                    print("[  INFO  ] SSH {}".format(ssh))
+                    self.check_hls_report(project_name)
+                else:
+                    save_cache_info(self.cache, "status", "done")
+
+        else:
+            # Compile locally using the same tool chain
+            if xpfm is not None:
+                self.XPFM = xpfm
+            self.tool.compile(work_path, self.XPFM)
+            
+    def copy_utility(self, path, source):
+        self.tool.copy_utility(path, source)
+
+    def execute(self, work_path, mode, remote=False, 
+            ssh_key_path=None, instance="fpga-pac-s10"):
+
+        if remote:
+            status = get_cache_info(self.cache, "status")
+            if status == "done":
+                # Run the host program
+                mode = self.tool.mode   
+                project_name = Project.project_name
+                run_cmd = """
+cd $HOME/{project_name}
+if [ -f qsub-execute.sh ]; then
+    rm qsub-execute.sh
+fi
+
+echo "#!/bin/bash
+#PBS -l select=1:ncpus=12 -q {instance}
+source /export/fpga/bin/setup-fpga-env {instance}
+
+cd $HOME/{project_name}
+make host
+aocl program acl0 kernel.aocx
+{execute_cmd}
+" >> qsub-execute.sh
+
+qsub -v "path=$PWD" -l walltime=36:00:00 -N {project_name} -o fpga.out \
+    -e fpga.err qsub-execute.sh
+"""    
+                ret = True
+                ssh = get_cache_info(self.cache, "ssh")
+                if mode == "sw_sim":
+                    execute_cmd = "env CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA=1 ./host"
+                    inputs = {"project_name": project_name, 
+                              "execute_cmd": execute_cmd,
+                              "instance": instance}
+                    out = run_shell_remote(run_cmd, inputs, ssh)
+                    self.copy_data_back(project_name)
+
+                elif mode == "hw_sim":
+                    execute_cmd = "env CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./host"
+                    inputs = {"project_name": project_name, 
+                              "execute_cmd": execute_cmd,
+                              "instance": instance}
+                    out = run_shell_remote(run_cmd, inputs, ssh)
+                    self.copy_data_back(project_name)
+
+                # Check if the AFI image is registered
+                elif mode == "hw_exe":
+                    execute_cmd = "./host kernel.aocx"
+                    inputs = {"project_name": project_name, 
+                              "execute_cmd": execute_cmd,
+                              "instance": instance}
+                    out = run_shell_remote(run_cmd, inputs, ssh)
+                    print(out)
+                    self.copy_data_back(project_name) 
+                return ret
+            else:
+                print("[  INFO  ] Instance not done yet. Status {}".format(status))
+                ret = False; return ret
+        else:
+            self.tool.execute(work_path, mode)
+            ret = True; return ret
+    
+    # Download HLS report back if exists
+    def check_hls_report(self, project_name):
+        ssh = get_cache_info(self.cache, "ssh")
+        command = """
+cd $HOME/{project_name}
+if [ -d kernel/reports ]; then 
+    echo "Found HLS reports"
+fi
+"""
+        inputs = {"project_name": project_name}
+        out = run_shell_remote(command, inputs, ssh)
+        if "Found HLS reports" in out:
+            if not os.path.isdir("{}/reports".format(project_name)):
+                key_path = get_cache_info(self.cache, "key_path")
+                command = "scp -i {} -r sx233@ssh-iam.intel-research.net:~/{}/kernel/reports {}/".\
+                    format(key_path, project_name, project_name)
+                run_shell_script(command)
+                print("[  INFO  ] Found HLS report. Downloading...")
+            print("[  INFO  ] HLS report path {}/reports".format(project_name))
+    
+    def copy_data_back(self, project_name):
+        print("[  INFO  ] Copying result back...")
+        key_path = get_cache_info(self.cache, "key_path")
+        command = "scp -i {} sx233@ssh-iam.intel-research.net:~/{}/*.json {}/".\
+            format(key_path, project_name, project_name)
+        run_shell_script(command)
+        command = "scp -i {} sx233@ssh-iam.intel-research.net:~/{}/*.out {}/".\
+            format(key_path, project_name, project_name)
+        run_shell_script(command)
+        command = "scp -i {} sx233@ssh-iam.intel-research.net:~/{}/*.err {}/".\
+            format(key_path, project_name, project_name)
+        run_shell_script(command)
+
+        # Also copy the report back if MODE is hw_exe
+        if self.tool.mode == "hw_exe":
+            command = "scp -i {} \
+                sx233@ssh-iam.intel-research.net:~/{}/kernel/acl_quartus_report.txt {}/".\
+                format(key_path, project_name, project_name)
+            run_shell_script(command)            
+    
+    def report(self, project_name):
+        self.tool.report(project_name)
 
 class U280(Platform):
     def __init__(self):
@@ -319,7 +653,25 @@ class U280(Platform):
     def execute(self, work_path, mode, **kwargs):
         self.tool.execute(work_path, mode)
 
-Platform.aws_f1 = AWS_F1()
-Platform.zc706  = ZC706()
-Platform.vlab   = VLAB()
-Platform.u280   = U280()
+# Mainly used for AutoSA compilation
+class Docker(U280):
+    def __init__(self):
+        super(Docker, self).__init__()
+
+class Insider(AWS_F1):
+    def __init__(self):
+        super(Insider, self).__init__()
+        self.AMI_ID = "ami-04c8ef1dee652fe24"
+
+class U250(U280):
+    def __init__(self):
+        super(U250, self).__init__()
+        self.XFPM = "xilinx_u250_qdma_201920_1.xpfm"   
+
+Platform.aws_f1  = AWS_F1()
+Platform.zc706   = ZC706()
+Platform.vlab    = VLAB()
+Platform.u280    = U280()
+Platform.u250    = U250()
+Platform.insider = Insider()
+Platform.docker  = Docker()

--- a/python/heterocl/tools.py
+++ b/python/heterocl/tools.py
@@ -2,9 +2,20 @@
 import os, subprocess
 from .devices import Tool
 from . import devices
+from .report import *
 
 """Define HeteroCL default tool settings"""
 #pylint: disable=too-few-public-methods, too-many-return-statements
+
+
+def run_shell_script(command):
+    with open("temp.sh", "w") as fp:
+        fp.write(command)
+    ret = subprocess.run(command, 
+        stdout=subprocess.PIPE, check=True, shell=True)
+    os.remove("temp.sh")
+    return ret.stdout.decode('utf-8')
+
 
 class VivadoHLS(Tool):
     def __init__(self):
@@ -16,6 +27,7 @@ class VivadoHLS(Tool):
         }
         super(VivadoHLS, self).__init__(name, mode, options)
 
+
 class AOCL(Tool):
     def __init__(self):
         name = "aocl"
@@ -26,6 +38,7 @@ class AOCL(Tool):
         }
         super(AOCL, self).__init__(name, mode, options)
 
+
 class Vitis(Tool):
     def __init__(self):
         name = "vitis"
@@ -35,17 +48,82 @@ class Vitis(Tool):
             "Version":  "2019.2"
         }
         super(Vitis, self).__init__(name, mode, options)
-    
+
+        self.tool_mode = None
+        self.xpfm = None
+        self.binary = None
+        self.build_dir = None
+
     def copy_utility(self, path, source):
         source_path = os.path.join(source, "vitis")
         command = "cp {}/* {}".format(source_path, path)
         os.system(command)
     
-    def compile(self, work_path):
-        pass
+    def compile(self, work_path, mode, xpfm):
+        if mode == "hw_exe": 
+            self.tool_mode = "hw"
+        elif mode == "sw_sim": 
+            self.tool_mode = "sw_emu"
+        elif mode == "hw_sim": 
+            self.tool_mode = "hw_emu"
+
+        self.xpfm = xpfm
+        device = self.xpfm.split("/")[-1].replace(".xpfm", "")
+        path = "build_dir.{}.{}".format(self.tool_mode, device)
+        
+        build_dir = "_x.{}.{}".format(self.tool_mode, device)
+        self.build_dir = os.path.join(work_path, build_dir)
+
+        path = os.path.join(path, "kernel.xclbin")
+        binary = os.path.join(work_path, path)
+        self.binary = binary 
+
+        if not os.path.exists(self.binary):
+            print("[  INFO  ] Not found {}. recompile".format(binary))
+            command = "cd {}; ".format(work_path)
+            command += "make all TARGET={} DEVICE={}".\
+                format(self.tool_mode, xpfm)
+            run_shell_script(command)
+        else:
+            print("[  INFO  ] Found compiled binary {}".format(binary))
+
+
+    def execute(self, work_path, mode):  
+        assert os.path.exists(self.binary), self.binary
+        run_cmd = "cp {} {};".format(self.binary, work_path)
+        run_cmd += "cd {};".format(work_path)
+        if mode == "hw_exe":
+            run_cmd += "./host kernel.xclbin"
+        elif mode == "sw_sim":
+            run_cmd += "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
+        elif mode == "hw_sim":
+            run_cmd += "XCL_EMULATION_MODE=hw_emu ./host kernel.xclbin"
+        run_shell_script(run_cmd)
+
+
+    def report(self):
+        final = dict()
+        path = os.path.join(self.build_dir, "reports/kernel/hls_reports/test_csynth.rpt")
+        print("[  INFO  ] Parsing HLS report {}".format(path))
+
+        hls_rpt = parse_vhls_report(path)
+        final["hls"] = hls_rpt
+
+        # Include runtime profiling result
+        if self.tool_mode in ("hw", "hw_emu"):
+            print("[  INFO  ] Parsing runtime profiling data...")
+            path = self.build_dir.replace("_x.", "build_dir.")
+            runtime_qor = parse_vitis_prof_report(path)
+            final["runtime"] = runtime_qor
+
+        return final
+
+class SDAccel(Vitis):
+    pass
 
 Tool.vivado_hls = VivadoHLS()
 Tool.vitis = Vitis()
 Tool.aocl = AOCL()
+Tool.sdaccel = SDAccel()
 
 

--- a/python/heterocl/tools.py
+++ b/python/heterocl/tools.py
@@ -10,10 +10,10 @@ model_table = {
 }
 
 option_table = {
-  "llvm"    : ("sw_sim", {"version" : "6.0.0"}),
-  "sdaccel" : ("sw_sim", {"version" : "2017.1", "clock" : "1"}),
-  "sdsoc"   : ("sw_sim", {"version" : "2017.1", "clock" : "1"}),
-  "vitis"   : ("sw_sim", {"version" : "2019.2", "clock" : "1"}),
+  "llvm"       : ("sw_sim", {"version" : "6.0.0"}),
+  "sdaccel"    : ("sw_sim", {"version" : "2017.1", "clock" : "1"}),
+  "sdsoc"      : ("sw_sim", {"version" : "2017.1", "clock" : "1"}),
+  "vitis"      : ("sw_sim", {"version" : "2019.2", "clock" : "1"}),
   "vivado_hls" : ("sw_sim", {"version" : "2017.1"}),
   "rocket"     : ("debug", {"RISCV" : ""}),
 

--- a/python/heterocl/tools.py
+++ b/python/heterocl/tools.py
@@ -1,129 +1,51 @@
+# from .devices import Tool
+import os, subprocess
+from .devices import Tool
+from . import devices
+
 """Define HeteroCL default tool settings"""
 #pylint: disable=too-few-public-methods, too-many-return-statements
 
-model_table = {
-  "xilinx" : ["fpga_xc7z045", "fpga_xcvu19p", "fpga_xcu250"],
-  "intel"  : ["cpu_e5", "cpu_i7", "fpga_stratix10_gx", 
-              "fpga_stratix10_dx", "fpga_stratix10_mx", "fpga_arria10"],
-  "arm"    : ["cpu_a7", "cpu_a9", "cpu_a53"],
-  "riscv"  : ["cpu_riscv"]
-}
+class VivadoHLS(Tool):
+    def __init__(self):
+        name = "vivado_hls"
+        mode = "sw_sim"
+        options = {
+            "Frequency": "300",
+            "Version":  "2019.2"
+        }
+        super(VivadoHLS, self).__init__(name, mode, options)
 
-option_table = {
-  "llvm"       : ("sw_sim", {"version" : "6.0.0"}),
-  "sdaccel"    : ("sw_sim", {"version" : "2017.1", "clock" : "1"}),
-  "sdsoc"      : ("sw_sim", {"version" : "2017.1", "clock" : "1"}),
-  "vitis"      : ("sw_sim", {"version" : "2019.2", "clock" : "1"}),
-  "vivado_hls" : ("sw_sim", {"version" : "2017.1"}),
-  "rocket"     : ("debug", {"RISCV" : ""}),
+class AOCL(Tool):
+    def __init__(self):
+        name = "aocl"
+        mode = "sw_sim"
+        options = {
+            "Frequency": "300",
+            "Version":  "2019.2"
+        }
+        super(AOCL, self).__init__(name, mode, options)
 
-  # refer to xilinx2016_1/ug904-vivado-implementation.pdf
-  "vivado"     : ("pnr",
-      {"version" : "2017.1",
-       "logic" : [
-           "Default", 
-           "Explore", 
-           "ExploreSequentialArea", 
-           "AddRemap", 
-           "ExploreArea"],
-       "placement" : [
-           "Default", 
-           "Explore", 
-           "ExtraNetDelay_high", 
-           "ExtraNetDelay_medium", 
-           "ExtraNetDelay_low", 
-           "ExtraPostPlacementOpt", 
-           "WLDrivenBlockPlacement", 
-           "LateBlockPlacement", 
-           "AltSpreadLogic_low", 
-           "AltSpreadLogic_medium", 
-           "AltSpreadLogic_high"],
-       "routing" : [
-           "Default", 
-           "Explore", 
-           "HigherDelayCost"],
-       "fanout_opt"        : ["on", "off"],
-       "placement_opt"     : ["on", "off"],
-       "critical_cell_opt" : ["on", "off"],
-       "critical_pin_opt"  : ["on", "off"],
-       "retime"            : ["on", "off"],
-       "rewire"            : ["on", "off"],
-      }),
+class Vitis(Tool):
+    def __init__(self):
+        name = "vitis"
+        mode = "sw_sim"
+        options = {
+            "Frequency": "300",
+            "Version":  "2019.2"
+        }
+        super(Vitis, self).__init__(name, mode, options)
+    
+    def copy_utility(self, path, source):
+        source_path = os.path.join(source, "vitis")
+        command = "cp {}/* {}".format(source_path, path)
+        os.system(command)
+    
+    def compile(self, work_path):
+        pass
 
-  "quartus"    : ("pnr", 
-      {"version" : "17.1",
-      "auto_dsp_recognition"                        : ['On', 'Off'],
-      "disable_register_merging_across_hierarchies" : ['On', 'Off', 'Auto'],
-      "mux_restructure"                             : ['On', 'Off', 'Auto'],
-      "optimization_technique"                      : ['Area', 'Speed', 'Balanced'],
-      "synthesis_effort"                            : ['Auto', 'Fast'],
-      "synth_timing_driven_synthesis"               : ['On', 'Off'],
-      "fitter_aggressive_routability_optimization"  : ['Always', 'Automatically', 'Never'],
-      "fitter_effort"                               : ['Standard Fit', 'Auto Fit'],
-      "remove_duplicate_registers"                  : ['On', 'Off'],
-      "physical_synthesis"                          : ['On', 'Off'],
-      "adv_netlist_opt_synth_wysiwyg_remap"         : ['On', 'Off'],
-      "allow_any_ram_size_for_recognition"          : ['On', 'Off'],
-      "allow_any_rom_size_for_recognition"          : ['On', 'Off'],
-      "allow_any_shift_register_size_for_recognition" : ['On', 'Off'],
-      "allow_power_up_dont_care"                      : ['On', 'Off'],
-      "allow_shift_register_merging_across_hierarchies" : ["Always", "Auto", "Off"],
-      "allow_synch_ctrl_usage"                      : ['On', 'Off'],
-      "auto_carry_chains"                           : ['On', 'Off'],
-      "auto_clock_enable_recognition"               : ['On', 'Off'],
-      "auto_dsp_recognition"                        : ['On', 'Off'],
-      "auto_enable_smart_compile"                   : ['On', 'Off'],
-      "auto_open_drain_pins"                        : ['On', 'Off'],
-      "auto_ram_recognition"                        : ['On', 'Off'],
-      "auto_resource_sharing"                       : ['On', 'Off'],
-      "auto_rom_recognition"                        : ['On', 'Off'],
-      "auto_shift_register_recognition"             : ["Always", "Auto", "Off"],
-      "disable_register_merging_across_hierarchies" : ["Auto", "On", "Off"],
-      "enable_state_machine_inference"              : ['On', 'Off'],
-      "force_synch_clear"                           : ['On', 'Off'],
-      "ignore_carry_buffers"                        : ['On', 'Off'],
-      "ignore_cascade_buffers"                      : ['On', 'Off'],
-      "ignore_max_fanout_assignments"               : ['On', 'Off'],
-      "infer_rams_from_raw_logic"                   : ['On', 'Off'],
-      "mux_restructure"                             : ["Auto", "On", "Off"],
-      "optimization_technique"                      : ["Area", "Balanced", "Speed"],
-      "optimize_power_during_synthesis" : ["Extra effort", "Normal compilation", "Off"],
-      "remove_duplicate_registers"                  : ['On', 'Off'],
-      "shift_register_recognition_aclr_signal"      : ['On', 'Off'],
-      "state_machine_processing"                    : ["Auto", "Gray", 
-           "Johnson, Minimal Bits", "One-Hot", "Sequential", "User-Encoded"],
-      "strict_ram_recognition"                      : ['On', 'Off'],
-      "synthesis_effort"                            : ["Auto", "Fast"],
-      "synthesis_keep_synch_clear_preset_behavior_in_unmapper" : ['On', 'Off'],
-      "synth_resource_aware_inference_for_block_ram" : ['On', 'Off'],
-      "synth_timing_driven_synthesis"                : ['On', 'Off'],
-      "alm_register_packing_effort"                  : ["High", "Low", "Medium"],
-      "auto_delay_chains"                            : ['On', 'Off'],
-      "auto_delay_chains_for_high_fanout_input_pins" : ["On", "Off"],
-      "eco_optimize_timing"                          : ["On", "Off"],
-      "final_placement_optimization"                 : ["Always", "Automatically", "Never"],
-      "fitter_aggressive_routability_optimization"   : ["Always", "Automatically", "Never"],
-      "fitter_effort"                                : ["Standard Fit", "Auto Fit"],
-      "optimize_for_metastability"                   : ["On", "Off"],
-      "optimize_hold_timing"                         : ["All Paths", "IO Paths and Minimum TPD Paths", "Off"],
-      "optimize_ioc_register_placement_for_timing"   : ["Normal", "Off", "Pack All IO Registers"],
-      "optimize_multi_corner_timing"                 : ['On', 'Off'],
-      "optimize_power_during_fitting"                : ["Extra effort", "Normal compilation", "Off"],
-      "physical_synthesis"                           : ['On', 'Off'],
-      "placement_effort_multiplier"                  : [0.2, 0.5, 1.0, 2.0, 3.0, 4.0],
-      "programmable_power_technology_setting"        : ["Automatic", 
-          "Force All Tiles with Failing Timing Paths to High Speed", 
-          "Force All Used Tiles to High Speed", "Minimize Power Only"],
-      "qii_auto_packed_registers"                    : ["Auto", "Minimize Area", 
-          "Minimize Area with Chains", "Normal", "Off", "Sparse", "Sparse Auto"],
-      "router_clocking_topology_analysis"            : ['On', 'Off'],
-      "router_lcell_insertion_and_logic_duplication" : ["Auto", "On", "Off"],
-      "router_register_duplication"                  : ["Auto", "On", "Off"],
-      "router_timing_optimization_level"             : ["MINIMUM", "Normal", "MAXIMUM"],
-      "seed"                                         : (1, 5),
-      "tdc_aggressive_hold_closure_effort"           : ['On', 'Off'],
-      "allow_register_retiming"                      : ['On', 'Off']}),
+Tool.vivado_hls = VivadoHLS()
+Tool.vitis = Vitis()
+Tool.aocl = AOCL()
 
-  "aocl" : ("sw_sim", {"version" : "17.0", "clock" : "1.5"})
-}
 

--- a/python/heterocl/tools.py
+++ b/python/heterocl/tools.py
@@ -38,6 +38,19 @@ class AOCL(Tool):
         }
         super(AOCL, self).__init__(name, mode, options)
 
+    def copy_utility(self, path, source):
+        source_path = os.path.join(source, "aocl")
+        command = "cp {}/* {}".format(source_path, path)
+        os.system(command)
+    
+    def report(self, project_name):
+        res = dict()
+        if self.mode == "hw_exe":
+            path = os.path.join(project_name, "acl_quartus_report.txt")
+            assert os.path.exists(path), path
+            rpt = parse_aocl_prof_report(path)
+            res["pnr"] = rpt
+        return res
 
 class Vitis(Tool):
     def __init__(self):

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -24,7 +24,7 @@ from . import ndarray
 from . import target as _target
 from . import make
 from .runtime import *
-from ..devices import platform
+from ..devices import Platform
 
 class DumpIR(object):
     """
@@ -497,7 +497,7 @@ def build_fpga_kernel(sch, args, target, name="default_function", schedule_name=
             keys = [k for k in target.tool.options.keys()]
             vals = [v for v in target.tool.options.values()]
 
-            # platform & backend lang
+            # Platform & backend lang
             keys.insert(0, "name")
             vals.insert(0, target.tool.name)
             keys.insert(1, "mode")
@@ -514,7 +514,10 @@ def build_fpga_kernel(sch, args, target, name="default_function", schedule_name=
                 folder = "{}-{}".format(schedule_name,target.project)
             else:
                 folder = target.project
+
             Project.path = folder
+            Project.platform = target
+
             vals.insert(4, folder)
             # make the project folder first
             os.makedirs(folder, exist_ok=True)
@@ -573,7 +576,7 @@ def build(sch,
     ----
     See the note on :any:`tvm.target` on target string format.
     """
-    if isinstance(target, platform):
+    if isinstance(target, Platform):
         return build_fpga_kernel(sch, args, target, name=name, schedule_name=schedule_name)
     else: # default string type target
         target = _target.current_target() if target is None else target

--- a/python/heterocl/tvm/build_module.py
+++ b/python/heterocl/tvm/build_module.py
@@ -489,6 +489,7 @@ def build_fpga_kernel(sch, args, target, name="default_function", schedule_name=
             host_code = builder(fdevice, 1, target_tool)
             builder = getattr(codegen, "build_{0}".format(xcel))
             xcel_code = builder(fdevice, 2, target_tool)
+            
             return "------ Host Code ------\n\n" + host_code + \
                    "------ Xcel Code ------\n\n" + xcel_code
 

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -95,8 +95,11 @@ class Module(ModuleBase):
         for arg in args:
             new_args.append(asarray(arg))
         
-        # Here we only generate code and do not 
-        # modify the passed-in memory pointers
+        if "docker" in kwargs:
+            print("[  INFO  ] Generate code inside HCL docker and copy back")
+            assert hasattr(devices.Project.platform, "")
+            return
+
         devices.Project.platform.to_codegen = True
         self.__call__(*new_args)
         devices.Project.platform.to_codegen = False
@@ -122,7 +125,7 @@ class Module(ModuleBase):
         target = devices.Project.platform
         name = devices.Project.project_name
         mode = target.tool.mode
-        print("[  INFO  ] Start execution (mode {})...".format(mode))
+        print("[  INFO  ] Execution (mode {})...".format(mode))
         new_args = []
         for arg in args:
             new_args.append(asarray(arg))
@@ -135,9 +138,12 @@ class Module(ModuleBase):
         devices.Project.platform.to_execute = False
 
         # Extract performanece numbers
-        rpt = target.tool.report()
-        rets = [ _.asnumpy() for _ in new_args ]
-        return rets, rpt
+        if devices.Project.platform.execute_status:
+            rpt = target.report(name)
+            rets = [ _.asnumpy() for _ in new_args ]
+            return rets, rpt
+        else:
+            import sys; sys.exit()
 
     def report(self):
         """Get tool report

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -81,6 +81,24 @@ class Module(ModuleBase):
                     new_args.append(arg)
             return super().__call__(*new_args)
 
+    def compile(self, args, **kwargs):
+        """Compile the Module
+
+        Parameters
+        ----------
+        target : hcl.Platform
+        """
+        if "target" not in self.__dict__.keys():
+            raise RuntimeError("No attached target!") 
+        target = self.target 
+        # Generate local project files
+        new_args = []
+        for arg in args:
+            new_args.append(asarray(arg))
+        print(new_args)
+        self.__call__(*new_args)
+        target.compile(**kwargs)
+
     def report(self):
         """Get tool report
 

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -65,7 +65,7 @@ class Module(ModuleBase):
 
         Parameters
         ----------
-        target : hcl.platform
+        target : hcl.Platform
         """
         self.target = target
 

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -110,6 +110,34 @@ class Module(ModuleBase):
         """
         target = devices.Project.platform
         target.compile(args, **kwargs)
+    
+    # Run and evaluate the performance
+    def execute(self, args, **kwargs):
+        """Run the Module
+
+        Parameters
+        ----------
+        target : hcl.Platform
+        """
+        target = devices.Project.platform
+        name = devices.Project.project_name
+        mode = target.tool.mode
+        print("[  INFO  ] Start execution (mode {})...".format(mode))
+        new_args = []
+        for arg in args:
+            new_args.append(asarray(arg))
+
+        # Execute the bitstream and fetch result to memory pointer
+        devices.Project.platform.to_execute = True
+        devices.Project.platform.execute_arguments = kwargs
+        self.__call__(*new_args)
+        devices.Project.platform.execute_arguments = dict()
+        devices.Project.platform.to_execute = False
+
+        # Extract performanece numbers
+        rpt = target.tool.report()
+        rets = [ _.asnumpy() for _ in new_args ]
+        return rets, rpt
 
     def report(self):
         """Get tool report

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -108,6 +108,7 @@ def process_extern_module(attr_key, keys, values, code):
             header = fp.read() + "\n"            
         with open(f"{autosa_dir}/autosa.tmp/output/src/hcl_autosa_tmp_hcl_decl.h", "r") as fp:
             ret_code = fp.readlines()[0].strip() + ";\n"
+            ret_code = ret_code.replace("buffer_", "")
 
         # analyze the input code
         return [header, ret_code] 

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -2,6 +2,7 @@ from ._ffi.function import register_func
 import os, subprocess, time, re, glob
 from ..report import parse_xml
 from ..devices import Project, Platform
+from ..autosa import autosa_infer_types
 debug = True
 
 def replace_text(f_name, prev, new):
@@ -108,7 +109,7 @@ def process_extern_module(attr_key, keys, values, code):
             header = fp.read() + "\n"            
         with open(f"{autosa_dir}/autosa.tmp/output/src/hcl_autosa_tmp_hcl_decl.h", "r") as fp:
             ret_code = fp.readlines()[0].strip() + ";\n"
-            ret_code = ret_code.replace("buffer_", "")
+            ret_code = autosa_infer_types(header, ret_code)
 
         # analyze the input code
         return [header, ret_code] 

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -270,22 +270,6 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
                   "./top_function_0_host.exe -f top_function_0.hw.xclbin"
             out = run_process(cmd)
 
-    elif platform == "vitis":
-        assert os.system("which v++ >> /dev/null") == 0, \
-            "cannot find v++ on system path"
-        cmd = "cd {}; ".format(Project.path)
-
-        if mode == "hw_exe":
-            cmd += "./host kernel.xclbin"
-        elif mode == "sw_sim":
-            cmd += "XCL_EMULATION_MODE=sw_emu ./host kernel.xclbin"
-        elif mode == "hw_sim":
-            cmd += "XCL_EMULATION_MODE=hw_emu ./host kernel.xclbin"
-
-        if host_only:
-            cmd = "cd {}; ./host".format(Project.path)
-        out = run_process(cmd)
-
     elif platform == "aocl":
         if mode == "sw_sim":
             cmd = "cd {}; ".format(Project.path) + \
@@ -306,6 +290,8 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
 def hcl_status_control(empty, dev_hash):
     assert isinstance(Project.platform, Platform)
     p = Project.platform
+    mode = Project.platform.tool.mode
+    execute_arguments = p.execute_arguments
 
     if p.to_codegen:
         print("[{}] Copying harness files for platform {}...".\
@@ -324,7 +310,8 @@ def hcl_status_control(empty, dev_hash):
         return "codegen"
 
     elif p.to_execute:
-        p.execute(Project.path)
+        # Launch the binary and write output to JSON
+        p.execute(Project.path, mode, **execute_arguments)
         return "execute"
 
 # Generate harness and kernel

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -242,48 +242,6 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
         else:
             raise RuntimeError("{} does not support {} mode".format(platform, mode))
 
-    elif platform == "sdsoc":
-        assert os.system("which sds++ >> /dev/null") == 0, \
-            "cannot find sds++ on system path"
-        out = run_process("cd {}; make sdsoc".format(Project.path))
-
-    elif platform == "sdaccel":
-        assert os.system("which xocc >> /dev/null") == 0, \
-            "cannot find xocc on system path"
-
-        if mode == "sw_sim":
-            cmd = "cd {}; ".format(Project.path) +\
-                  "export XCL_EMULATION_MODE=sw_emu; " +\
-                  "./top_function_0_host.exe -f top_function_0.sw_emu.xclbin"
-            out = run_process(cmd)
-
-        elif mode == "hw_sim":
-            cmd = "cd {}; ".format(Project.path) +\
-                  "export XCL_EMULATION_MODE=hw_emu; " +\
-                  "./top_function_0_host.exe -f top_function_0.hw_emu.xclbin"
-            out = run_process(cmd)
-            os.system("cat " + os.path.join(Project.path,"profile_summary.csv"))
-
-        elif mode == "hw_exe":
-            cmd = "cd {}; ".format(Project.path) +\
-                  "export XCL_EMULATION_MODE=hw; " +\
-                  "./top_function_0_host.exe -f top_function_0.hw.xclbin"
-            out = run_process(cmd)
-
-    elif platform == "aocl":
-        if mode == "sw_sim":
-            cmd = "cd {}; ".format(Project.path) + \
-                  "env CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA=1 ./host " + \
-                  " kernel.aocx"
-            out = run_process(cmd)
-        elif mode == "hw_sim":
-            cmd = "cd {}; ".format(Project.path) + \
-                  "env CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./host"
-            out = run_process(cmd)
-
-    else:  # unsupported
-        assert False, "unsupported " + platform
-    return str(qor)
 
 # Define HCL runtime behavior
 @register_func
@@ -294,8 +252,13 @@ def hcl_status_control(empty, dev_hash):
     execute_arguments = p.execute_arguments
 
     if p.to_codegen:
-        print("[{}] Copying harness files for platform {}...".\
-            format(time.strftime("%H:%M:%S", time.gmtime()), p.name))
+        curr_time = time.strftime("%H:%M:%S", time.gmtime())
+        host_file = os.path.join(Project.path, "host.cpp")
+        if os.path.exists(host_file):
+            print("[{}] Workdir {} exists. Skip codegen.".format(curr_time, host_file))
+            return "pass"
+
+        print("[{}] Copying harness files for platform {}...".format(curr_time, p.name))
         path = os.path.dirname(__file__)
         path = os.path.join(path, "../harness/")
         # common harness files
@@ -311,163 +274,14 @@ def hcl_status_control(empty, dev_hash):
 
     elif p.to_execute:
         # Launch the binary and write output to JSON
-        p.execute(Project.path, mode, **execute_arguments)
-        return "execute"
-
-# Generate harness and kernel
-@register_func
-def copy_and_compile(platform, mode, backend, host_only, cfg, script):
-    """ Create necessary files and compile into binary """
-    SUCCESS = ""
-
-    # copy sdsoc makefile
-    if platform == "sdsoc":
-        os.system("cp " + path + "sdsoc/* " + Project.path)
-        os.system("cp " + path + "harness.mk " + Project.path)
-        return "success"
-
-    elif platform == "sdaccel":
-        os.system("cp " + path + "sdaccel/* " + Project.path)
-        os.system("cp " + path + "harness.mk " + Project.path)
-        replace_text(os.path.join(Project.path,"Makefile"), "App", "top_function_0")
-        replace_text(os.path.join(Project.path,"utils.h"), 
-                     "xilinx_aws-vu9p-f1-04261818_dynamic_5_0", 
-                     "xilinx_vcu1525_dynamic_5_1")
-        if backend == "vhls":
-          replace_text(os.path.join(Project.path,"Makefile"), "kernel.cl", "kernel.cpp")
-
-        # compile the program 
-        assert os.system("which xocc >> /dev/null") == 0, \
-            "cannot find xocc on system path"
-
-        if mode == "sw_sim":
-            env = os.environ.copy()
-            assert "AWS_PLATFORM" in os.environ, \
-                   "aws platform info missing" 
-
-            # re-compile host only (reuse context ?) 
-            if False and os.path.isfile("top_function_0.sw_emu.xclbin"):
-              run_process("cd {}; make clean; make host".format(Project.path))
-              run_process("cp top_function_0.sw_emu.xclbin " + Project.path)
-
-            else: # config & compile
-              env["XCL_EMULATION_MODE"] = "sw_emu"
-              cmd = "cd {}; make clean;".format(Project.path)
-              cmd += "emconfigutil --platform=$AWS_PLATFORM;"
-              cmd += "make ocl OCL_TARGET=sw_emu \
-                      OCL_PLATFORM=$AWS_PLATFORM \
-                      APPLICATION_DIR=" + os.path.join(os.getcwd(),Project.path)
-              out = run_process(cmd, env=env)
-
-        # enable profiler 
-        elif mode == "hw_sim":
-            env = os.environ.copy()
-            assert "AWS_PLATFORM" in os.environ, \
-                   "aws platform info missing" 
-
-            env["XCL_EMULATION_MODE"] = "hw_emu"
-            cmd = "cd {}; make clean;".format(Project.path)
-            cmd += "emconfigutil --platform=$AWS_PLATFORM;"
-            cmd += "make ocl OCL_TARGET=hw_emu \
-                    OCL_PLATFORM=$AWS_PLATFORM \
-                    APPLICATION_DIR=" + os.path.join(os.getcwd(),Project.path)
-            out = run_process(cmd, env=env)
-
-        elif mode == "hw":
-            env = os.environ.copy()
-            assert "AWS_PLATFORM" in os.environ, \
-                   "aws platform info missing" 
-
-            env["XCL_EMULATION_MODE"] = "hw"
-            cmd = "cd {}; make clean;".format(Project.path)
-            cmd += "emconfigutil --platform=$AWS_PLATFORM;"
-            cmd += "make ocl OCL_TARGET=hw \
-                    OCL_PLATFORM=$AWS_PLATFORM \
-                    APPLICATION_DIR=" + os.path.join(os.getcwd(),Project.path)
-            out = run_process(cmd, env=env)
-          
-        return "success"
-
-    elif platform == "vitis":
-        env = os.environ.copy()
-        assert "XDEVICE" in os.environ, \
-               "vitis platform info missing" 
-        os.system("cp " + path + "vitis/* " + Project.path)
-        cmd = "cd {}; make clean; ".format(Project.path)
-
-        if mode == "hw_exe": mode = "hw"
-        elif mode == "sw_sim": mode = "sw_emu"
-        elif mode == "hw_sim": mode = "hw_emu"
-
-        # create connecivity config 
-        with open(os.path.join(Project.path,"config.ini"), "w") as fp:
-            fp.write(cfg)
-
-        if not host_only:
-            cmd += "make all TARGET=" + mode + " DEVICE=$XDEVICE"
-        else: cmd += "make host"
-        out = run_process(cmd)
-
-        # mv combined binary to root and save
-        device = os.environ["XDEVICE"].split("/")[-1]
-        device = device.replace(".xpfm", "")
-        path = os.path.join(Project.path, "build_dir.{}.{}/kernel.xclbin".format(mode, device))
-        assert os.path.exists(path), "Not found {}".format(path)
-        run_process("cp {} ".format(path) + os.path.join(Project.path, "kernel.xclbin"))
-
-        kernel = os.path.join(Project.path,"kernel.cpp")
-        with open(kernel, "r") as fp:
-            regex = "HASH:(\d+)\n"
-            hash_v = re.findall(regex, fp.read())[0]
-
-        cache = os.path.join(Project.path,"save/{}-{}.xclbin".format(mode, hash_v))
-        run_process("cp " + os.path.join(Project.path, "kernel.xclbin") + " {}".format(cache))
-        return "success"
-
-    elif platform == "aocl":
-        env = os.environ.copy()
-
-        # check aoc version 
-        assert os.system("which aoc >> /dev/null") == 0, \
-            "cannot find aoc on system path"
-        ver = run_process("aoc --version", "\d+\.\d\.\d")[0].split(".")
-
-        assert "INTELFPGAOCLSDKROOT" in os.environ, \
-               "cannot find aocl sdk for fpga on path" 
-
-        os.system("cp " + path + "aocl/* " + Project.path)
-        cmd = "cd {}; make clean; make;".format(Project.path)
-
-        # compile kernel for xcel device
-        cmd += " aoc"
-        if mode == "sw_sim":
-            cmd += " -march=emulator"
-        elif mode == "hw_sim":
-            if int(ver[0]) < 19:
-                raise RuntimeError("AOC version {}.{}.{} is too old, ".format(*ver) + \
-                        "does not support hw simulation")
-            cmd += " -march=simulator"
-
-        # custom makefile flags 
-        if cfg != "":
-            deps = re.findall(r"deps: {(.+?)}", cfg)[0]
-            custom_cmds = re.findall(r"cmds: {(.+?)}", cfg)[0]
-            mk = re.findall(r"makefiles: {(.+?)}", cfg)[0]
-
-            # copy dependency files
-            out = run_process("cp -r " + deps + " " + Project.path) 
-            print("[{}] Running custom commands: {}".format(
-                time.strftime("%H:%M:%S", time.gmtime()), custom_cmds))
-            out = run_process("cd {}; ".format(Project.path) + custom_cmds) 
-            cmd += " " + mk + " "
-
-        cmd += " -I $INTELFPGAOCLSDKROOT/include/kernel_headers"
-        cmd += " -time time.out -time-passes"
-        cmd += " -v -fpc -fp-relaxed -opt-arg -nocaching"
-        cmd += " -profile -report kernel.cl"
-
-        out = run_process(cmd) 
-        return "success"
+        status = p.execute(Project.path, mode, **execute_arguments)
+        if status:
+            print("[  INFO  ] Compilation done...")
+            Project.platform.execute_status = True
+            return "execute"
+        else:
+            print("[  INFO  ] Compilation still running. Please wait...")
+            return "pass"
 
     else: # unrecognized platform
         assert False, "unsupported platform " + platform

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -215,9 +215,10 @@ def process_extern_module(attr_key, keys, values, code):
 def exec_init(dev_hash, tool, mode):
     assert isinstance(Project.platform, Platform)
     p = Project.platform
+
     print("[ INFO ] Initializing platform {}...".format(p.name))
     # return True if the per-compiled bitstream is found
-    return p.initialize(dev_hash)
+    return p.initialize(Project.path, dev_hash)
 
     # Check whether pre-compiled bitstream exitsts
     kernel = os.path.join(Project.path, "kernel.cpp")

--- a/python/heterocl/util.py
+++ b/python/heterocl/util.py
@@ -9,6 +9,7 @@ from . import config
 from .scheme import Scheme
 from .debug import DTypeError
 from .mutator import Mutator
+import numpy as np
 
 class VarName():
     """A counter for each type of variables.
@@ -141,3 +142,16 @@ class CastRemover(Mutator):
 
     def mutate_Cast(self, node):
         return self.mutate(node.value)
+
+def gen_np_array(sch):
+    rets = []
+    tensors = set(sch.inputs + sch.outputs)
+    for tensor in tensors:
+        if "int" in tensor.dtype:
+            v = np.random.randint(10, size=tensor.shape)
+            rets.append(v)
+        else:
+            v = np.random.uniform(low=0, high=10.0, 
+                size=tensor.shape)
+            rets.append(v)
+    return rets

--- a/samples/3d_rendering/3d_rendering_vhls.py
+++ b/samples/3d_rendering/3d_rendering_vhls.py
@@ -239,7 +239,7 @@ twod_update = main_body.twod_update
 #s[main_body].pipeline(main_body.axis[0])
 #print(hcl.build(s, target="vhls"))
 
-target = hcl.platform.zc706
+target = hcl.Platform.zc706
 s.to([triangle_3d, angle], target.xcel)
 s.to(rendering.main_body.frame_buffer, target.host)
 target.config(compile="vivado_hls", mode="csim|csyn")

--- a/samples/bnn/resnet_aocl.py
+++ b/samples/bnn/resnet_aocl.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys
 from resnet_main2 import *
 
-target = hcl.platform.vlab
+target = hcl.Platform.vlab
 target.config(compile="aocl", mode="hw_sim")
 
 if not args.opt:

--- a/samples/bnn/resnet_const.py
+++ b/samples/bnn/resnet_const.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 else: # vhls
     batch_size = 1
     qtype_float = hcl.Fixed(32,12) # for interface synthesis
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     if args.vitis:
         print("Use Vitis to compile")
         target.config(compile="vitis", mode="hw_exe", project="project-vitis")
@@ -180,7 +180,7 @@ def build_resnet20(input_image): # params are placeholders here
 
 def build_resnet20_inf(target=target):
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image], target.xcel)
         s.to(build_resnet20.fc, target.host)
 
@@ -291,7 +291,7 @@ def build_resnet20_stream_inf(target=target):
                      getattr(f,"layer{}_{}_residual2".format(layer,bb)),
                      depth=depth.value)
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image], target.xcel)
         s.to(build_resnet20.fc, target.host)
 

--- a/samples/bnn/resnet_const_aocl.py
+++ b/samples/bnn/resnet_const_aocl.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys
 from resnet_const_bn import *
 
-target = hcl.platform.vlab
+target = hcl.Platform.vlab
 target.config(compile="aocl", mode="hw_sim")
 if not args.opt:
     resnet20 = build_resnet20_inf(target)

--- a/samples/bnn/resnet_const_bn.py
+++ b/samples/bnn/resnet_const_bn.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 else: # vhls
     batch_size = 1
     qtype_float = hcl.Fixed(32,12) # for interface synthesis
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     if args.vitis:
         print("Use Vitis to compile")
         target.config(compile="vitis", mode="hw_exe", project="project-vitis")
@@ -206,7 +206,7 @@ def build_resnet20(input_image): # params are placeholders here
 
 def build_resnet20_inf(target=target):
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image], target.xcel)
         s.to(build_resnet20.fc, target.host)
 
@@ -317,7 +317,7 @@ def build_resnet20_stream_inf(target=target):
                      getattr(f,"layer{}_{}_residual2".format(layer,bb)),
                      depth=depth.value)
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image], target.xcel)
         s.to(build_resnet20.fc, target.host)
 

--- a/samples/bnn/resnet_main.py
+++ b/samples/bnn/resnet_main.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 else: # vhls
     batch_size = 1
     qtype_float = hcl.Fixed(32,12) # for interface synthesis
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     if args.vitis:
         print("Use Vitis to compile")
         target.config(compile="vitis", mode="hw_exe")
@@ -165,7 +165,7 @@ def build_resnet20(*params): # params are placeholders here
 
 def build_resnet20_inf(params, target=target):
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image] + hcl_ph, target.xcel)
         s.to(build_resnet20.fc, target.host)
 
@@ -239,7 +239,7 @@ def build_resnet20_stream_inf(params, target=target):
                 s.to(getattr(f,"layer{}_{}_rprelu1".format(layer,bb)),
                     getattr(f,"layer{}_{}_residual2".format(layer,bb)))
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image] + hcl_ph, target.xcel)
         s.to(build_resnet20.fc, target.host)
 

--- a/samples/bnn/resnet_main2.py
+++ b/samples/bnn/resnet_main2.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 else: # vhls
     batch_size = 1
     qtype_float = hcl.Fixed(32,12) # for interface synthesis
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     if args.vitis:
         print("Use Vitis to compile")
         target.config(compile="vitis", mode="hw_exe")
@@ -172,7 +172,7 @@ def build_resnet20(*params): # params are placeholders here
 
 def build_resnet20_inf(params, target=target):
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image] + hcl_ph, target.xcel)
         s.to(build_resnet20.fc, target.host)
 
@@ -246,7 +246,7 @@ def build_resnet20_stream_inf(params, target=target):
                 s.to(getattr(f,"layer{}_{}_rprelu1".format(layer,bb)),
                     getattr(f,"layer{}_{}_residual2".format(layer,bb)))
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image] + hcl_ph, target.xcel)
         s.to(build_resnet20.fc, target.host)
 

--- a/samples/bnn/resnet_packed.py
+++ b/samples/bnn/resnet_packed.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 else: # vhls
     batch_size = 1
     qtype_float = hcl.Fixed(32,12) # for interface synthesis
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     if args.vitis:
         print("Use Vitis to compile")
         target.config(compile="vitis", mode="hw_exe")
@@ -170,7 +170,7 @@ def build_resnet20(*params): # params are placeholders here
 
 def build_resnet20_inf(params, target=target):
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image] + hcl_ph, target.xcel)
         s.to(build_resnet20.fc, target.host)
 
@@ -246,7 +246,7 @@ def build_resnet20_stream_inf(params, target=target):
                 s.to(getattr(f,"layer{}_{}_rprelu1".format(layer,bb)),
                     getattr(f,"layer{}_{}_residual2".format(layer,bb)))
 
-    if isinstance(target,hcl.platform):
+    if isinstance(target,hcl.Platform):
         s.to([input_image] + hcl_ph, target.xcel)
         s.to(build_resnet20.fc, target.host)
 

--- a/samples/digitrec/digitrec_stream.py
+++ b/samples/digitrec/digitrec_stream.py
@@ -17,7 +17,7 @@ setting = {
   "clock"   : "10"
 }
 tool = hcl.tool.vivado("csim", setting)
-target = hcl.platform.aws_f1
+target = hcl.Platform.aws_f1
 
 def knn(test_images, train_images):
 

--- a/samples/flexcnn/flexcnn.py
+++ b/samples/flexcnn/flexcnn.py
@@ -824,7 +824,7 @@ def test_flexcnn():
 
     s = hcl.create_schedule(arg_list, top_module)
     print(hcl.lower(s))
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile='vitis', mode='debug')
     # p = "vhls"
 

--- a/samples/gemm/gemm_hbm.py
+++ b/samples/gemm/gemm_hbm.py
@@ -23,7 +23,7 @@ def gemm_hbm(m=1024, n=1024, k=1024, dtype=hcl.UInt(32)):
             hcl.dev.fpga("xilinx", "xcvu19p")
         ]
     }
-    target = hcl.platform.custom(config)
+    target = hcl.Platform.custom(config)
     target.config(compile="vitis", mode="hw_exe", backend="vhls")
 
     # block tiling and reorder

--- a/samples/gemm/gemm_vhls.py
+++ b/samples/gemm/gemm_vhls.py
@@ -21,7 +21,7 @@ def gemm_vhls(m=1024, n=1024, k=1024, dtype=hcl.Int()):
     x0, x1 = s[out_matrix].split(out_matrix.axis[1], factor=block_size)
     s[out_matrix].reorder(y0, x0, y1, x1)
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     s.to([matrix_1, matrix_2], target.xcel, local_buffer=False)
     s.to(kernel.out_matrix, target.host, local_buffer=False)
     target.config(compile="vivado_hls", mode="csim|csyn")

--- a/samples/kmeans/kmeans_vitis.py
+++ b/samples/kmeans/kmeans_vitis.py
@@ -63,7 +63,7 @@ def top(target=None):
 
     return hcl.build(s, target=target)
 
-p = hcl.platform.aws_f1
+p = hcl.Platform.aws_f1
 p.config(compile="vitis", mode="hw_exe")
 f = top(p)
 points_np = np.random.randint(100, size=(N, dim))

--- a/samples/lenet_systolic/flexcnn_conv.py
+++ b/samples/lenet_systolic/flexcnn_conv.py
@@ -14,7 +14,7 @@ def test_vadd_vhls(length):
         ret = hlib.ip.vadd(A, B, length, name="ret")
         return hcl.compute(A.shape, lambda *args: ret[args] * 2, "out")
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A, B], math_func)
     s.to([A, B, math_func.ret], target.xcel)
     s.to(math_func.vadd.ret, target.host)
@@ -59,7 +59,7 @@ def test_conv2d_nchw_systolic():
         return conv2d_nchw_systolic(Tensor, Weight)
 
     s = hcl.create_schedule([Tensor, Weight], conv2d_nchw)
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
 
     code = str(hcl.build(s, p))

--- a/samples/mapreduce/mapreduce.py
+++ b/samples/mapreduce/mapreduce.py
@@ -45,7 +45,7 @@ def kernel(inputs):
     hcl.mutate((class_number,), lambda x: reducer(ress, output, x), "reducer")
     return output
 
-target = hcl.platform.aws_f1
+target = hcl.Platform.aws_f1
 s = hcl.create_schedule([inputs], kernel)
 
 # new_inputs = s.to(inputs, target.xcel)

--- a/samples/sobel/sobel_aocl.py
+++ b/samples/sobel/sobel_aocl.py
@@ -35,7 +35,7 @@ def test_sobel_vivado_hls():
     # s[sobel.xx].pipeline(sobel.xx.axis[1])
     # s[sobel.yy].pipeline(sobel.yy.axis[1])
 
-    target = hcl.platform.zc706 
+    target = hcl.Platform.zc706 
     s.to([A,Gx,Gy], target.xcel) 
     s.to(sobel.Fimg, target.host)
 

--- a/samples/sobel/sobel_sdsoc.py
+++ b/samples/sobel/sobel_sdsoc.py
@@ -30,7 +30,7 @@ def sobel(A, Gx, Gy):
               lambda x, y :hcl.sqrt(B[x,y]*B[x,y] + C[x,y]*C[x,y])/4328*255,
               name="output", dtype=hcl.Float())
 
-target = hcl.platform.zc706
+target = hcl.Platform.zc706
 target.config(compile="sdsoc", mode="sw_sim")
 
 s = hcl.create_schedule([A,Gx,Gy], sobel)

--- a/samples/sobel/sobel_stream.py
+++ b/samples/sobel/sobel_stream.py
@@ -30,7 +30,7 @@ def sobel(A, Gx, Gy):
               lambda x, y :hcl.sqrt(B[x,y]*B[x,y] + C[x,y]*C[x,y])/4328*255,
               name="output", dtype=hcl.Float())
 
-target = hcl.platform.aws_f1
+target = hcl.Platform.aws_f1
 target.config(compile="vitis", backend="vhls")
 
 s = hcl.create_schedule([A,Gx,Gy], sobel)

--- a/samples/sobel/sobel_vhls.py
+++ b/samples/sobel/sobel_vhls.py
@@ -62,7 +62,7 @@ s[sobel.yy].pipeline(sobel.yy.axis[1])
 #                 for z in range (0, 3):
 #                         newimg[x,y,z]=npF[x,y]
 
-target = hcl.platform.zc706 
+target = hcl.Platform.zc706 
 s.to([A,Gx,Gy], target.xcel) 
 s.to(sobel.Fimg, target.host)
 target.config(compile= "vivado_hls" , mode= "debug" )

--- a/samples/stream/stream.py
+++ b/samples/stream/stream.py
@@ -1,7 +1,7 @@
 import heterocl as hcl
 
 hcl.init()
-target = hcl.platform.zc706
+target = hcl.Platform.zc706
 initiation_interval = 4
 
 a = hcl.placeholder((10, 20), name="a")

--- a/samples/systolic_array/systolic_array_autosa.py
+++ b/samples/systolic_array/systolic_array_autosa.py
@@ -5,9 +5,9 @@ import os
 import sys
 
 def autosa_systolic_array():
-    m=64
-    n=64
-    k=64
+    m=1024
+    n=1024
+    k=1024
     hcl.init()
     dtype=hcl.Int()
 

--- a/samples/systolic_array/systolic_array_autosa.py
+++ b/samples/systolic_array/systolic_array_autosa.py
@@ -23,7 +23,7 @@ def autosa_systolic_array():
                     with hcl.for_(0, k, name="k") as r:
                         Y[i][j] += A[i][r] * B[r][j]
 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
 
     # [Important] Note that you have to make sure `autosa` binary
     # in on the PATH, otherwise HCL runtime will only generate a 

--- a/samples/systolic_array/systolic_array_autosa.py
+++ b/samples/systolic_array/systolic_array_autosa.py
@@ -22,13 +22,14 @@ def autosa_systolic_array():
                     Y[i][j] = 0
                     with hcl.for_(0, k, name="k") as r:
                         Y[i][j] += A[i][r] * B[r][j]
+        return Y
 
-    p = hcl.Platform.aws_f1
+    p = hcl.Platform.u280
 
     # [Important] Note that you have to make sure `autosa` binary
     # in on the PATH, otherwise HCL runtime will only generate a 
     # function placeholder for the GEMM code
-    p.config(compile="vitis", mode="debug")
+    p.config(compile="vitis", mode="hw_sim")
     s = hcl.create_schedule([A, B], kernel)
     MM = kernel.Y
 
@@ -44,8 +45,17 @@ def autosa_systolic_array():
 
     # Pack the input tensors
     s.pack([MM.B, MM.A, MM.Y0], factor=512)
+
+    # Generate inputs
+    np_A = np.random.randint(10, size=(m,k))
+    np_B = np.random.randint(10, size=(k,n))
+    np_C = np.zeros((m,n))
+    args = (np_A, np_B, np_C)
+
+    # Print lowered IR and inspect code
     print(hcl.lower(s))
-    print(hcl.build(s, p))
+    f = hcl.build(s, target=p)
+    f.inspect(args)
 
 if __name__ == '__main__':
     autosa_systolic_array()

--- a/samples/systolic_array/systolic_array_module.py
+++ b/samples/systolic_array/systolic_array_module.py
@@ -97,7 +97,7 @@ def systolic(m=2, k=2, n=2, w=2, h=2, dtype=hcl.Int(), target=None):
     # systolic connection with .to()
     # s.to(k.input_b11, s[k.out_11])
 
-    if isinstance(target, hcl.platform):
+    if isinstance(target, hcl.Platform):
         s.to([Ain, Bin], target.xcel)
         s.to(systolic_array.update.Output, target.host)
         target.config(compile="vitis", mode="hw_exe")
@@ -125,7 +125,7 @@ hcl_m2 = hcl.asarray(np_2, dtype=dtype)
 hcl_m3 = hcl.asarray(np.zeros((m,n)), dtype=dtype)
 
 # systolic array
-target = hcl.platform.zc706
+target = hcl.Platform.zc706
 # target = "vhls_csim"
 # target = "llvm"
 # target = "vhls"

--- a/samples/systolic_array/systolic_array_module_stream.py
+++ b/samples/systolic_array/systolic_array_module_stream.py
@@ -117,7 +117,7 @@ def systolic(m=2, k=2, n=2, w=2, h=2, dtype=hcl.Int(), target=None):
             s.to(ta, s[k], s[k])
             s.to(tb, s[k], s[k])
 
-    if isinstance(target, hcl.platform):
+    if isinstance(target, hcl.Platform):
         s.to([Ain, Bin], target.xcel)
         s.to(systolic_array.update.Output, target.host)
         target.config(compile="vitis", mode="hw_exe")
@@ -144,7 +144,7 @@ hcl_m2 = hcl.asarray(np_2, dtype=dtype)
 hcl_m3 = hcl.asarray(np.zeros((m,n)), dtype=dtype)
 
 # systolic array
-target = hcl.platform.zc706
+target = hcl.Platform.zc706
 # target = "vhls_csim"
 # target = "llvm"
 # target = "vhls"

--- a/samples/systolic_array/systolic_array_vitis.py
+++ b/samples/systolic_array/systolic_array_vitis.py
@@ -56,7 +56,7 @@ hcl_m1 = hcl.asarray(np_1, dtype=dtype)
 hcl_m2 = hcl.asarray(np_2, dtype=dtype)
 hcl_m3 = hcl.asarray(np.zeros((m, n)), dtype=dtype)
 
-target = hcl.platform.aws_f1
+target = hcl.Platform.aws_f1
 target.config(compile="vitis", backend="vhls")
 fs = systolic(m, n, k, dtype=hcl.Int(), target=target)
 fs(hcl_m1, hcl_m2, hcl_m3)

--- a/tests/issues/test_issue_219.py
+++ b/tests/issues/test_issue_219.py
@@ -8,7 +8,7 @@ def test_partition_before_streaming():
         B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B", dtype=hcl.UInt(8))
         return B
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     s = hcl.create_schedule([A], kernel)
     s.partition(A, hcl.Partition.Block, dim=1, factor=2) 
     s.to(A, target.xcel)
@@ -23,7 +23,7 @@ def test_partition_after_streaming():
         B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B", dtype=hcl.UInt(8))
         return B
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     s = hcl.create_schedule([A], kernel)
     s.to(A, target.xcel)
     s.partition(A, hcl.Partition.Block, dim=1, factor=2) # memory optimization

--- a/tests/issues/test_issue_230.py
+++ b/tests/issues/test_issue_230.py
@@ -10,7 +10,7 @@ def test_reuse_before_streaming():
     s = hcl.create_schedule([A], kernel)
     kernel_B = kernel.B
     RB = s.reuse_at(A, s[kernel_B], kernel_B.axis[1])
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csim")
     s.to(kernel.B, target.xcel)
     s.to(kernel.C, target.host)
@@ -25,7 +25,7 @@ def test_reuse_after_streaming():
         C = hcl.compute((10, 8), lambda y, x: B[y, x] + B[y, x+1] + B[y, x+2], "C")
         return C
     s = hcl.create_schedule([A], kernel)
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csim")
     B_ = s.to(kernel.B, target.xcel)
     s.reuse_at(B_, s[kernel.C], kernel.C.axis[1])

--- a/tests/issues/test_issue_240.py
+++ b/tests/issues/test_issue_240.py
@@ -13,7 +13,7 @@ def test_partition():
         return C
     s = hcl.create_schedule(A, kernel)
     s.partition(kernel.B)
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls",mode="debug")
 
     print(hcl.build(s, target))

--- a/tests/issues/test_issue_260.py
+++ b/tests/issues/test_issue_260.py
@@ -12,7 +12,7 @@ def test_host_dtype():
         return hcl.compute((10,), lambda x: A[x] + 1, "B", dtype=qtype)
 
     s = hcl.create_schedule(A, kernel)
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vitis", mode="sw_sim", backend="vhls")
     f = hcl.build(s, target=target)
     hcl_A = hcl.asarray(np.random.randint(0, 10, A.shape), dtype=qtype)

--- a/tests/issues/test_issue_261.py
+++ b/tests/issues/test_issue_261.py
@@ -11,7 +11,7 @@ def test_vivado_hls():
     def kernel(A):
         return hcl.compute((10,10), lambda x, y: A[x][y] | 1, "B", dtype=qtype)
     s = hcl.create_schedule(A, kernel)
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csim|csyn")
     s.to(A, target.xcel)
     s.to(kernel.B,target.host)
@@ -33,7 +33,7 @@ def test_vitis():
     def kernel(A):
         return hcl.compute((10,10), lambda x, y: A[x][y] | 1, "B", dtype=qtype)
     s = hcl.create_schedule(A, kernel)
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vitis", mode="hw_exe")
     s.to(A, target.xcel)
     s.to(kernel.B,target.host)

--- a/tests/issues/test_issue_262.py
+++ b/tests/issues/test_issue_262.py
@@ -13,7 +13,7 @@ def test_inter_stage_stream():
         D = hcl.compute(B.shape, lambda i: C[i], "D")
         return D
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn")
     s = hcl.create_schedule([A], kernel)
 

--- a/tests/issues/test_issue_267.py
+++ b/tests/issues/test_issue_267.py
@@ -117,7 +117,7 @@ def systolic(m=2, k=2, n=2, w=2, h=2, dtype=hcl.Int(), target=None):
             s.to(ta, s[k], s[k])
             s.to(tb, s[k], s[k])
 
-    if isinstance(target, hcl.platform):
+    if isinstance(target, hcl.Platform):
         s.to([Ain, Bin], target.xcel)
         s.to(systolic_array.update.Output, target.host)
         target.config(compile="vitis", mode="debug")
@@ -146,7 +146,7 @@ def test_systolic_array():
     hcl_m3 = hcl.asarray(np.zeros((m,n)), dtype=dtype)
     
     # systolic array
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     # target = "vhls_csim"
     # target = "llvm"
     # target = "vhls"

--- a/tests/issues/test_issue_270.py
+++ b/tests/issues/test_issue_270.py
@@ -16,7 +16,7 @@ def test_duplicated():
                 lambda i: B[i] + 1, "C")
         return C
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn")
     s = hcl.create_schedule([A], kernel)
     s.to([A], target.xcel)

--- a/tests/issues/test_issue_271.py
+++ b/tests/issues/test_issue_271.py
@@ -23,7 +23,7 @@ def test_imperative():
 
     s = hcl.create_schedule([A], kernel)
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls",mode="csyn")
     s.to(A, target.xcel)
     s.to(kernel.C, target.host)

--- a/tests/issues/test_issue_273.py
+++ b/tests/issues/test_issue_273.py
@@ -21,7 +21,7 @@ def test_conv2():
     s.partition(F, hcl.Partition.Cyclic, factor=3, dim=1) # different dimensions
     s[kernel.B].pipeline(kernel.B.axis[1])
     
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls",mode="csyn")
     f = hcl.build(s, target=target)
     hcl_A = hcl.asarray(np.random.randint(0, 10, A.shape))

--- a/tests/issues/test_issue_274.py
+++ b/tests/issues/test_issue_274.py
@@ -63,7 +63,7 @@ def test_offload_entire_program():
         return 
 
     hcl.init()
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csyn")
     f = top(target)
 
@@ -91,7 +91,7 @@ def test_disconnect_dfg():
         return hcl.compute((10,32), lambda *args: 1, "O")
 
     s = hcl.create_schedule([A, B], kernel)
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csyn")
     f = hcl.build(s, target)
 

--- a/tests/issues/test_issue_277.py
+++ b/tests/issues/test_issue_277.py
@@ -64,7 +64,7 @@ def test_offload_entire_program_burst():
         return 
 
     hcl.init()
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vitis", mode="hw_exe")
     f = top(target)
 
@@ -139,7 +139,7 @@ def test_offload_entire_program():
         return 
 
     hcl.init()
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csyn")
     f = top(target)
 
@@ -167,7 +167,7 @@ def test_disconnect_dfg():
         return hcl.compute((10,32), lambda *args: 1, "O")
 
     s = hcl.create_schedule([A, B], kernel)
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csyn")
 
     s.to(A, target.xcel)

--- a/tests/issues/test_issue_281.py
+++ b/tests/issues/test_issue_281.py
@@ -13,7 +13,7 @@ def test_inter_stage_stream():
         D = hcl.compute(B.shape, lambda i: C[i], "D")
         return D
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn")
     s = hcl.create_schedule([A], kernel)
 

--- a/tests/issues/test_issue_283.py
+++ b/tests/issues/test_issue_283.py
@@ -11,7 +11,7 @@ def test_pipe():
                 module=True, inputs=[B])
         return C
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn")
     s = hcl.create_schedule([A], kernel)
 

--- a/tests/issues/test_issue_284.py
+++ b/tests/issues/test_issue_284.py
@@ -15,7 +15,7 @@ def test_condition_pipe():
                 lambda i: hcl.select(i < 10, B[i], 0),"C")
         return C
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn")
     s = hcl.create_schedule([A], kernel)
 
@@ -40,7 +40,7 @@ def test_zero():
         D = hcl.compute(A.shape, lambda i: C2[i] + 1, "D")
         return D
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csim")
     s = hcl.create_schedule([A], kernel)
 

--- a/tests/issues/test_issue_286.py
+++ b/tests/issues/test_issue_286.py
@@ -13,7 +13,7 @@ def test_tile():
         C = hcl.compute(A.shape, lambda *i: B[i] * 2, "C")
         return C
 
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn")
     s = hcl.create_schedule([A], kernel)
 

--- a/tests/issues/test_issue_297.py
+++ b/tests/issues/test_issue_297.py
@@ -39,11 +39,11 @@ def test_vecadd_sim(length=32, sim=False):
 
         return hcl.compute(A.shape, lambda *args: ret[args] * 2, "out")
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A, B], math_func)
 
     # test ir correctness 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
     code = str(hcl.build(s, p)); print(code)
     pattern = "vec_add(C, B, ret, {});".format(length)

--- a/tests/issues/test_issue_308.py
+++ b/tests/issues/test_issue_308.py
@@ -24,7 +24,7 @@ def test_consec_move():
         return hcl.compute((30,), lambda x: hcl.sum(X[x+k]*W[k], axis=k), "Y")
     
     s = hcl.create_schedule([W, X], kernel)
-    p = hcl.platform.zc706
+    p = hcl.Platform.zc706
 
     pes = s.parallel(kernel.Y, axis=kernel.Y.axis[1])
     pe1, pe2, pe3 = pes

--- a/tests/issues/test_issue_320.py
+++ b/tests/issues/test_issue_320.py
@@ -391,7 +391,7 @@ def main():
         s[toptop.mainloop.densestage].unroll(toptop.mainloop.densestage.densem)
         s[toptop.mainloop.densestage].unroll(toptop.mainloop.densestage.densen)
 
-    p = hcl.platform.zc706
+    p = hcl.Platform.zc706
     p.config(compile="vivado_hls", mode="csyn")
 
     print(hcl.lower(s))

--- a/tests/issues/test_issue_335.py
+++ b/tests/issues/test_issue_335.py
@@ -7,13 +7,13 @@ def test_aws_runtime(dtype=hcl.Int()):
     A = hcl.placeholder((2, 3), "A", dtype)
     B = hcl.placeholder((2, 3), "B", dtype)
 
-    def kernel_gemm(A, B):
+    def pw_mul(A, B):
         return hcl.compute((2, 3),
                 lambda x, y: A[x, y] * B[x, y], dtype = dtype, name = "C")
 
-    s = hcl.create_schedule([A, B], kernel_gemm)
+    s = hcl.create_schedule([A, B], pw_mul)
     target = hcl.Platform.aws_f1
-    target.config(compile="vitis", mode="hw_sim")
+    target.config(compile="vitis", mode="hw_sim", project="test_aws")
     f = hcl.build(s, target=target)
 
     # Requires AWS CLI package
@@ -21,8 +21,8 @@ def test_aws_runtime(dtype=hcl.Int()):
         return
 
     np_A = np.random.randint(10, size=(2,3))
-    np_B = np.random.randint(10, size=(3,5))
-    np_C = np.zeros((2,5))
+    np_B = np.random.randint(10, size=(2,3))
+    np_C = np.zeros((2,3))
     args = (np_A, np_B, np_C)
 
     # Generate local projects
@@ -30,10 +30,48 @@ def test_aws_runtime(dtype=hcl.Int()):
 
     # Compile FPGA binary
     key_path = "/home/sx233/aws-sx233-test.pem"
-    f.compile(args, remote=True, aws_key_path=key_path)
+    f.compile(args, remote=True, 
+        aws_key_path=key_path, instance="t2.2xlarge")
 
     # Execute bitstream on board
-    f.execute(args, remote=True, aws_key_path=key_path)
+    f.execute(args, remote=True, 
+        aws_key_path=key_path, instance="f1.2xlarge")
+
+
+def test_vitis_runtime(dtype=hcl.Int()):
+    hcl.init(dtype)
+    A = hcl.placeholder((2, 3), "A", dtype)
+    B = hcl.placeholder((2, 3), "B", dtype)
+
+    def pw_mul(A, B):
+        return hcl.compute((2, 3),
+                lambda x, y: A[x, y] * B[x, y], dtype = dtype, name = "C")
+
+    s = hcl.create_schedule([A, B], pw_mul)
+    target = hcl.Platform.u280
+    target.config(compile="vitis", mode="hw_sim")
+    f = hcl.build(s, target=target)
+
+    # Requires AWS CLI package
+    if os.system("which v++ >> /dev/null") != 0:
+        return
+
+    np_A = np.random.randint(10, size=(2,3))
+    np_B = np.random.randint(10, size=(2,3))
+    np_C = np.zeros((2,3))
+    args = (np_A, np_B, np_C)
+
+    # Generate local projects
+    f.inspect(args)
+
+    # Compile FPGA binary
+    xpfm = "/opt/xilinx/platforms/xilinx_u280_xdma_201920_3/xilinx_u280_xdma_201920_3.xpfm"
+    f.compile(args, xpfm=xpfm)
+
+    # Execute bitstream on board
+    outputs, rpt = f.execute(args)
+    print(rpt)
 
 if __name__ == "__main__":
+    test_vitis_runtime()
     test_aws_runtime()

--- a/tests/issues/test_issue_335.py
+++ b/tests/issues/test_issue_335.py
@@ -1,0 +1,25 @@
+import heterocl as hcl
+import os
+
+def test_aws_runtime(dtype=hcl.Int()):
+    hcl.init(dtype)
+    A = hcl.placeholder((2, 3), "A")
+    B = hcl.placeholder((3, 5), "B")
+    C = hcl.placeholder((2, 5), "C")
+
+    def kernel_gemm(A, B, C):
+        r = hcl.reduce_axis(0, 3, "r")
+        out_AB = hcl.compute((2, 3),
+                lambda x, y: hcl.sum(2 * A[x, r] * B[r, y],
+                axis = r, dtype = dtype), name = "out_AB")
+        hcl.update(C, lambda x, y: 3 * C[x, y] + out_AB[x, y], name = "C1")
+
+    s = hcl.create_schedule([A, B, C], kernel_gemm)
+    target = hcl.Platform.aws_f1
+    f = hcl.build(s, target=target)
+
+    if os.system("which aws >> /dev/null") != 0:
+        return 
+    f.compile(remote=True, aws_key_path=None)
+
+test_aws_runtime()

--- a/tests/issues/test_issue_335.py
+++ b/tests/issues/test_issue_335.py
@@ -13,7 +13,7 @@ def test_aws_runtime(dtype=hcl.Int()):
 
     s = hcl.create_schedule([A, B], kernel_gemm)
     target = hcl.Platform.aws_f1
-    target.config(compile="vitis", mode="sw_sim")
+    target.config(compile="vitis", mode="hw_sim")
     f = hcl.build(s, target=target)
 
     # Requires AWS CLI package
@@ -23,10 +23,17 @@ def test_aws_runtime(dtype=hcl.Int()):
     np_A = np.random.randint(10, size=(2,3))
     np_B = np.random.randint(10, size=(3,5))
     np_C = np.zeros((2,5))
-    f(np_A, np_B, np_C)
+    args = (np_A, np_B, np_C)
 
+    # Generate local projects
+    f.inspect(args)
+
+    # Compile FPGA binary
     key_path = "/home/sx233/aws-sx233-test.pem"
     f.compile(args, remote=True, aws_key_path=key_path)
+
+    # Execute bitstream on board
+    f.execute(args, remote=True, aws_key_path=key_path)
 
 if __name__ == "__main__":
     test_aws_runtime()

--- a/tests/test_codegen_autosa.py
+++ b/tests/test_codegen_autosa.py
@@ -23,7 +23,7 @@ def test_autosa_basic():
                     with hcl.for_(0, k) as r:
                         Y[i][j] += A[i][r] * B[r][j]
 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([A, B], kernel)
 
@@ -58,7 +58,7 @@ def test_autosa_pack():
                     with hcl.for_(0, k) as r:
                         Y[i][j] += A[i][r] * B[r][j]
 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([A, B], kernel)
 

--- a/tests/test_codegen_vhls.py
+++ b/tests/test_codegen_vhls.py
@@ -155,7 +155,7 @@ def test_select_type_cast():
         s = hcl.create_scheme(A, kernel)
         s = hcl.create_schedule_from_scheme(s)
         code = hcl.build(s, target="vhls")
-        assert "(uint)0U)" in code
+        assert "(unsigned int)0U)" in code
 
     def test_binary_ops():
         A = hcl.placeholder((8, 8), "A", dtype=hcl.Int(20))

--- a/tests/test_runtime_build.py
+++ b/tests/test_runtime_build.py
@@ -23,7 +23,7 @@ def test_debug_asic_target():
             hcl.dev.asic("xilinx")
         ]
     }
-    p = hcl.platform.custom(config)
+    p = hcl.Platform.custom(config)
     s = hcl.create_schedule([A, B], kernel)
     p.config(compile="vitis", mode="debug", backend="vhls")
     code = hcl.build(s, p)
@@ -39,7 +39,7 @@ def test_debug_mode():
         return D
 
     def test_sdaccel_debug():
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.B, target.xcel)
         s.to(kernel.C, target.host)
@@ -49,7 +49,7 @@ def test_debug_mode():
         assert "cl::Kernel kernel(program, \"test\", &err)" in code
 
     def test_vhls_debug():
-        target = hcl.platform.zc706
+        target = hcl.Platform.zc706
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.B, target.xcel)
         s.to(kernel.C, target.host)
@@ -74,7 +74,7 @@ def test_vivado_hls():
             D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
             return D
         
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.B, target.xcel)
         s.to(kernel.C, target.host)
@@ -112,7 +112,7 @@ def test_mixed_stream():
         E = hcl.compute(C.shape, lambda i, j: D[i][j] * 3, "E")
         return E
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A, B], kernel)
 
     s.to([A, B], target.xcel)
@@ -146,7 +146,7 @@ def test_vitis():
             D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
             return D
         
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.B, target.xcel)
         s.to(kernel.C, target.host)
@@ -173,7 +173,7 @@ def test_vitis():
             D = hcl.compute(C.shape, lambda i, j: C[i,j] + 1, "D")
             return D
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         target.config(compile="vitis", mode="sw_sim")
         s = hcl.create_schedule([A, B], kernel)
         s.to(A, target.xcel, mode=hcl.IO.FIFO)
@@ -208,7 +208,7 @@ def test_xilinx_sdsoc():
             D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
             return D
         
-        target = hcl.platform.zc706
+        target = hcl.Platform.zc706
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.B, target.xcel)
         s.to(kernel.C, target.host)
@@ -238,7 +238,7 @@ def test_intel_aocl():
         D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
         return D
     
-    target = hcl.platform.vlab
+    target = hcl.Platform.vlab
     s = hcl.create_schedule([A], kernel)
     s.to(A, target.xcel)
     s.to(kernel.C, target.host)
@@ -271,7 +271,7 @@ def test_project():
         C = hcl.compute((M, N), lambda x, y: hcl.sum(A[x, k] * B[k, y], axis=k, dtype=dtype), "C", dtype=dtype)
         return C
     
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn", project="gemm")
 
     def make_schedule(opt=False):

--- a/tests/test_runtime_build.py
+++ b/tests/test_runtime_build.py
@@ -3,33 +3,42 @@ from itertools import permutations
 import os
 import numpy as np
 
-# note that here we still consider the ASIC
-# target to have a host which acts as a centralized controller
-# the host does not have to be a standalone CPU (e.g. 
-# ROCC interfaced RSIC-V processor in this example) 
-# it can also be part of the ASIC chip controlling other part
-def test_debug_asic_target():
+# User need to configure AWS CLI ahead of time
+def test_aws_remote_execution():
+    return 
     hcl.init()
     A = hcl.placeholder((10, 32), "A")
-    B = hcl.placeholder((10, 32), "B")
-    def kernel(A, B):
-        C = hcl.compute(A.shape, lambda i, j: A[i,j] + B[i,j], "C")
-        D = hcl.compute(C.shape, lambda i, j: C[i,j] + 1, "D")
+
+    def kernel(A):
+        B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B")
+        C = hcl.compute(A.shape, lambda *args : B[args] + 1, "C")
+        D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
         return D
 
-    config = {
-        "host" : hcl.dev.cpu("riscv"),
-        "xcel" : [
-            hcl.dev.asic("xilinx")
-        ]
-    }
-    p = hcl.Platform.custom(config)
-    s = hcl.create_schedule([A, B], kernel)
-    p.config(compile="vitis", mode="debug", backend="vhls")
-    code = hcl.build(s, p)
+    target = hcl.Platform.aws_f1
+    s = hcl.create_schedule([A], kernel)
+    s.to(kernel.B, target.xcel)
+    s.to(kernel.C, target.host)
+    target.config(compile="vitis", mode="sw_sim")
+
+    # Prepare input data
+    np_A = np.random.randint(10, size=(10,32))
+    np_B = np.zeros((10,32))
+
+    # Run simulation locally
+    f = hcl.build(s, target)
+    hcl_A = hcl.asarray(np_A)
+    hcl_B = hcl.asarray(np_B, dtype=hcl.Int(32))
+    f(hcl_A, hcl_B)
+
+    # Run simulation on AWS FPGA instance
+    with hcl.env.aws(image="ami-0cb13f44051292b93", type="t2.micro"):
+        f = hcl.build(s, target)
+        hcl_A = hcl.asarray(np_A)
+        hcl_B = hcl.asarray(np_B, dtype=hcl.Int(32))
+        f(hcl_A, hcl_B)
 
 def test_debug_mode():
-
     hcl.init()
     A = hcl.placeholder((10, 32), "A")
     def kernel(A):
@@ -303,7 +312,6 @@ def test_project():
     assert os.path.isdir("gemm-s2/out.prj")
 
 if __name__ == '__main__':
-    test_debug_asic_target()
     test_debug_mode()
     test_vivado_hls()
     test_mixed_stream()

--- a/tests/test_schedule_layout.py
+++ b/tests/test_schedule_layout.py
@@ -23,7 +23,7 @@ def test_kernel_in_kernel():
         C = hcl.compute((10,), lambda x: A[x] + B[x], "C")
         hcl.update(C, lambda x: popcount(C[x]), "updateC")
 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([A, B], kernel)   
 
@@ -51,7 +51,7 @@ def test_tensor_layout():
                     with hcl.for_(0, k, name="k") as r:
                         Y[i][j] += A[i][r] * B[r][j]
 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([A, B], kernel)
 

--- a/tests/test_schedule_stream.py
+++ b/tests/test_schedule_stream.py
@@ -830,7 +830,6 @@ def test_host_to_device_stream():
     s.to(A, s[kernel.B])
 
 def test_stream_multi_buffer_access():
-
     def _test_invalid_stream_pattern():
         A = hcl.placeholder((10,), "A")
         def kernel(A):
@@ -889,7 +888,6 @@ if __name__ == '__main__':
     test_extern_ops()
     test_inner_loop_body_placement()
     test_stages_one_to_many()
-    test_kernel_multicast()
     test_mixed_stream()
     test_kernel_duplicate()
     test_stream_advanced_features()

--- a/tests/test_schedule_stream.py
+++ b/tests/test_schedule_stream.py
@@ -15,7 +15,7 @@ def test_placeholders():
             hcl.update(B, lambda i, j: B[i, j] * 2, "update2")
             return B
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to(A, target.xcel)
         s.to(kernel.update1.B, target.host)
@@ -32,7 +32,7 @@ def test_placeholders():
             hcl.update(A, lambda i, j: A[i, j] + 1, "update1")
             hcl.update(A, lambda i, j: A[i, j] * 2, "update2")
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to(A, target.xcel)
         s.to(kernel.update1.A, target.host)
@@ -51,7 +51,7 @@ def test_placeholders():
             D = hcl.compute(C.shape, lambda i, j: B[i,j] + 1, "D")
             return hcl.compute(C.shape, lambda i, j: C[i,j] + D[i,j], "E")
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A, B], kernel)
         s.to([A, B], target.xcel)
         s.to([kernel.C, kernel.D], target.host)
@@ -72,7 +72,7 @@ def test_extern_ops():
         D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
         return D
     
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A], kernel)
     s.to(kernel.B, target.xcel)
     s.to(kernel.C, target.host)
@@ -96,7 +96,7 @@ def test_inner_loop_body_placement():
                         C[i, j] = 2 * B[i, j]
             return C
         
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A, B], kernel)
 
         stage = kernel.stage
@@ -115,7 +115,7 @@ def test_inner_loop_body_placement():
             C = hcl.compute(A.shape, lambda *args : A[args] * 4, "C")
             return C
         
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to(kernel.C, target.xcel, axis=1)
         code = str(hcl.lower(s))
@@ -128,7 +128,7 @@ def test_inner_loop_body_placement():
             C = hcl.compute(A.shape, lambda *args : A[args] * 4, "C")
             return C
         
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
 
         stage = kernel.C
@@ -152,7 +152,7 @@ def test_stages_one_to_many():
         E = hcl.compute(C.shape, lambda i, j: C[i][j] * 2, "E")
         return D, E
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A, B], kernel)
     s.to(kernel.C, s[kernel.D])
     s.to(kernel.C, s[kernel.E])
@@ -172,7 +172,7 @@ def test_mixed_stream():
         D = hcl.compute(C.shape, lambda i, j: C[i][j], "D")
         return D
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A, B], kernel)
 
     s.to([A, B], target.xcel)
@@ -197,7 +197,7 @@ def test_fork_join():
             E = hcl.compute(C.shape, lambda i, j: C[i,j] * 2, "E")
             return D, E
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A, B], kernel)
         s.fork(kernel.C, [kernel.D, kernel.E])
         code = str(hcl.lower(s))
@@ -216,7 +216,7 @@ def test_fork_join():
             hcl.update(C, lambda i, j: B[i,j] * 2, "s2")
             return hcl.compute(C.shape, lambda *args: C[args] + 3, "ret")
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A, B], kernel)
 
         s.to(kernel.s1.C, kernel.ret.C)
@@ -242,7 +242,7 @@ def test_kernel_duplicate():
             hcl.update(C, lambda i, j: B[i,j] * 2, "s2")
             return hcl.compute(C.shape, lambda *args: C[args] + 3, "ret")
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A, B], kernel)
 
         s.to([A, B], target.xcel)
@@ -271,7 +271,7 @@ def test_kernel_duplicate():
             hcl.update(C, lambda i, j: B[i,j] * 2, "s2")
             return hcl.compute(C.shape, lambda *args: C[args] + 3, "ret")
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A, B], kernel)
 
         s.to([A, B], target.xcel)
@@ -302,7 +302,7 @@ def test_stream_advanced_features():
             ]
         }
 
-        p = hcl.platform.custom(config)
+        p = hcl.Platform.custom(config)
         s = hcl.create_schedule([A, B], kernel)
         s.to(A, p.xcel.HBM[0])
         s.to(B, p.xcel.HBM[1])
@@ -329,7 +329,7 @@ def test_stream_advanced_features():
             ]
         }
 
-        p = hcl.platform.custom(config)
+        p = hcl.Platform.custom(config)
         s = hcl.create_schedule([A, B], kernel)
         s.to(A, p.devs[1])
         s.to(B, p.devs[2])
@@ -347,7 +347,7 @@ def test_stream_advanced_features():
             D = hcl.compute(C.shape, lambda i, j: C[i,j] + 1, "D")
             return D
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         target.config(compile="vitis", mode="debug")
         s = hcl.create_schedule([A, B], kernel)
 
@@ -368,7 +368,7 @@ def test_stream_advanced_features():
             C = hcl.compute((8, 8), lambda y, x: B[y, x] + B[y+1, x] + B[y+2, x], "C")
             return C
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         target.config(compile="vitis", mode="debug", backend="vhls")
         s = hcl.create_schedule([A], stencil)
 
@@ -407,9 +407,9 @@ def test_stream_advanced_features():
             ]
         }
 
-        p = hcl.platform.custom(config)
+        p = hcl.Platform.custom(config)
         s = hcl.create_schedule([A, B], kernel)
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         target.config(compile="vitis", mode="debug")
         s = hcl.create_schedule([A, B], kernel)
 
@@ -440,7 +440,7 @@ def test_mem_customization():
                     name="B", dtype=hcl.UInt(8))
             return B
     
-        target = hcl.platform.zc706
+        target = hcl.Platform.zc706
         s = hcl.create_schedule([A], kernel)
 
         s.to(A, target.xcel)
@@ -469,7 +469,7 @@ def test_mem_customization():
             return C
         s = hcl.create_schedule([A], kernel)
         kernel_B = kernel.B
-        target = hcl.platform.zc706
+        target = hcl.Platform.zc706
         target.config(compile="vivado_hls",mode="csim")
 
         # RB = s.reuse_at(A, s[kernel_B], kernel_B.axis[1])
@@ -488,7 +488,7 @@ def test_mem_customization():
             D = hcl.compute((10, 8), lambda y, x: C[y, x], name="D")
             return D
         s = hcl.create_schedule([A], kernel)
-        target = hcl.platform.zc706
+        target = hcl.Platform.zc706
         target.config(compile="vivado_hls",mode="csim")
 
         s[kernel.B].compute_at(s[kernel.C], kernel.C.axis[1])
@@ -506,7 +506,7 @@ def test_mem_customization():
             C = hcl.compute((10, 8), lambda y, x: B[y, x] + B[y, x+1] + B[y, x+2], "C")
             return C
         s = hcl.create_schedule([A], kernel)
-        target = hcl.platform.zc706
+        target = hcl.Platform.zc706
         target.config(compile="vivado_hls",mode="csim")
 
         s.to(kernel.B, target.xcel)
@@ -531,7 +531,7 @@ def test_dataflow_graph():
         F = hcl.compute((10, 30), lambda y, x: E[y, x] + E[y, x+1] + E[y, x+2], "F")
         return F
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     # E.reuse.partition is atatched to F
     s = hcl.create_schedule([A, B, C], kernel)
     RB = s.reuse_at(kernel.E, s[kernel.F], kernel.F.axis[1])
@@ -562,7 +562,7 @@ def test_subgraph():
         F = hcl.compute((10, 30), lambda y, x: E[y, x] + E[y, x+1] + E[y, x+2], "F")
         return F
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     # E.reuse.partition is atatched to F
     s = hcl.create_schedule([A, B, C], kernel)
     RB = s.reuse_at(kernel.E, s[kernel.F], kernel.F.axis[1])
@@ -613,7 +613,7 @@ def test_sobel_vivado_hls():
     s[sobel.xx].pipeline(sobel.xx.axis[1])
     s[sobel.yy].pipeline(sobel.yy.axis[1])
 
-    target = hcl.platform.zc706 
+    target = hcl.Platform.zc706 
     s.to([A,Gx,Gy], target.xcel) 
     s.to(sobel.Fimg, target.host)
 
@@ -624,7 +624,7 @@ def test_super_stage():
     hcl.init()
     A = hcl.placeholder((10, 32), "A")
     B = hcl.placeholder((10, 32), "B")
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
 
     def kernel(A, B):
         C = hcl.compute((10, 32), lambda *args : A[args] + B[args], "C")
@@ -700,7 +700,7 @@ def test_inter_stage_streaming():
         D = hcl.compute(C.shape, lambda i, j: C[i][j], "D")
         return D
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A, B], kernel)
     s.to(kernel.C, s[kernel.D])
     code = str(hcl.lower(s))
@@ -719,7 +719,7 @@ def test_one_stage_on_dev():
         C = hcl.compute((M, N), lambda x, y: hcl.sum(A[x, k] * B[k, y], axis=k, dtype=dtype), "C", dtype=dtype)
         return C
     
-    target = hcl.platform.zc706
+    target = hcl.Platform.zc706
     target.config(compile="vivado_hls", mode="csyn", project="gemm")
 
     s = hcl.create_schedule([A, B], kernel)
@@ -736,7 +736,7 @@ def test_auto_move_to_dev():
         D = hcl.compute(C.shape, lambda i, j: C[i][j], "D")
         return D
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="debug", project="gemm")
 
     s = hcl.create_schedule([A, B], kernel)
@@ -756,7 +756,7 @@ def test_vhls_host_dtype():
         B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B", dtype=dtype)
         return B
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csim", project="test")
     s = hcl.create_schedule([A], kernel)
     f = hcl.build(s, target)
@@ -777,7 +777,7 @@ def test_vhls_kernel_interface_naming():
         B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B.1", dtype=dtype)
         return B
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csim", project="test")
     s = hcl.create_schedule([A], kernel)
     f = hcl.build(s, target)
@@ -800,7 +800,7 @@ def test_inter_stage_consective_streaming():
         D = hcl.compute(A.shape, lambda *args : C[args] + 1, "D", dtype=dtype)
         return D
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vivado_hls", mode="csim", project="test")
 
     s = hcl.create_schedule([A], kernel)
@@ -840,7 +840,7 @@ def test_stream_multi_buffer_access():
                     lambda i: hcl.select(i < 9, B[i] + B[i+1], B[i]),"C")
             return C
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to([A], target.xcel)
         s.to(kernel.C, target.host)
@@ -860,7 +860,7 @@ def test_stream_multi_buffer_access():
             C = hcl.compute(B.shape, lambda i: hcl.select(i < 9, B[i]+1, B[i]),"C")
             return C
 
-        target = hcl.platform.aws_f1
+        target = hcl.Platform.aws_f1
         s = hcl.create_schedule([A], kernel)
         s.to([A], target.xcel)
         s.to(kernel.C, target.host)

--- a/tests/test_schedule_systolic.py
+++ b/tests/test_schedule_systolic.py
@@ -28,7 +28,7 @@ def test_autosa_schedule():
         #     hcl.sum(matrix_1[x, r] * matrix_2[r, y], axis=r, dtype=dtype),
         #         dtype=dtype, name="Y")
 
-    p = hcl.platform.aws_f1
+    p = hcl.Platform.aws_f1
     p.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
 
@@ -86,7 +86,7 @@ def test_autosa_gemm():
         #     hcl.sum(matrix_1[x, r] * matrix_2[r, y], axis=r, dtype=dtype),
         #         dtype=dtype, name="Y")
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
 
@@ -104,7 +104,7 @@ def test_basic_streaming():
         C = hcl.compute(A.shape, lambda *args : B[args] + A[args], "C")
         return C
    
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     target.config(compile="vitis", mode="debug")
     s = hcl.create_schedule([A, B], kernel)
 
@@ -154,7 +154,7 @@ def test_static_variable():
         k = hcl.reduce_axis(0, 3, "k")
         return hcl.compute((30,), lambda x: hcl.sum(X[x+k]*W[k], axis=k), "Y")
     
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     sch = hcl.create_schedule([W, X], kernel)
 
     # The loop reorder seems not to work on imperfect loops
@@ -193,7 +193,7 @@ def test_weight_stationary_sa():
              hcl.dev.fpga("xilinx", "xcvu19p")
         ]
     }
-    p = hcl.platform.custom(config)
+    p = hcl.Platform.custom(config)
     p.config(compile="vitis", mode="debug", backend="vhls")
     s = hcl.create_schedule([W, X], kernel)
 
@@ -233,7 +233,7 @@ def test_inter_module_stream():
         add(A, B)
         mul(B, C)
 
-    target = hcl.platform.aws_f1
+    target = hcl.Platform.aws_f1
     s = hcl.create_schedule([A], kernel)
     
     # Stream one kernel's output to another's input

--- a/tutorials/tutorial_10_placement.py
+++ b/tutorials/tutorial_10_placement.py
@@ -35,13 +35,13 @@ s = hcl.create_schedule([matrix_1, matrix_2], kernel)
 ##############################################################################
 # Move tensor to device
 # -----------------------
-# HeteroCL has many built-in platforms (including aws_f1, zc706, stratix10, e.t.c). 
-# Here we use the zc706 platform as an example. The zc706 platform is associated with 
+# HeteroCL has many built-in Platforms (including aws_f1, zc706, stratix10, e.t.c). 
+# Here we use the zc706 Platform as an example. The zc706 Platform is associated with 
 # Vivado HLS tool by default. By using .to() primitives, tensors will be moved into device 
 # scope, and all computations depending on these tensors will be performed on FPGA. 
 # Note that you also need to move the result tensor back to host. 
 
-target = hcl.platform.zc706
+target = hcl.Platform.zc706
 s.to([matrix_1, matrix_2], target.xcel)
 s.to(kernel.out_matrix, target.host)
 target.config(compile="vivado_hls", mode="csyn")

--- a/tutorials/tutorial_11_streaming.py
+++ b/tutorials/tutorial_11_streaming.py
@@ -41,7 +41,7 @@ config = {
 }
 
 mode = "debug" if os.system("which v++ >> /dev/null") != 0 else "hw_exe"
-target = hcl.platform.custom(config)
+target = hcl.Platform.custom(config)
 target.config(compile="vitis", mode="hw_exe")
 
 s.to([vector_1, vector_2], target.xcel, mode=hcl.IO.Stream)

--- a/tvm/src/codegen/build_common.cc
+++ b/tvm/src/codegen/build_common.cc
@@ -96,6 +96,8 @@ class SimModuleNode final : public ModuleNode {
           GenJSONInputs(args, arg_names_, arg_sizes, arg_types, options_["project"]);
           LOG(CLEAN) << "Generating kernel code (harness files copied) ...";
           GenKernelCode(dev_, arg_names_, platform_, options_["backend"], options_["project"]); 
+          // Generate configuration
+          GenConfigCode(cfg_, platform_, options_["project"]);
           return;       
 
         } else if (code == "execute") {

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -423,6 +423,19 @@ void PrintCopyBack(TVMArray* arr,
   stream << "  document[\"" << arg_names[nth_arr] << "\"] = v_" << arg_names[nth_arr] << ";\n";
 }
 
+// Generate config code (TCL/INI e.t.c)
+void GenConfigCode(std::string& test_file, 
+    std::string platform, std::string project) {
+  if (test_file.find_first_not_of(" \t\n") == std::string::npos) return;
+  if (platform == "vitis") {
+    std::ofstream stream;
+    std::string config_ext = "ini";
+    stream.open(project + "/config." + config_ext);
+    stream << test_file;
+    stream.close();
+  }
+}
+
 // generate kernel code into files 
 void GenKernelCode(std::string& test_file, std::vector<std::string> arg_names, 
                    std::string platform, std::string backend, std::string project) {
@@ -570,17 +583,27 @@ using namespace rapidjson;
 
     stream << R"(
 
-#define CHECK(status) 							\
-    if (status != CL_SUCCESS)						\
-{									\
+#define CHECK(status) 							                              \
+    if (status != CL_SUCCESS)						                          \
+{									                                                \
     fprintf(stderr, "error %d in line %d.\n", status, __LINE__);	\
-    exit(1);								\
-}									\
+    exit(1);								                                      \
+}									                                                \
 
 void* acl_aligned_malloc (size_t size) {
   void *result = NULL;
   posix_memalign (&result, 64, size);
   return result;
+}
+
+double compute_kernel_execution_time(cl_event &event, double &start_d, double &end_d)
+{
+    cl_ulong start, end;
+    clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &end, NULL);
+    clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &start, NULL);
+    start_d = (double)1.0e-9 * start;
+    end_d   = (double)1.0e-9 * end;
+    return 	(double)1.0e-9 * (end - start); // nanoseconds to seconds
 }
 
 )";
@@ -798,19 +821,19 @@ void GenHostCode(TVMArgs& args,
   CHECK(status);
 
   // read aocx and create binary
-  FILE *fp = fopen(AOCX_FILE, "rb");
-  fseek(fp, 0, SEEK_END);
-  size_t  binary_length = ftell(fp);
+  FILE *handle = fopen(AOCX_FILE, "rb");
+  fseek(handle, 0, SEEK_END);
+  size_t  binary_length = ftell(handle);
 
   // create program from binary 
   const unsigned char *binary;
   binary = (unsigned char*) malloc(sizeof(unsigned char) * binary_length);
-  assert(binary && "Malloc failed"); rewind(fp);
-  if (fread((void*)binary, binary_length, 1, fp) == 0) {
+  assert(binary && "Malloc failed"); rewind(handle);
+  if (fread((void*)binary, binary_length, 1, handle) == 0) {
     printf("Failed to read from the AOCX file (fread).\n");
     return -1;
   }
-  fclose(fp);
+  fclose(handle);
   cl_program program = clCreateProgramWithBinary(context, 1, devices,
       &binary_length, (const unsigned char **)&binary, &status, NULL);
 
@@ -840,6 +863,17 @@ void GenHostCode(TVMArgs& args,
       PrintCopyBack(arr, arg_names, stream, indent, i, multi_dim_arr);
     }
   }
+
+  // Print runtime measurement
+  stream << "  std::cout << \"[INFO] Finish running...\\n\";\n";
+  stream << R"(
+  double k_start_time;	
+  double k_end_time;
+  double k_exec_time;
+
+  k_exec_time = compute_kernel_execution_time(kernel_exec_event, k_start_time, k_end_time);     
+  printf("FPGA Execution time %.8f s \\n");
+  )";
 
   // Write back to JSON
   stream << R"(

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -866,7 +866,8 @@ void GenHostCode(TVMArgs& args,
 
   // Print runtime measurement
   stream << "  std::cout << \"[INFO] Finish running...\\n\";\n";
-  stream << R"(
+  if (platform == "aocl") {
+    stream << R"(
   double k_start_time;	
   double k_end_time;
   double k_exec_time;
@@ -874,6 +875,7 @@ void GenHostCode(TVMArgs& args,
   k_exec_time = compute_kernel_execution_time(kernel_exec_event, k_start_time, k_end_time);     
   printf("FPGA Execution time %.8f s \\n");
   )";
+  }
 
   // Write back to JSON
   stream << R"(

--- a/tvm/src/codegen/build_util.cc
+++ b/tvm/src/codegen/build_util.cc
@@ -265,7 +265,8 @@ void GenJSONInputs(TVMArgs& args,
       CHECK(false) << arg_types[i].code;
     }
     const std::string name = arg_names[i];
-    jsonDoc.AddMember(rapidjson::GenericStringRef<char>(name.c_str()), v, allocator);
+    rapidjson::Value n(name.c_str(), allocator);
+    jsonDoc.AddMember(n, v, allocator);
     free(mem);
   } 
 

--- a/tvm/src/codegen/build_util.h
+++ b/tvm/src/codegen/build_util.h
@@ -59,6 +59,10 @@ void GenKernelCode(std::string& test_file,
                    std::string backend,
                    std::string project);
 
+void GenConfigCode(std::string& test_file, 
+                   std::string platform,
+                   std::string project);
+
 void GenHostCode(TVMArgs& args,
                  const std::vector<int>& shmids,
                  const std::vector<TVMType>& arg_types,

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -145,13 +145,13 @@ void CodeGenVivadoHLS::PrintType(Type t, std::ostream& os) {
     if (t.is_uint()) {
       if (!enable_native_dtype) {
         if (t.bits() == 32) {
-          os << "uint";
+          os << "unsigned int";
         } else {
           os << "ap_uint<" << t.bits() << ">";
         }
       } else {
         if (t.bits() == 8 || t.bits() == 16 || t.bits() == 32 || t.bits() == 64) {
-          os << "uint";
+          os << "unsigned int";
         }
       }
     } else if (t.is_int()) {
@@ -732,7 +732,14 @@ void CodeGenVivadoHLS::VisitStmt_(const KernelDef* op) {
   // Non-top kernel function 
   } else {
     std::ostringstream func_os;
-    func_os << "static void " << op->name << "(";
+    const UIntImm* is_void = op->ret_void.as<UIntImm>();
+    CHECK(is_void);
+    if (is_void->value) {
+      func_os << "static void " << op->name << "(";
+    } else {
+      PrintType(op->ret_type, func_os);
+      func_os  << " " << op->name << "(";
+    }
     for (size_t i = 0; i < op->args.size(); ++i) {
       VarExpr v = op->args[i];
       var_shape_map_[v.get()] = op->arg_shapes[i];

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -128,7 +128,7 @@ void CodeGenVivadoHLS::AddFunction(LoweredFunc f,
 
   stream << ") {\n";
   int func_scope = this->BeginScope();
-  range_ = CollectIterRange(f->body);
+  range_ = CollectIterRange(f->body); 
   this->PrintStmt(f->body);
   this->EndScope(func_scope);
   this->PrintIndent();

--- a/tvm/src/codegen/opencl/codegen_opencl.cc
+++ b/tvm/src/codegen/opencl/codegen_opencl.cc
@@ -113,7 +113,6 @@ std::string CodeGenOpenCL::GetBufferRef(Type t, const Variable* buffer, Expr ind
     if (is_scalar) {
       os << vid;
     } else { 
-        
       os << vid;
       CHECK(var_shape_map_.count(buffer)) 
         << "buffer " << buffer->name_hint << " not found in var_shape_map";

--- a/tvm/src/codegen/opencl/codegen_xocl_host.cc
+++ b/tvm/src/codegen/opencl/codegen_xocl_host.cc
@@ -13,6 +13,29 @@
 namespace TVM {
 namespace codegen {
 
+const std::string stream_header_def = R"(
+// Declaration of custom stream APIs that binds to Xilinx Streaming APIs.
+decltype(&clCreateStream) xcl::Stream::createStream = nullptr;
+decltype(&clReleaseStream) xcl::Stream::releaseStream = nullptr;
+decltype(&clReadStream) xcl::Stream::readStream = nullptr;
+decltype(&clWriteStream) xcl::Stream::writeStream = nullptr;
+decltype(&clPollStreams) xcl::Stream::pollStreams = nullptr;
+)";
+
+const std::string hbm_header_def = R"(
+#define MAX_HBM_BANKCOUNT 32
+#define BANK(n) n | XCL_MEM_TOPOLOGY
+const int bank[MAX_HBM_BANKCOUNT] = {
+    BANK(0),  BANK(1),  BANK(2),  BANK(3),  BANK(4),
+    BANK(5),  BANK(6),  BANK(7),  BANK(8),  BANK(9),
+    BANK(10), BANK(11), BANK(12), BANK(13), BANK(14),
+    BANK(15), BANK(16), BANK(17), BANK(18), BANK(19),
+    BANK(20), BANK(21), BANK(22), BANK(23), BANK(24),
+    BANK(25), BANK(26), BANK(27), BANK(28), BANK(29),
+    BANK(30), BANK(31)
+};
+)";
+
 void CodeGenXOCLHost::AddFunction(LoweredFunc f,
         str2tupleMap<std::string, Type> map_arg_type) {
   CodeGenC::AddFunction(f, map_arg_type);
@@ -245,7 +268,7 @@ void CodeGenXOCLHost::VisitStmt_(const KernelStmt* op) {
 
     // Memory type, MemPort, StreamType, ChannelDepth
     numbers.push_back(std::stoi(s));
-    CHECK(numbers.size() == 5);
+    CHECK(numbers.size() >= 5);
 
     auto dev_type = static_cast<DeviceType>(numbers[0]);
     auto mem_dev = static_cast<StorageType>(numbers[1]);
@@ -260,8 +283,6 @@ void CodeGenXOCLHost::VisitStmt_(const KernelStmt* op) {
 
   // Initialize buffers and opencl kernel 
   if (args_info.size() > 0) {
-
-    // create kernels
     stream << "\n";
     PrintIndent();
 
@@ -270,6 +291,7 @@ void CodeGenXOCLHost::VisitStmt_(const KernelStmt* op) {
 
     int num_of_stream_args = 0;
     CHECK(args_info.size() == op->args.size());
+    cfg_stream << "[connectivity]\n";
     for (size_t k = 0; k < op->args.size(); k++) {
       auto v = op->args[k].as<Variable>();
       CHECK(v) << "invalid input var";
@@ -285,11 +307,16 @@ void CodeGenXOCLHost::VisitStmt_(const KernelStmt* op) {
       if (info.mem_type == StorageType::devDRAM) {
         switch (info.stream_type) {
           case StreamType::DMA: {
+            cfg_stream << "sp=" << op->name << "_1."
+              << arg_name << ":DDR[" << info.mem_port << "]\n";
             PrintIndent();
+            std::string mode = "CL_MEM_WRITE_ONLY";
+            if (info.dev_type == DeviceType::devHost)
+              mode = "CL_MEM_READ_ONLY";
             stream << "cl::Buffer buffer_" 
                    << arg_name
                    << "(context, " 
-                   << "CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, "
+                   << "CL_MEM_USE_HOST_PTR | " << mode << ", "
                    << "sizeof(";
             PrintType(handle_data_type_[v], stream);
             stream << ")*";
@@ -308,15 +335,9 @@ void CodeGenXOCLHost::VisitStmt_(const KernelStmt* op) {
             if (decl_stream.str().find("cl_ext_xilinx.h") == std::string::npos) {
               decl_stream << "#include <thread>\n";
               decl_stream << "#include <CL/cl_ext_xilinx.h>\n";
-              decl_stream << R"(
-// Declaration of custom stream APIs that binds to Xilinx Streaming APIs.
-decltype(&clCreateStream) xcl::Stream::createStream = nullptr;
-decltype(&clReleaseStream) xcl::Stream::releaseStream = nullptr;
-decltype(&clReadStream) xcl::Stream::readStream = nullptr;
-decltype(&clWriteStream) xcl::Stream::writeStream = nullptr;
-decltype(&clPollStreams) xcl::Stream::pollStreams = nullptr;
-)";
+              decl_stream << stream_header_def;
 
+              stream << "  " << "auto device = devices[0];\n";
               stream << "  " << "cl_platform_id platform_id = ";
               stream << "device.getInfo<CL_DEVICE_PLATFORM>(&err);\n";
               stream << "  " << "xcl::Stream::init(platform_id);\n\n";
@@ -329,37 +350,28 @@ decltype(&clPollStreams) xcl::Stream::pollStreams = nullptr;
             }
             stream << "  " << "ext.flags = " << k << ";\n";
             // create xcl stream
-            std::string mode = "CL_STREAM_READ_ONLY";
+            std::string mode = "XCL_STREAM_READ_ONLY";
             if (info.dev_type == DeviceType::devHost)
-                mode = "CL_STREAM_WRITE_ONLY";
+                mode = "XCL_STREAM_WRITE_ONLY";
             stream << "  " << "cl_stream StreamExt_" + arg_name << " = "
                    << "xcl::Stream::createStream(device.get(), " << mode << ", "
                    << "CL_STREAM, &ext, &err);\n";
             break;
 
           }
+          case StreamType::MMIO:
+          case StreamType::ATTR:
+          default: LOG(FATAL) << "Unsupported IO type";
         }
 
       } else if (info.mem_type == StorageType::devHBM) {
         if (decl_stream.str().find("HBM") == std::string::npos) {
-          decl_stream << R"(
-#define MAX_HBM_BANKCOUNT 32
-#define BANK(n) n | XCL_MEM_TOPOLOGY
-const int bank[MAX_HBM_BANKCOUNT] = {
-    BANK(0),  BANK(1),  BANK(2),  BANK(3),  BANK(4),
-    BANK(5),  BANK(6),  BANK(7),  BANK(8),  BANK(9),
-    BANK(10), BANK(11), BANK(12), BANK(13), BANK(14),
-    BANK(15), BANK(16), BANK(17), BANK(18), BANK(19),
-    BANK(20), BANK(21), BANK(22), BANK(23), BANK(24),
-    BANK(25), BANK(26), BANK(27), BANK(28), BANK(29),
-    BANK(30), BANK(31)
-};
-)";
-          // create tcl script 
-          cfg_stream << "[connectivity]\n";
+          decl_stream << hbm_header_def;
         }
+        std::string mode = "CL_MEM_WRITE_ONLY";
+        if (info.dev_type == DeviceType::devHost)
+            mode = "CL_MEM_READ_ONLY";
         auto name = "BufExt_" + arg_name; 
-        // create external mem pointer
         stream << "  " << "cl_mem_ext_ptr_t " << name << ";\n";
         stream << "  " << name << ".flags = bank[" << info.mem_port << "];\n"; 
         stream << "  " << name << ".param = 0;\n"; 
@@ -369,7 +381,7 @@ const int bank[MAX_HBM_BANKCOUNT] = {
                << arg_name
                << "(context, " 
                << "CL_MEM_EXT_PTR_XILINX | "
-               << "CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, "
+               << "CL_MEM_USE_HOST_PTR | " << mode << ", "
                << "sizeof(";
         PrintType(handle_data_type_[v], stream);
         stream << ")*";

--- a/tvm/src/codegen/opencl/codegen_xocl_host.h
+++ b/tvm/src/codegen/opencl/codegen_xocl_host.h
@@ -32,8 +32,6 @@ class CodeGenXOCLHost : public CodeGenC {
 
   void GenForStmt(const For* op, std::string pragma, bool before);
   
- protected:
-  std::string GetBufferRef(Type t, const Variable* buffer, Expr index);
 };
 
 }  // namespace codegen

--- a/tvm/src/pass/transform_layout.cc
+++ b/tvm/src/pass/transform_layout.cc
@@ -194,6 +194,7 @@ class IndicesTransformer final : public IRMutator {
       
     // Mutate the function argument
     Stmt Mutate_(const KernelDef* op, const Stmt& s) override {
+      has_autosa_module = false;
       Stmt body = this->Mutate(op->body);
       Array<VarExpr> args;
       Array<Array<Expr>> arg_shapes;
@@ -201,7 +202,7 @@ class IndicesTransformer final : public IRMutator {
 
       for (size_t k = 0; k < op->args.size(); k++) {
           auto name = op->args[k].get()->name_hint;
-          if (name == info_.name) {
+          if (name == info_.name && !has_autosa_module) {
             // Create arg with same node
             VarExpr new_var(info_.name, info_.type);
             args.push_back(new_var);
@@ -214,7 +215,7 @@ class IndicesTransformer final : public IRMutator {
             arg_types.push_back(op->arg_types[k]);
           }
       }
-
+      has_autosa_module = false;
       return KernelDef::make(args, arg_shapes, arg_types, op->arg_tensors,
                        body, op->ret_void, op->ret_type, op->name, op->attributes);
     }


### PR DESCRIPTION
This PR mainly improves the following aspects:

- Reorganize the `hcl.Platform` class hierarchy. Each platform object is associated with a set of target devices (`class Device`) and hardware synthesis tools (`class Tool`). 
- Improves modularity. Each platform class should have its own (customizable) methods for hardware synthesis and deployment. Need to remove all the hardcoding logic.
- (TBD) introduce new APIs for HCL compiled function (i.e., the function returned by `hcl.build`) for application deployment and performance measurement. 

Here is the proposed interface. To be strict, `f.compile` and `f.generate_code` functions are invoked before program execution. So they should not be part of the runtime system. But for simplicity, I just put them together here in the example.
```python
# Generate source code in a local workdir
f.generate_code(args)

# Compile FPGA binary
key_path = "/home/sx233/aws-sx233-test.pem"
f.compile(args, remote=True, aws_key_path=key_path)

# Execute bitstream on AWS F1
f.execute(args, remote=True, aws_key_path=key_path)
```

This PR has a lower priority than PR #332. 
