### PR TITLE
[CI] Use decorator=4.4.2 to avoid pkg incompatibility in installation 

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,7 @@ setup(
   packages = find_packages(),
   install_requires=[
       'numpy==1.18.5',
-      'decorator',
+      'decorator==4.4.2',
       'networkx',
       'matplotlib',
       'backports.functools_lru_cache',


### PR DESCRIPTION
```shell
Installed /home/circleci/.local/lib/python3.7/site-packages/PyYAML-5.4.1-py3.7-linux-x86_64.egg
Searching for keras-applications>=1.0.6
Reading https://pypi.org/simple/keras-applications/
Downloading https://files.pythonhosted.org/packages/71/e3/19762fdfc62877ae9102edf6342d71b28fbfd9dea3d2f96a882ce099b03f/Keras_Applications-1.0.8-py3-none-any.whl#sha256=df4323692b8c1174af821bf906f1e442e63fa7589bf0f1230a0b6bdc5a810c95
Best match: Keras-Applications 1.0.8
Processing Keras_Applications-1.0.8-py3-none-any.whl
Installing Keras_Applications-1.0.8-py3-none-any.whl to /home/circleci/.local/lib/python3.7/site-packages
Adding Keras-Applications 1.0.8 to easy-install.pth file

Installed /home/circleci/.local/lib/python3.7/site-packages/Keras_Applications-1.0.8-py3.7.egg
error: decorator 5.0.6 is installed but decorator<5,>=4.3 is required by {'networkx'}
make: *** [Makefile:14: build-hcl] Error 1
```