### PR TITLE
[Pass] Remove Unnecessary Simplification for Bitwise Operators

### DIFF
--- a/tests/issues/test_issue_398.py
+++ b/tests/issues/test_issue_398.py
@@ -1,0 +1,17 @@
+import heterocl as hcl
+import numpy as np
+
+def test_mask():
+
+    def mask(A):
+        return hcl.compute(A.shape, lambda x: (A[x] & 0xFFFF), "mask", dtype=A.dtype)
+
+    A = hcl.placeholder((2,), "A", dtype=hcl.UInt(16))
+    s = hcl.create_schedule([A], mask)
+
+    m = hcl.build(s)
+
+    hcl_A = hcl.asarray([10,5], dtype=A.dtype)
+    hcl_R = hcl.asarray([99,99], dtype=hcl.UInt(16))
+    m(hcl_A, hcl_R)
+    assert np.array_equal(hcl_A.asnumpy(), [10, 5])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,6 +119,53 @@ def test_select():
 
     assert np.allclose(np_B, np_C)
 
+def test_bitwise_and():
+    hcl.init(hcl.UInt(8))
+
+    N = 100
+    A = hcl.placeholder((N, N))
+    B = hcl.placeholder((N, N))
+
+    def kernel(A, B):
+        return hcl.compute(A.shape, lambda x, y: A[x, y] & B[x, y])
+
+    s = hcl.create_schedule([A, B], kernel)
+    f = hcl.build(s)
+
+    a = np.random.randint(0, 255, (N, N))
+    b = np.random.randint(0, 255, (N, N))
+    c = np.zeros((N, N))
+    g = a & b
+
+    hcl_a = hcl.asarray(a)
+    hcl_b = hcl.asarray(b)
+    hcl_c = hcl.asarray(c)
+    f(hcl_a, hcl_b, hcl_c)
+    assert np.array_equal(hcl_c.asnumpy(), g)
+
+def test_bitwise_or():
+    hcl.init(hcl.UInt(8))
+
+    N = 100
+    A = hcl.placeholder((N, N))
+    B = hcl.placeholder((N, N))
+
+    def kernel(A, B):
+        return hcl.compute(A.shape, lambda x, y: A[x, y] | B[x, y])
+
+    s = hcl.create_schedule([A, B], kernel)
+    f = hcl.build(s)
+
+    a = np.random.randint(0, 255, (N, N))
+    b = np.random.randint(0, 255, (N, N))
+    c = np.zeros((N, N))
+    g = a | b
+
+    hcl_a = hcl.asarray(a)
+    hcl_b = hcl.asarray(b)
+    hcl_c = hcl.asarray(c)
+    f(hcl_a, hcl_b, hcl_c)
+    assert np.array_equal(hcl_c.asnumpy(), g)
 
 def test_tesnro_slice_shape():
     A = hcl.placeholder((3, 4, 5))

--- a/tvm/HalideIR/src/arithmetic/Simplify.cpp
+++ b/tvm/HalideIR/src/arithmetic/Simplify.cpp
@@ -3375,21 +3375,7 @@ class Simplify : public IRMutator {
       if (propagate_indeterminate_expression(a, b, op->type, &expr)) {
         return;
       }
-
-      int64_t ib = 0;
-      uint64_t ub = 0;
-      int bits;
-
-      if (const_int(b, &ib) && !b.type().is_max(ib) &&
-          is_const_power_of_two_integer(make_const(a.type(), ib + 1), &bits)) {
-        expr = Mod::make(a, make_const(a.type(), ib + 1));
-      } else if (const_uint(b, &ub) && b.type().is_max(ub)) {
-        expr = a;
-      } else if (const_uint(b, &ub) &&
-                 is_const_power_of_two_integer(make_const(a.type(), ub + 1),
-                                               &bits)) {
-        expr = Mod::make(a, make_const(a.type(), ub + 1));
-      } else if (a.same_as(op->args[0]) && b.same_as(op->args[1])) {
+      if (a.same_as(op->args[0]) && b.same_as(op->args[1])) {
         expr = self;
       } else {
         expr = a & b;


### PR DESCRIPTION
**Fixed issue** #398

**Detailed description:**
In this PR, we remove unnecessary simplification for bitwise operators. In the original code base, inside `Simplify.cpp`, the bitwise_and will become a modular operator in certain cases, which is not necessary and can be wrong. This logic is now removed in this PR.

**Link to the tests:**
Two tests are added. [One](https://github.com/seanlatias/heterocl/blob/quick_fix/tests/issues/test_issue_398.py) under tests/issues and [the other](https://github.com/seanlatias/heterocl/blob/8c45e709b912120dc92b2a64966e94989c413ab2/tests/test_api.py#L122) for more general testing under tests/test_api.py.
