### PR TITLE
[API] Generate correct error message when operating with NumPy numbers

### DIFF
--- a/python/heterocl/debug.py
+++ b/python/heterocl/debug.py
@@ -61,12 +61,12 @@ def hcl_excepthook(etype, value, tb):
         extracted_tb = traceback.extract_tb(tb)
         frame_stack = []
         for e_tb in extracted_tb:
-            if 'heterocl' in e_tb[0]:
+            if '/python/heterocl/' in e_tb[0]:
                 continue
             frame_stack.append(e_tb)
         for frame in traceback.format_list(frame_stack):
             sys.stdout.write(frame)
             sys.stdout.flush()
-        print("\33[1;34m[HeteroCL Error]\33[0m" + value.message)
+        print("\33[1;34m[HeteroCL Error]\33[0m" + value.args[0])
     else:
         sys.__excepthook__(etype, value, tb)

--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -5,7 +5,7 @@ from .tvm import expr as _expr
 from .tvm import ir_pass as _pass
 from .tvm.api import decl_buffer
 from .tvm._ffi.node import NodeGeneric
-from .debug import TensorError
+from .debug import APIError, TensorError
 from .schedule import Stage
 from . import util
 from . import debug
@@ -178,6 +178,9 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
                                      index))
 
     def __getattr__(self, key):
+        if key in ('__array_priority__', '__array_struct__'):
+            raise APIError(
+                    "Cannot use NumPy numbers as left-hand-side operand")
         hcl_dtype = self.tensor.hcl_dtype
         if not isinstance(hcl_dtype, types.Struct):
             raise TensorError(

--- a/python/heterocl/tvm/expr.py
+++ b/python/heterocl/tvm/expr.py
@@ -121,8 +121,9 @@ class ExprOp(object):
         raise APIError("Cannot set bit/slice of an expression")
 
     def __nonzero__(self):
-        raise ValueError("Cannot use and / or / not operator to Expr, hint: " +
-                         "use tvm.all / tvm.any instead")
+        raise APIError("1) Cannot use and / or / not operator to Expr, " +
+                       "2) Cannot compare NumPy numbers with HeteroCL exprs, " +
+                       "hint: swap the operands")
 
     def __bool__(self):
         return self.__nonzero__()

--- a/tests/issues/test_issue_342.py
+++ b/tests/issues/test_issue_342.py
@@ -1,0 +1,42 @@
+import heterocl as hcl
+import numpy as np
+
+def test_numpy_operator_err_msg_0():
+    hcl.init()
+
+    A = hcl.placeholder((10, 10))
+    np_A = np.array([5, 10, 15])
+
+    try:
+        np_A[1] > A[5, 5]
+    except hcl.debug.APIError:
+        return
+    assert False
+
+def test_numpy_operator_err_msg_1():
+    hcl.init()
+
+    A = hcl.placeholder((10, 10))
+    np_A = np.array([5, 10, 15])
+
+    try:
+        np_A[1] + A[5, 5]
+    except hcl.debug.APIError:
+        return
+    assert False
+
+def test_numpy_operator_no_err_0():
+    hcl.init()
+
+    A = hcl.placeholder((10, 10))
+    np_A = np.array([5, 10, 15])
+
+    A[5, 5] > np_A[1]
+
+def test_numpy_operator_no_err_1():
+    hcl.init()
+
+    A = hcl.placeholder((10, 10))
+    np_A = np.array([5, 10, 15])
+
+    A[5, 5] + np_A[1]


### PR DESCRIPTION
**Solved Issue**: #342 

**Reason and solution**: When operating with NumPy numbers (e.g., `+`, `>`), if we put NumPy numbers on LHS, it will trigger NumPy's operators instead of HeteroCL's. Thus, it generates errors. The existing error message does not show the correct information. This PR fixes the output error messages.

**Test case**: tests/issues/test_issue_342.py