### PR TITLE
[API] Report Display Row Organization Bug Fix

### DIFF
--- a/python/heterocl/report.py
+++ b/python/heterocl/report.py
@@ -45,9 +45,6 @@ class Displayer(object):
     __data_acquisition(elem)
         Extract out latency information from the report file.
 
-    __collapse(elem)
-        Reorder the data appropriately for display.
-
     init_table(obj)
         Initialize the attributes given the report file.
 
@@ -213,11 +210,6 @@ class Displayer(object):
  
         return frame
 
-    def __collapse(self, elem):
-        """Reorder the data acquired
-        """
-        return (elem.pop(0), elem)
-
     def init_table(self, obj):
         """Initialize attributes defined above for the specific report file.
 
@@ -296,20 +288,15 @@ class Displayer(object):
 
             frame_lst = new_frame_lst
 
-        
+        lev_seq = list(map(lambda x: x.count('+'), self._loop_name_aux))
         for cat in self._category_aux:
-            lst = fin_dict[cat]
-            while len(lst) != 0:
-                res = list(map(self.__collapse, lst))
-                lst = []
-                for item in res:
-                    self._data[cat].append(item[0])
-                    if len(item[1]) != 0:
-                        lst.append(item[1])
- 
+            for lev in lev_seq:
+                self._data[cat].append(fin_dict[cat][lev].pop(0))
+
     def get_max(self, col):
-        """Form a tuple list that sorts loops in a decreasing order with
-        respect to the latency information of the specified latency category.
+        """Form a 3-element tuple list that sorts loops in a decreasing order
+        with respect to the latency information of the specified latency 
+        category.
                    
         Parameters
         ----------
@@ -319,11 +306,13 @@ class Displayer(object):
         Returns
         ----------
         list
-            Tuple list with loop names and its corresponding latency value. 
+            3-element tuple list with loop names, its data corresponding to
+            [col] latency category, and the loop level.
         """
-        tup_lst = list(map(lambda x, y: (x, y), self._loop_name, self._data[col]))
+        tup_lst = list(map(lambda x, y, z: (x, y, z), self._loop_name, self._data[col], self._loop_name_aux))
+        tup_lst = list(map(lambda x: (x[0], x[1], x[2].count('+')), tup_lst))
         return list(reversed(sorted(tup_lst, key=lambda x: int(x[1]))))
-    
+
     def display(self, loops=None, level=None, cols=None):
         """Display the report file.
   

--- a/tests/test_hls_report.py
+++ b/tests/test_hls_report.py
@@ -129,7 +129,9 @@ def _test_rpt(config):
 
     def test_get_max():
         res = rpt.get_max('Latency')
-        assert dict(res) == get_expected(alg_name, 'GetMax')
+        res_dict = {x : {y : z} for x, y, z in res} 
+        print(res_dict)
+        assert res_dict == get_expected(alg_name, 'GetMax')
 
     def test_col(): 
         res = rpt.display()

--- a/tests/test_report_data/expected.json
+++ b/tests/test_report_data/expected.json
@@ -1,6 +1,6 @@
 {
   "sobel" : {
-    "GetMax" : {"Y_x_reuse1_Y_y_reuse1": "29741875", "X_x_reuse_X_y_reuse": "29741875", "P_x": "8643760", "A_x1": "4068088", "R_x3_R_y2": "252173", "F_x4_F_y3": "252156", "P_y": "20978", "A_y1": "9872", "P_z": "15"},
+    "GetMax" : {"Y_x_reuse1_Y_y_reuse1": {"29741875": 0}, "X_x_reuse_X_y_reuse": {"29741875": 0}, "P_x": {"8643760": 0}, "A_x1": {"4068088": 0}, "R_x3_R_y2": {"252173": 0}, "F_x4_F_y3": {"252156": 0}, "P_y": {"20978": 1}, "A_y1": {"9872": 1}, "P_z": {"15": 2}},
     "Category" : "Trip Count, Latency Iteration Latency Pipeline II Pipeline Depth",
     "NoQuery" : ["Trip Count, Latency Iteration Latency Pipeline II Pipeline Depth", "P_x, 412, 8643760, 20980, N/A, N/A", "+ P_y, 617, 20978, 34, N/A, N/A", "++ P_z, 3, 15, 5, N/A, N/A", "A_x1, 412, 4068088, 9874, N/A, N/A", "+ A_y1, 617, 9872, 16, N/A, N/A", "X_x_reuse_X_y_reuse, 254204, 29741875, N/A, 117, 125", "Y_x_reuse1_Y_y_reuse1, 254204, 29741875, N/A, 117, 125", "R_x3_R_y2, 252150, 252173, N/A, 1, 25", "F_x4_F_y3, 252150, 252156, N/A, 1, 8"],
     "LoopQuery" : ["Trip Count, Latency Iteration Latency Pipeline II Pipeline Depth", "P_x, 412, 8643760, 20980, N/A, N/A", "+ P_y, 617, 20978, 34, N/A, N/A", "++ P_z, 3, 15, 5, N/A, N/A", "A_x1, 412, 4068088, 9874, N/A, N/A", "+ A_y1, 617, 9872, 16, N/A, N/A"],
@@ -11,7 +11,7 @@
     "AllQuery" : ["Latency", "P_x, 8643760", "+ P_y, 20978", "A_x1, 4068088", "+ A_y1, 9872"]
   },
   "spam_filter" : {
-    "GetMax" : {"outer_loop_x_outer_loop_y": "92610000", "dot_product_loop_x_outer1_dot_product_loop_x_inner1": "1027", "update_param_loop_x_outer3_update_param_loop_x_inner3": "1026", "grad_x_outer2_grad_x_inner2": "1026", "data_local_x_outer_data_local_x_inner": "1026"},
+    "GetMax" : {"outer_loop_x_outer_loop_y": {"92610000": 0}, "dot_product_loop_x_outer1_dot_product_loop_x_inner1": {"1027": 1}, "update_param_loop_x_outer3_update_param_loop_x_inner3": {"1026": 1}, "grad_x_outer2_grad_x_inner2": {"1026": 1}, "data_local_x_outer_data_local_x_inner": {"1026": 1}},
     "Category" : "Trip Count, Latency Iteration Latency Pipeline II Pipeline Depth",
     "NoQuery" : ["Trip Count, Latency Iteration Latency Pipeline II Pipeline Depth", "outer_loop_x_outer_loop_y, 22500, 92610000, 4116, N/A, N/A", "+ data_local_x_outer_data_local_x_inner, 1024, 1026, N/A, 1, 4", "+ dot_product_loop_x_outer1_dot_product_loop_x_inner1, 1024, 1027, N/A, 1, 5", "+ grad_x_outer2_grad_x_inner2, 1024, 1026, N/A, 1, 4", "+ update_param_loop_x_outer3_update_param_loop_x_inner3, 1024, 1026, N/A, 1, 4"],
     "LoopQuery" : ["Trip Count, Latency Iteration Latency Pipeline II Pipeline Depth", "outer_loop_x_outer_loop_y, 22500, 92610000, 4116, N/A, N/A", "+ dot_product_loop_x_outer1_dot_product_loop_x_inner1, 1024, 1027, N/A, 1, 5", "+ update_param_loop_x_outer3_update_param_loop_x_inner3, 1024, 1026, N/A, 1, 4"],


### PR DESCRIPTION
This PR attempts to fix a minor issue that the report displayer has, where it incorrectly places latency information when loop optimization primitives have been applied to different loops. 

For instance, when the user applies pipeline to the first nested loop of `E`, the output looks like such:
```
+-----------+--------------+-----------+---------------------+---------------+------------------+
|           |   Trip Count |   Latency |   Iteration Latency |   Pipeline II |   Pipeline Depth |
|-----------+--------------+-----------+---------------------+---------------+------------------|
| B_x       |          400 |   2240800 |                5602 |           N/A |              N/A |
| + B_y     |          400 |      5600 |                  14 |           N/A |              N/A |
| E_x1_E_y1 |            3 |       123 |                  41 |           N/A |              N/A |
| D_x3      |            3 |        39 |                  13 |           N/A |              N/A |
| + D_y2    |       158404 |    792139 |                 N/A |             5 |              125 |
| ++ D_ra0  |          398 |     52138 |                 131 |           N/A |              N/A |
| +++ D_ra1 |          398 |  20751720 |               52140 |           N/A |              N/A |
| Fimg_x5   |          398 |     11144 |                  28 |           N/A |              N/A |
| + Fimg_y3 |          398 |   4436108 |               11146 |           N/A |              N/A |
+-----------+--------------+-----------+---------------------+---------------+------------------+
* Units in clock cycles
```
whereas the correct output should be this
```
+-----------+--------------+-----------+---------------------+---------------+------------------+
|           |   Trip Count |   Latency |   Iteration Latency |   Pipeline II |   Pipeline Depth |
|-----------+--------------+-----------+---------------------+---------------+------------------|
| B_x       |          400 |   2240800 |                5602 |           N/A |              N/A |
| + B_y     |          400 |      5600 |                  14 |           N/A |              N/A |
| E_x1_E_y1 |       158404 |    792139 |                 N/A |             5 |              125 |
| D_x3      |          398 |  20751720 |               52140 |           N/A |              N/A |
| + D_y2    |          398 |     52138 |                 131 |           N/A |              N/A |
| ++ D_ra0  |            3 |       123 |                  41 |           N/A |              N/A |
| +++ D_ra1 |            3 |        39 |                  13 |           N/A |              N/A |
| Fimg_x5   |          398 |   4436108 |               11146 |           N/A |              N/A |
| + Fimg_y3 |          398 |     11144 |                  28 |           N/A |              N/A |
+-----------+--------------+-----------+---------------------+---------------+------------------+
* Units in clock cycles
```
since the pipeline primitive has been applied to loop `E` instead of `D_y2`.

This example output is from an *unoptimized* version (commenting out all the optimization techniques) of the Sobel example mentioned in PR #384 except loop `E` pipelined on `axis[1]`.