### PR TITLE
[API] Allow string initialization for `hcl.struct`

### DIFF
--- a/python/heterocl/types.py
+++ b/python/heterocl/types.py
@@ -28,6 +28,10 @@ class Type(object):
         self.bits = bits
         self.fracs = fracs
 
+    def __eq__(self, other):
+        other = dtype_to_hcl(other)
+        return other.bits == self.bits and other.fracs == self.fracs
+
 class Int(Type):
     """Arbitrary-bit signed integers"""
     def __repr__(self):
@@ -59,10 +63,12 @@ class Struct(Type):
     The struct members are defined with a Python dictionary
     """
     def __init__(self, dtype_dict):
-        self.dtype_dict = OrderedDict(dtype_dict)
         self.bits = 0
-        for dtype in dtype_dict.values():
+        for name, dtype in dtype_dict.items():
+            dtype = dtype_to_hcl(dtype)
+            dtype_dict[name] = dtype
             self.bits += dtype.bits
+        self.dtype_dict = OrderedDict(dtype_dict)
         Type.__init__(self, self.bits, 0)
 
     def __repr__(self):

--- a/tests/issues/test_issue_410.py
+++ b/tests/issues/test_issue_410.py
@@ -1,4 +1,5 @@
 import heterocl as hcl
+import numpy as np
 
 def test_issue_410():
 
@@ -6,3 +7,25 @@ def test_issue_410():
     B = hcl.Struct ({'foo': 'uint16' })
 
     assert A['foo'] == B['foo']
+
+def test_issue_410_2():
+
+    A = hcl.placeholder((10,), dtype="uint16")
+
+    def f(A):
+        t = hcl.Struct ({'foo': 'uint16' })
+        B = hcl.compute(A.shape, lambda x: (A[x],), dtype=t)
+        return hcl.compute(A.shape, lambda x: B[x].foo)
+
+    s = hcl.create_schedule([A], f)
+    f = hcl.build(s)
+
+    npA = np.random.randint(0, 10, A.shape)
+    npO = np.zeros(A.shape)
+
+    hclA = hcl.asarray(npA, dtype="uint16")
+    hclO = hcl.asarray(npO)
+
+    f(hclA, hclO)
+
+    assert np.array_equal(npA, hclO.asnumpy())

--- a/tests/issues/test_issue_410.py
+++ b/tests/issues/test_issue_410.py
@@ -1,0 +1,8 @@
+import heterocl as hcl
+
+def test_issue_410():
+
+    A = hcl.Struct ({'foo': hcl.UInt(16) })
+    B = hcl.Struct ({'foo': 'uint16' })
+
+    assert A['foo'] == B['foo']


### PR DESCRIPTION
**Fixed issue:** #410

**Detailed description:** 
Enable the string initialization in types.py. Also, added a `__eq__` method in the Type base class for checking the equivalence between types.

**Link to the tests:**
tests/issues/test_issue_410.py