### PR TITLE
[CI] Fix CPPLINT tests and fix version for networkx

### DIFF
--- a/hlib/python/setup.py
+++ b/hlib/python/setup.py
@@ -37,8 +37,6 @@ setup(
   packages = find_packages(),
   install_requires=[
       'numpy==1.18.5',
-      'decorator',
-      'networkx',
       'matplotlib',
       'backports.functools_lru_cache',
       'ordered_set',

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
   install_requires=[
       'numpy==1.18.5',
       'decorator==4.4.2',
-      'networkx',
+      'networkx==2.5.1',
       'matplotlib',
       'backports.functools_lru_cache',
       'ordered_set',

--- a/tvm/CPPLINT.cfg
+++ b/tvm/CPPLINT.cfg
@@ -7,5 +7,6 @@ filter=-build/namespaces
 filter=-build/include_what_you_use
 filter=-build/include_subdir
 filter=-build/c++11
+filter=-readability/casting
 # TODO(sean) : should add this back
 filter=-runtime/references


### PR DESCRIPTION
In this PR, due to the update of Python cpplint package, a new rule is excluded for our repo. Also, we fixed the version of package `networkx` to avoid Numpy version mismatch.