### PR TITLE
[API] Add "shape" property to tensor slice

### DIFF
--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -228,6 +228,13 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
     def dtype(self):
         return self._dtype
 
+    @property
+    def shape(self):
+        if len(self.indices) > len(self.tensor.shape):
+            raise TensorError("Shape is not defined when the length of indices"
+                              + " is greater than the number of dimensions")
+        return self.tensor.shape[len(self.indices):]
+
     def asnode(self):
         if len(self.indices) < len(self.tensor.shape):
             raise TensorError("Accessing a slice of tensor is not allowed")

--- a/tests/issues/test_issue_368.py
+++ b/tests/issues/test_issue_368.py
@@ -1,0 +1,6 @@
+import heterocl as hcl
+
+def test_tensor_slice_shape():
+    A = hcl.compute((2,10), lambda i,j: 0)
+
+    assert A[0].shape == (10,)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,6 +119,14 @@ def test_select():
 
     assert np.allclose(np_B, np_C)
 
+
+def test_tesnro_slice_shape():
+    A = hcl.placeholder((3, 4, 5))
+
+    assert(A.shape == (3, 4, 5))
+    assert(A[0].shape == (4, 5))
+    assert(A[0][1].shape == (5,))
+
 def test_build_from_stmt():
     hcl.init(hcl.Int())
     # First, we still need to create HeteroCL inputs


### PR DESCRIPTION
Currently, we only allow users to access the `shape` property of a tensor. In this PR, we extend the use of `shape` to a tensor slice. We follow the same semantic as NumPy. For example,

```python
A = hcl.placeholder((2, 3, 4))
A.shape           # (2, 3, 4)
A[0].shape        # (3, 4)
A[0][1].shape     # (4,)
A[0][1][2].shape  # ()
```