### PR TITLE
[API] Fix hcl.print with Incorrect Output Shape

### DIFF
--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -455,7 +455,7 @@ def print(vals, format=""):
             if isinstance(val, TensorSlice):
                 ndim = nshape - len(val.indices)
             args = ["print_"+str(n) for n in range(0, ndim)]
-            ivs = [_IterVar((0, val.tensor.shape[nshape-n-1]), args[n], 0) \
+            ivs = [_IterVar((0, val.tensor.shape[n]), args[n], 0) \
                     for n in range(0, ndim)]
             import builtins
             stage.emit(print_tensor(val, ivs, ndim-1, ndim))
@@ -488,7 +488,7 @@ def assert_(cond, message="assert error\n", vals=0):
     """
     if "\n" not in message:
         message = message + "\n"
-      
+
     if not isinstance(vals, (tuple, list)):
         vals = [vals]
     stage = Stage.get_current()

--- a/tests/issues/issue_408_code.py
+++ b/tests/issues/issue_408_code.py
@@ -1,0 +1,12 @@
+import heterocl as hcl
+import numpy as np
+
+def test (DRAM):
+        hcl.print ((), f"DRAM: {DRAM.shape} {DRAM.dtype}\n")
+        hcl.print(DRAM)
+
+DRAM    = hcl.placeholder((4,2), "dram", dtype=hcl.UInt(64))
+s = hcl.create_schedule([DRAM], test)
+f = hcl.build(s)
+dram    = hcl.asarray (np.zeros(DRAM.shape), dtype=DRAM.dtype)
+f(dram)

--- a/tests/issues/test_issue_408.py
+++ b/tests/issues/test_issue_408.py
@@ -1,0 +1,20 @@
+import subprocess
+import pathlib
+
+def get_stdout():
+    path = pathlib.Path(__file__).parent.absolute()
+    path = str(path) + "/issue_408_code.py"
+    p = subprocess.run(['python', path], stdout=subprocess.PIPE)
+    output = p.stdout.decode('utf-8')
+    return str(output)
+
+def test_issue_408():
+
+    str = get_stdout()
+
+    assert str == """DRAM: (4, 2) uint64
+[[0, 0],
+[0, 0],
+[0, 0],
+[0, 0]]
+"""

--- a/tests/test_api_print.py
+++ b/tests/test_api_print.py
@@ -39,3 +39,11 @@ def test_print_tensor_2D():
     N = 10
     for i in range(0, N):
         assert outputs[i] == outputs[i+N]
+
+def test_print_tensor_2D_rect():
+
+    outputs = get_stdout("print_tensor_2D_rect").split("\n")
+
+    N = 5
+    for i in range(0, N):
+        assert outputs[i] == outputs[i+N]

--- a/tests/test_api_print_cases/print_tensor_2D_rect.py
+++ b/tests/test_api_print_cases/print_tensor_2D_rect.py
@@ -1,0 +1,30 @@
+import heterocl as hcl
+import numpy as np
+
+hcl.init()
+
+A = hcl.placeholder((5, 10))
+
+def kernel(A):
+    hcl.print(A)
+
+s = hcl.create_schedule([A], kernel)
+f = hcl.build(s)
+
+np_A = np.random.randint(0, 10, size=(10, 10))
+hcl_A = hcl.asarray(np_A)
+
+f(hcl_A)
+
+s = "["
+for i in range(0, 5):
+    s += "["
+    for j in range(0, 10):
+        s += str(np_A[i][j])
+        if j < 9:
+            s += ", "
+    s += "]"
+    if i < 4:
+        s += ",\n"
+s += "]"
+print(s)


### PR DESCRIPTION
**Fixed issue:** #408

**Detailed description:** 
In this PR, we make sure the output shape is the same as the input shape. The bug was from incorrect loop bound (tensor shape) collection when printing the tensor.

**Link to the tests:** 
tests/issues/test_issue_408.py
A separate test is also added under tests/test_api_print.py