### PR TITLE
[API] Raise exception when `hcl.assert` fails

### DIFF
--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -15,7 +15,7 @@ from . import util
 from . import types
 from . import config
 
-def init(init_dtype="int32", raise_exception=True):
+def init(init_dtype="int32", raise_assert_exception=True):
     """Initialize a HeteroCL environment with configurations.
 
     This API must be called each time the users write an application.
@@ -55,7 +55,7 @@ def init(init_dtype="int32", raise_exception=True):
     """
     # set the configurations
     config.init_dtype  = init_dtype
-    config.raise_exception = raise_exception
+    config.raise_assert_exception = raise_assert_exception
     # initialize global variables
     Schedule.stage_ops = []
     Schedule.stage_names = set()

--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -15,7 +15,7 @@ from . import util
 from . import types
 from . import config
 
-def init(init_dtype="int32"):
+def init(init_dtype="int32", raise_exception=True):
     """Initialize a HeteroCL environment with configurations.
 
     This API must be called each time the users write an application.
@@ -55,6 +55,7 @@ def init(init_dtype="int32"):
     """
     # set the configurations
     config.init_dtype  = init_dtype
+    config.raise_exception = raise_exception
     # initialize global variables
     Schedule.stage_ops = []
     Schedule.stage_names = set()

--- a/python/heterocl/api.py
+++ b/python/heterocl/api.py
@@ -146,6 +146,11 @@ def create_scheme(inputs, func):
     """
     if not isinstance(inputs, list):
         inputs = [inputs]
+    # reset the global variables
+    Schedule.stage_ops = []
+    Schedule.mod_calls = dict()
+    Schedule.stage_names = set()
+    Schedule.last_stages = OrderedSet([])
     with Stage("_top") as top:
         func(*inputs)
     for op in top.substages:

--- a/python/heterocl/config.py
+++ b/python/heterocl/config.py
@@ -1,3 +1,3 @@
 
 init_dtype = "int32"
-raise_exception = True
+raise_assert_exception = True

--- a/python/heterocl/config.py
+++ b/python/heterocl/config.py
@@ -1,2 +1,3 @@
 
 init_dtype = "int32"
+raise_exception = True

--- a/python/heterocl/debug.py
+++ b/python/heterocl/debug.py
@@ -50,6 +50,11 @@ class DeviceError(HCLError):
     def __init__(self, msg):
         HCLError.__init__(self, msg, "\33[1;31m[Device]\33[0m ")
 
+class AssertError(HCLError):
+    """A subclass for specifying assert related exception"""
+    def __init__(self, msg):
+        HCLError.__init__(self, msg, "\33[1;31m[Assert]\33[0m ")
+
 def hcl_excepthook(etype, value, tb):
     """Customized excepthook
 

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -22,7 +22,7 @@ class Module(ModuleBase):
 
     def __call__(self, *args):
         ret = ModuleBase.__call__(self, *args)
-        if ret == 1 and config.raise_exception:
+        if ret == 1 and config.raise_assert_exception:
             raise AssertError("Assert Failed!!")
         return ret
 

--- a/python/heterocl/tvm/module.py
+++ b/python/heterocl/tvm/module.py
@@ -7,6 +7,8 @@ from collections import namedtuple
 from ._ffi.function import ModuleBase, _set_class_module
 from ._ffi.function import _init_api
 from .contrib import cc as _cc, tar as _tar, util as _util
+from .. import config
+from ..debug import AssertError
 from ..report import report_stats
 
 ProfileResult = namedtuple("ProfileResult", ["mean", "results"])
@@ -17,6 +19,12 @@ class Module(ModuleBase):
 
     def __repr__(self):
         return "Module(%s, %x)" % (self.type_key, self.handle.value)
+
+    def __call__(self, *args):
+        ret = ModuleBase.__call__(self, *args)
+        if ret == 1 and config.raise_exception:
+            raise AssertError("Assert Failed!!")
+        return ret
 
     @property
     def type_key(self):

--- a/tests/test_api_assert.py
+++ b/tests/test_api_assert.py
@@ -42,3 +42,24 @@ def test_dsl_def_assert():
     golden = get_stdout("dsl_def_assert_tests_golden")
 
     assert str(output) == golden
+
+def test_assert_exception():
+    hcl.init()
+
+    A = hcl.placeholder((10,))
+
+    def kernel(A):
+        hcl.assert_(5 == 6)
+        return hcl.compute(A.shape, lambda x: A[x])
+
+    s = hcl.create_schedule([A], kernel)
+    f = hcl.build(s)
+
+    hclA = hcl.asarray(np.zeros(A.shape))
+    hclO = hcl.asarray(np.zeros(A.shape))
+
+    try:
+        f(hclA, hclO)
+    except hcl.debug.AssertError:
+        return
+    assert False

--- a/tests/test_api_assert_cases/basic_assert_tests.py
+++ b/tests/test_api_assert_cases/basic_assert_tests.py
@@ -6,49 +6,49 @@ n = 64
 k = 64
 
 def test_with_if():
-    hcl.init()
+    hcl.init(raise_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
     def kernel(matrix_1, matrix_2):
         return_matrix = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y], "return_matrix")
-   
+
         with hcl.if_(matrix_2[0,0] == 0):
             hcl.assert_(matrix_2[1,1] == 0, "assert message in if statement") #result is true
             hcl.print(0, "in the if statement\n") #should be printed
-            
+
         hcl.assert_(matrix_1[0,0] != 0, "customized assert message 1") #result is false
         hcl.print(0, "this shouldn't be printed")
         return return_matrix
-        
-    s = hcl.create_schedule([matrix_1, matrix_2], kernel)  
+
+    s = hcl.create_schedule([matrix_1, matrix_2], kernel)
     return s
-    
+
 def test_with_for():
-    hcl.init()
+    hcl.init(raise_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
     def kernel(matrix_1, matrix_2):
         return_matrix = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y], "return_matrix")
-   
+
         with hcl.for_(0, 7, name="for_loop") as f:
             hcl.assert_(matrix_2[f,2] == 0, "assert message in the first for loop") #assert true
             hcl.print(0, "in the first for loop\n") #should be printed
-        
-        with hcl.for_(0, 7, name="for_loop") as f: 
-            hcl.assert_(matrix_2[f,2] != 0, "assert message in the second for loop") #assert false 
+
+        with hcl.for_(0, 7, name="for_loop") as f:
+            hcl.assert_(matrix_2[f,2] != 0, "assert message in the second for loop") #assert false
             hcl.print(0, "in the second for loop\n") #should not be printed
 
         hcl.print(0, "this should not be printed\n") #should not be printed
         return return_matrix
-        
+
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
     return s
-    
-    
+
+
 def test_for_if():
-    hcl.init()
+    hcl.init(raise_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
@@ -56,87 +56,87 @@ def test_for_if():
         return_matrix = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y], "return_matrix")
         matrix_A = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 7, "matrix_A")
         matrix_B = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 8, "matrix_B")
-        
+
         with hcl.for_(0, 7, name="for_loop") as f:
           with hcl.if_(matrix_1[0, f] == 0):
               hcl.assert_(matrix_2[f,2] == 0, "assert message in the first for loop") #assert true
               hcl.print(0, "in the first for loop and if statement\n") #should be printed 7 times
-          
-          hcl.print(0, "in the first for loop, outside if statement\n") #should be printed 7 times      
-        
+
+          hcl.print(0, "in the first for loop, outside if statement\n") #should be printed 7 times
+
         with hcl.for_(0, 7, name="for_loop") as f:
             with hcl.if_(matrix_1[0, f] == 0):
-                hcl.assert_(matrix_2[f,2] != 0, "assert message in the second for loop") #assert false 
+                hcl.assert_(matrix_2[f,2] != 0, "assert message in the second for loop") #assert false
                 hcl.print(0, "in the second for loop and if statement\n") #should not be printed
-            
+
             hcl.print(0, "in the second for loop, outside if statement\n") #should not be printed
-        
+
         hcl.print(0, "this should not be printed\n") #should not be printed
         matrix_C = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 9, "matrix_C")
         matrix_D = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 10, "matrix_D")
         return return_matrix
-        
+
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
     return s
 
 def test_mem_alloc():
-    hcl.init()
+    hcl.init(raise_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
     def kernel(matrix_1, matrix_2):
         first_matrix = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y], "first_matrix")
         return_matrix = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 7, "return_matrix")
-        
+
         hcl.assert_(matrix_1[0,0] == 0, "assert %d message % d", [matrix_1[0,0], matrix_2[0,0]]) #assert is true
         hcl.assert_(matrix_1[0,0] == 10, "assert %d message % d number 2", [matrix_1[0,0], matrix_2[0,0]]) #assert is false
-     
+
         matrix_C = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 9, "matrix_C")
         matrix_D = hcl.compute((m,k), lambda x, y: matrix_1[x,y] + matrix_2[x,y] + 10, "matrix_D")
-        
+
         hcl.assert_(matrix_1[0,0] == 0, "assert %d message % d number 3", [matrix_1[0,0], matrix_2[0,0]]) #assert is true
         hcl.print(0, "this should not be printed\n") #should not be printed
         return return_matrix
-        
+
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
     return s
-         
+
 def run_tests():
     hcl_m1_if = hcl.asarray(np.zeros((m, n)))
     hcl_m2_if = hcl.asarray(np.zeros((m, n)))
     hcl_m3_if = hcl.asarray(np.zeros((m,n)))
-    
+
     hcl_m1_for = hcl.asarray(np.zeros((m, n)))
     hcl_m2_for = hcl.asarray(np.zeros((m, n)))
     hcl_m3_for = hcl.asarray(np.zeros((m,n)))
-    
+
     hcl_m1_for_if = hcl.asarray(np.zeros((m, n)))
     hcl_m2_for_if = hcl.asarray(np.zeros((m, n)))
     hcl_m3_for_if = hcl.asarray(np.zeros((m,n)))
-    
+
     hcl_m1_mem = hcl.asarray(np.zeros((m, n)))
     hcl_m2_mem = hcl.asarray(np.zeros((m, n)))
     hcl_m3_mem = hcl.asarray(np.zeros((m,n)))
-  
+
     s_if = test_with_if()
     s_for = test_with_for()
     s_for_if = test_for_if()
     s_mem = test_mem_alloc()
-    
+
     #test assert in if statment
     f_if = hcl.build(s_if)
     f_if(hcl_m1_if, hcl_m2_if, hcl_m3_if)
-    
+
     #test assert in for loop
     f_for = hcl.build(s_for)
     f_for(hcl_m1_for, hcl_m2_for, hcl_m3_for)
-    
+
     #test assert in if statment in a for loop
     f_for_if = hcl.build(s_for_if)
     f_for_if(hcl_m1_for_if, hcl_m2_for_if, hcl_m3_for_if)
-   
+
     #test assert free memory
     f_mem = hcl.build(s_mem)
     f_mem(hcl_m1_mem, hcl_m2_mem, hcl_m3_mem)
-    
+
 run_tests()

--- a/tests/test_api_assert_cases/basic_assert_tests.py
+++ b/tests/test_api_assert_cases/basic_assert_tests.py
@@ -6,7 +6,7 @@ n = 64
 k = 64
 
 def test_with_if():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
@@ -25,7 +25,7 @@ def test_with_if():
     return s
 
 def test_with_for():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
@@ -48,7 +48,7 @@ def test_with_for():
 
 
 def test_for_if():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
@@ -80,7 +80,7 @@ def test_for_if():
     return s
 
 def test_mem_alloc():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 

--- a/tests/test_api_assert_cases/dsl_def_assert_tests.py
+++ b/tests/test_api_assert_cases/dsl_def_assert_tests.py
@@ -4,6 +4,7 @@ m = 64
 k = 64
 
 def test_assert_module_no_return():
+    hcl.init(raise_exception=False)
 
     def algorithm(A, B):
 
@@ -42,6 +43,7 @@ def test_assert_module_no_return():
     f(_A, _B)
 
 def test_assert_module_with_return():
+    hcl.init(raise_exception=False)
 
     def algorithm(A, B):
 
@@ -102,11 +104,12 @@ def test_assert_module_cond_return_if_only():
     _A = hcl.asarray(a)
     _B = hcl.asarray(b)
 
-    # enters if statement 4 times 
+    # enters if statement 4 times
     # assert condition in the if statement becomes false on the 5th iteration
     f(_A, _B)
 
 def test_assert_module_cond_return_if_else():
+    hcl.init(raise_exception=False)
 
     def algorithm(A, B):
 
@@ -141,6 +144,7 @@ def test_assert_module_cond_return_if_else():
     f(_A, _B)
 
 def test_assert_module_cond_return_multi_if_else():
+    hcl.init(raise_exception=False)
 
     def algorithm(A, B):
 
@@ -180,6 +184,7 @@ def test_assert_module_cond_return_multi_if_else():
     f(_A, _B)
 
 def test_assert_module_cond_return_for():
+    hcl.init(raise_exception=False)
 
     def algorithm(A, B):
 
@@ -213,6 +218,7 @@ def test_assert_module_cond_return_for():
     f(_A, _B)
 
 def test_assert_module_multi_calls():
+    hcl.init(raise_exception=False)
 
     def algorithm(A, B):
 
@@ -253,7 +259,7 @@ def test_assert_module_multi_calls():
     f(_A, _B, _C)
 
 def test_assert_module_declarative():
-    hcl.init()
+    hcl.init(raise_exception=False)
 
     def algorithm(a, b, c):
 
@@ -287,7 +293,7 @@ def test_assert_module_declarative():
     assert np.array_equal(_c.asnumpy(), a + b)
 
 def test_assert_module_declarative_internal_allocate():
-    hcl.init()
+    hcl.init(raise_exception=False)
 
     def algorithm(a, b, c):
 
@@ -322,7 +328,7 @@ def test_assert_module_declarative_internal_allocate():
     assert np.array_equal(_c.asnumpy(), np.zeros(10))
 
 def test_assert_module_declarative_compute_at():
-    hcl.init()
+    hcl.init(raise_exception=False)
 
     def algorithm(a, b, c):
 
@@ -360,7 +366,7 @@ def test_assert_module_declarative_compute_at():
     assert np.array_equal(_c.asnumpy(), a + b + 1)
 
 def test_assert_all_true():
-    hcl.init()
+    hcl.init(raise_exception=False)
 
     def algorithm(a, b, c):
 

--- a/tests/test_api_assert_cases/dsl_def_assert_tests.py
+++ b/tests/test_api_assert_cases/dsl_def_assert_tests.py
@@ -4,7 +4,7 @@ m = 64
 k = 64
 
 def test_assert_module_no_return():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(A, B):
 
@@ -43,7 +43,7 @@ def test_assert_module_no_return():
     f(_A, _B)
 
 def test_assert_module_with_return():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(A, B):
 
@@ -109,7 +109,7 @@ def test_assert_module_cond_return_if_only():
     f(_A, _B)
 
 def test_assert_module_cond_return_if_else():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(A, B):
 
@@ -144,7 +144,7 @@ def test_assert_module_cond_return_if_else():
     f(_A, _B)
 
 def test_assert_module_cond_return_multi_if_else():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(A, B):
 
@@ -184,7 +184,7 @@ def test_assert_module_cond_return_multi_if_else():
     f(_A, _B)
 
 def test_assert_module_cond_return_for():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(A, B):
 
@@ -218,7 +218,7 @@ def test_assert_module_cond_return_for():
     f(_A, _B)
 
 def test_assert_module_multi_calls():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(A, B):
 
@@ -259,7 +259,7 @@ def test_assert_module_multi_calls():
     f(_A, _B, _C)
 
 def test_assert_module_declarative():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(a, b, c):
 
@@ -293,7 +293,7 @@ def test_assert_module_declarative():
     assert np.array_equal(_c.asnumpy(), a + b)
 
 def test_assert_module_declarative_internal_allocate():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(a, b, c):
 
@@ -328,7 +328,7 @@ def test_assert_module_declarative_internal_allocate():
     assert np.array_equal(_c.asnumpy(), np.zeros(10))
 
 def test_assert_module_declarative_compute_at():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(a, b, c):
 
@@ -366,7 +366,7 @@ def test_assert_module_declarative_compute_at():
     assert np.array_equal(_c.asnumpy(), a + b + 1)
 
 def test_assert_all_true():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
 
     def algorithm(a, b, c):
 

--- a/tests/test_api_assert_cases/memory_assert_tests.py
+++ b/tests/test_api_assert_cases/memory_assert_tests.py
@@ -6,7 +6,7 @@ n = 64
 k = 64
 
 def test_mem_alloc_nested():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
 
@@ -43,7 +43,7 @@ def test_mem_alloc_nested():
     return s
 
 def test_mem_if():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
     def kernel(matrix_1, matrix_2):
@@ -64,7 +64,7 @@ def test_mem_if():
     return s
 
 def test_mutate():
-    hcl.init(raise_exception=False)
+    hcl.init(raise_assert_exception=False)
     A = hcl.placeholder((10, ))
     M = hcl.placeholder((2, ))
     def kernel(A, M):

--- a/tests/test_api_assert_cases/memory_assert_tests.py
+++ b/tests/test_api_assert_cases/memory_assert_tests.py
@@ -6,65 +6,65 @@ n = 64
 k = 64
 
 def test_mem_alloc_nested():
-    hcl.init()
+    hcl.init(raise_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
-    
+
     def kernel(matrix_1, matrix_2):
         first_matrix = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y], "first_matrix")
         return_matrix = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y] + 7, "return_matrix")
         ax = hcl.scalar(0)
         with hcl.while_(ax.v < 3):
             matrix_A = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y] + 7, "matrix_A")
-      
+
             with hcl.for_(0, 2, name="for_loop_in") as h:
                 matrix_B = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y] + 8, "matrix_B")
-                
+
                 with hcl.if_(matrix_1[0, 2] >= 0):
                     matrix_C = hcl.compute((m, k), lambda x, y : matrix_1[x, x] + matrix_2[x, x] + 9, "matrix_C")
                     hcl.assert_(matrix_1[0, 0]> 0, "assert message in the if statement %d", matrix_C[0, 0])
                     matrix_D = hcl.compute((m, k), lambda x, y : matrix_1[x, x] + matrix_2[x, x] + 9, "matrix_D")
                     hcl.print(0, "in if statement\n")
-               
+
                 hcl.assert_(matrix_1[0, 0]> 1, "assert message for loop")
                 matrix_F = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y] + 8, "matrix_F")
                 hcl.print(0, "in for loop\n")
-            
+
             hcl.assert_(matrix_1[0, 0]> 2, "assert error, matrix_A[1, 1]: %d matrix_A[2, 1]: %d matrix_A[3, 1]: %d", [matrix_A[1, 1], matrix_A[2, 1], matrix_A[3, 1]])
             hcl.print(0, "in the while loop\n")
             ax.v = ax.v + 1
-        
+
         hcl.assert_(matrix_1[0, 0]> 3, "assert message end")
         matrix_E = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y] + 10, "matrix_E")
         hcl.print(0, "this should not be printed\n")
         return return_matrix
-  
+
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
     return s
 
 def test_mem_if():
-    hcl.init()
+    hcl.init(raise_exception=False)
     matrix_1 = hcl.placeholder((m, k))
     matrix_2 = hcl.placeholder((k, n))
     def kernel(matrix_1, matrix_2):
         return_matrix = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y], "return_matrix")
-        
+
         with hcl.if_(matrix_2[0, 0] == 0):
             matrix_A = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y], "matrix_A")
         with hcl.else_():
             matrix_B = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y] + 2, "matrix_B")
-        
+
         hcl.assert_(matrix_1[0, 0] != 0, "customized assert message 1") #result is false
-        
+
         matrix_C = hcl.compute((m, k), lambda x, y : matrix_1[x, y] + matrix_2[x, y], "matrix_C")
         hcl.print(0, "this shouldn't be printed")
         return return_matrix
-    
+
     s = hcl.create_schedule([matrix_1, matrix_2], kernel)
     return s
 
 def test_mutate():
-    hcl.init()
+    hcl.init(raise_exception=False)
     A = hcl.placeholder((10, ))
     M = hcl.placeholder((2, ))
     def kernel(A, M):
@@ -85,52 +85,52 @@ def run_tests():
     hcl_m1_mem0 = hcl.asarray(np.zeros((m, n)))
     hcl_m2_mem0 = hcl.asarray(np.zeros((m, n)))
     hcl_m3_mem0 = hcl.asarray(np.zeros((m,n)))
-    
+
     hcl_m1_mem1 = hcl.asarray(np.ones((m, n)))
     hcl_m2_mem1 = hcl.asarray(np.ones((m, n)))
     hcl_m3_mem1 = hcl.asarray(np.zeros((m,n)))
-    
+
     np_mem2 = 2 * np.ones((m,n))
     hcl_m1_mem2 = hcl.asarray(np_mem2)
     hcl_m2_mem2 = hcl.asarray(np_mem2)
     hcl_m3_mem2 = hcl.asarray(np.zeros((m,n)))
-    
+
     np_mem3 = 3 * np.ones((m,n))
     hcl_m1_mem3 = hcl.asarray(np_mem3)
     hcl_m2_mem3 = hcl.asarray(np_mem3)
     hcl_m3_mem3 = hcl.asarray(np.zeros((m,n)))
-    
+
     s_mem = test_mem_alloc_nested()
-    
+
     f_mem = hcl.build(s_mem)
-     
-    #these tests check whether assert false deallocates memory properly when in nested loops 
-    f_mem(hcl_m1_mem0, hcl_m2_mem0, hcl_m3_mem0) 
-  
+
+    #these tests check whether assert false deallocates memory properly when in nested loops
+    f_mem(hcl_m1_mem0, hcl_m2_mem0, hcl_m3_mem0)
+
     f_mem(hcl_m1_mem1, hcl_m2_mem1, hcl_m3_mem1)
-  
+
     f_mem(hcl_m1_mem2, hcl_m2_mem2, hcl_m3_mem2)
-  
+
     f_mem(hcl_m1_mem3, hcl_m2_mem3, hcl_m3_mem3)
-   
+
     hcl_m1_if = hcl.asarray(np.zeros((m, n)))
     hcl_m2_if = hcl.asarray(np.zeros((m, n)))
     hcl_m3_if = hcl.asarray(np.zeros((m,n)))
-    
+
     s_if = test_mem_if()
-    
+
     #this is to test the case where memory gets allocated and then deallocated before assert statement
     f_if = hcl.build(s_if)
-    f_if(hcl_m1_if, hcl_m2_if, hcl_m3_if)  
-    
+    f_if(hcl_m1_if, hcl_m2_if, hcl_m3_if)
+
     hcl_m1_mutate = hcl.asarray(np.ones((10,)))
     hcl_m2_mutate = hcl.asarray(np.zeros((2,)))
     hcl_m3_mutate = hcl.asarray(np.zeros((m,n)))
-    
+
     s_mutate = test_mutate()
-    
+
     #this is to test whether assert is compatible with mutate
     f_mutate = hcl.build(s_mutate)
-    f_mutate(hcl_m1_mutate, hcl_m2_mutate)     
-    
+    f_mutate(hcl_m1_mutate, hcl_m2_mutate)
+
 run_tests()

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -230,16 +230,14 @@ void CodeGenLLVM::Optimize() {
   llvm::PassManagerBuilder builder;
   builder.OptLevel = 3;
 
-  /*
 #if TVM_LLVM_VERSION >= 50
   builder.Inliner =
       llvm::createFunctionInliningPass(builder.OptLevel, 0, false);
 #else
   builder.Inliner = llvm::createFunctionInliningPass(builder.OptLevel, 0);
 #endif
-  builder.LoopVectorize = true;
-  builder.SLPVectorize = true;
-  */
+  // builder.LoopVectorize = true;
+  // builder.SLPVectorize = true;
   this->InitPassManagerBuilder(&builder);
 
 #if TVM_LLVM_VERSION >= 50
@@ -1476,9 +1474,6 @@ void CodeGenLLVM::VisitStmt_(const ProducerConsumer* op) {
 void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   this->SaveFuncState();
   const UIntImm* is_void = op->ret_void.as<UIntImm>();
-  bool orig_assert_ret_void = assert_ret_void_;
-  has_assert_ = false;
-  assert_ret_void_ = is_void->value;
   std::unordered_map<const Variable*, llvm::Value*> var_map_old(var_map_);
   std::string name = function_->getName();
 
@@ -1500,7 +1495,6 @@ void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   function->setCallingConv(llvm::CallingConv::C);
   function->setDLLStorageClass(
       llvm::GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
-  function->addFnAttr(llvm::Attribute::NoInline);
   auto arg_it = function->arg_begin();
   for (size_t i = 0; i < op->args.size(); ++i, ++arg_it) {
     llvm::Argument* v = &(*arg_it);
@@ -1521,8 +1515,6 @@ void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   this->RestoreFuncState();
   function_ = module_->getFunction(name);
   builder_->SetInsertPoint(end);
-  assert_ret_void_ = orig_assert_ret_void;
-  kernel_has_assert_[op->name] = has_assert_;
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
@@ -1534,20 +1526,17 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
   }
   llvm::Function* f = module_->getFunction(op->name);
   llvm::Value* ret_val = builder_->CreateCall(f, arg_value);
-  if (kernel_has_assert_[op->name]) {
-    llvm::BasicBlock* assert_true_kernel =
-        llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
-    llvm::BasicBlock* assert_false_kernel =
-        llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
-    llvm::Value* assert_flag =
-        builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
-    llvm::Value* cond = builder_->CreateICmpEQ(assert_flag, ConstInt32(1));
-    builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
-    builder_->SetInsertPoint(assert_false_kernel);
-    AssertFreeVars();
-    builder_->CreateRet(ConstInt32(1));
-    builder_->SetInsertPoint(assert_true_kernel);
-  }
+  llvm::BasicBlock* assert_true_kernel =
+      llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
+  llvm::BasicBlock* assert_false_kernel =
+      llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
+  llvm::Value* cond =
+      builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
+  builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
+  builder_->SetInsertPoint(assert_false_kernel);
+  AssertFreeVars();
+  builder_->CreateRet(ConstInt32(0));
+  builder_->SetInsertPoint(assert_true_kernel);
   return ret_val;
 }
 
@@ -1560,20 +1549,17 @@ void CodeGenLLVM::VisitStmt_(const KernelStmt* op) {
   }
   llvm::Function* f = module_->getFunction(op->name);
   builder_->CreateCall(f, arg_value);
-  if (kernel_has_assert_[op->name]) {
-    llvm::BasicBlock* assert_true_kernel =
-        llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
-    llvm::BasicBlock* assert_false_kernel =
-        llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
-    llvm::Value* assert_flag =
-        builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
-    llvm::Value* cond = builder_->CreateICmpEQ(assert_flag, ConstInt32(1));
-    builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
-    builder_->SetInsertPoint(assert_false_kernel);
-    AssertFreeVars();
-    builder_->CreateRet(ConstInt32(1));
-    builder_->SetInsertPoint(assert_true_kernel);
-  }
+  llvm::BasicBlock* assert_true_kernel =
+      llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
+  llvm::BasicBlock* assert_false_kernel =
+      llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
+  llvm::Value* cond =
+      builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
+  builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
+  builder_->SetInsertPoint(assert_false_kernel);
+  AssertFreeVars();
+  builder_->CreateRet(ConstInt32(0));
+  builder_->SetInsertPoint(assert_true_kernel);
 }
 
 void CodeGenLLVM::VisitStmt_(const Return* op) {
@@ -1650,7 +1636,6 @@ void CodeGenLLVM::VisitStmt_(const MultiBlock* op) {
 }
 
 void CodeGenLLVM::VisitStmt_(const Assert* op) {
-  has_assert_ = true;
   std::vector<llvm::Value*> values;
   std::vector<Type> types;
   std::vector<llvm::Type*> llvm_types;
@@ -1697,17 +1682,15 @@ void CodeGenLLVM::VisitStmt_(const Assert* op) {
   builder_->CreateCall(printf_call, printf_args);
   AssertFreeVars();
   builder_->CreateStore(ConstInt32(0), assert_global_ptr_);
-  if (assert_ret_void_) {
-    builder_->CreateRetVoid();
-  } else {
-    builder_->CreateRet(ConstInt32(1));
-  }
+  builder_->CreateRet(ConstInt32(0));
   builder_->SetInsertPoint(assertstmt_true);
   builder_->CreateStore(ConstInt32(1), assert_global_ptr_);
 }
 
 void CodeGenLLVM::AssertFreeVars() {
   from_assert_ = true;
+  std::string if_then_name = "if_then_";
+  std::string if_end_name = "if_end_";
   for (size_t num_free = 0; num_free < assert_alloc_mem_.size(); num_free++) {
     Expr free_op =
         Call::make(Int(32), "TVMBackendFreeWorkspace",
@@ -1715,7 +1698,17 @@ void CodeGenLLVM::AssertFreeVars() {
                     cast(Int(32), assert_alloc_mem_[num_free].dev_id_),
                     assert_alloc_mem_[num_free].buffer_var_},
                    Call::Extern);
-    MakeValue(free_op);
+    llvm::Value* v = MakeValue(free_op);
+    llvm::Value* ne = builder_->CreateICmpNE(v, ConstInt32(0));
+    llvm::BasicBlock* if_true_ = llvm::BasicBlock::Create(
+        *ctx_, if_then_name + std::to_string(num_free), function_);
+    llvm::BasicBlock* if_end_ = llvm::BasicBlock::Create(
+        *ctx_, if_end_name + std::to_string(num_free), function_);
+    builder_->CreateCondBr(ne, if_end_, if_true_);
+    builder_->SetInsertPoint(if_end_);
+    builder_->CreateRet(ConstInt32(-1));
+    builder_->CreateBr(if_true_);
+    builder_->SetInsertPoint(if_true_);
   }
   from_assert_ = false;
 }

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -1535,7 +1535,7 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
   builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
   builder_->SetInsertPoint(assert_false_kernel);
   AssertFreeVars();
-  builder_->CreateRet(ConstInt32(0));
+  builder_->CreateRet(ConstInt32(1));
   builder_->SetInsertPoint(assert_true_kernel);
   return ret_val;
 }
@@ -1558,7 +1558,7 @@ void CodeGenLLVM::VisitStmt_(const KernelStmt* op) {
   builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
   builder_->SetInsertPoint(assert_false_kernel);
   AssertFreeVars();
-  builder_->CreateRet(ConstInt32(0));
+  builder_->CreateRet(ConstInt32(1));
   builder_->SetInsertPoint(assert_true_kernel);
 }
 
@@ -1682,7 +1682,7 @@ void CodeGenLLVM::VisitStmt_(const Assert* op) {
   builder_->CreateCall(printf_call, printf_args);
   AssertFreeVars();
   builder_->CreateStore(ConstInt32(0), assert_global_ptr_);
-  builder_->CreateRet(ConstInt32(0));
+  builder_->CreateRet(ConstInt32(1));
   builder_->SetInsertPoint(assertstmt_true);
   builder_->CreateStore(ConstInt32(1), assert_global_ptr_);
 }

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -230,14 +230,16 @@ void CodeGenLLVM::Optimize() {
   llvm::PassManagerBuilder builder;
   builder.OptLevel = 3;
 
+  /*
 #if TVM_LLVM_VERSION >= 50
   builder.Inliner =
       llvm::createFunctionInliningPass(builder.OptLevel, 0, false);
 #else
   builder.Inliner = llvm::createFunctionInliningPass(builder.OptLevel, 0);
 #endif
-  // builder.LoopVectorize = true;
-  // builder.SLPVectorize = true;
+  builder.LoopVectorize = true;
+  builder.SLPVectorize = true;
+  */
   this->InitPassManagerBuilder(&builder);
 
 #if TVM_LLVM_VERSION >= 50
@@ -1474,6 +1476,9 @@ void CodeGenLLVM::VisitStmt_(const ProducerConsumer* op) {
 void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   this->SaveFuncState();
   const UIntImm* is_void = op->ret_void.as<UIntImm>();
+  bool orig_assert_ret_void = assert_ret_void_;
+  has_assert_ = false;
+  assert_ret_void_ = is_void->value;
   std::unordered_map<const Variable*, llvm::Value*> var_map_old(var_map_);
   std::string name = function_->getName();
 
@@ -1495,6 +1500,7 @@ void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   function->setCallingConv(llvm::CallingConv::C);
   function->setDLLStorageClass(
       llvm::GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
+  function->addFnAttr(llvm::Attribute::NoInline);
   auto arg_it = function->arg_begin();
   for (size_t i = 0; i < op->args.size(); ++i, ++arg_it) {
     llvm::Argument* v = &(*arg_it);
@@ -1515,6 +1521,8 @@ void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   this->RestoreFuncState();
   function_ = module_->getFunction(name);
   builder_->SetInsertPoint(end);
+  assert_ret_void_ = orig_assert_ret_void;
+  kernel_has_assert_[op->name] = has_assert_;
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
@@ -1526,17 +1534,20 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
   }
   llvm::Function* f = module_->getFunction(op->name);
   llvm::Value* ret_val = builder_->CreateCall(f, arg_value);
-  llvm::BasicBlock* assert_true_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
-  llvm::BasicBlock* assert_false_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
-  llvm::Value* cond =
-      builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
-  builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
-  builder_->SetInsertPoint(assert_false_kernel);
-  AssertFreeVars();
-  builder_->CreateRet(ConstInt32(1));
-  builder_->SetInsertPoint(assert_true_kernel);
+  if (kernel_has_assert_[op->name]) {
+    llvm::BasicBlock* assert_true_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
+    llvm::BasicBlock* assert_false_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
+    llvm::Value* assert_flag =
+        builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
+    llvm::Value* cond = builder_->CreateICmpEQ(assert_flag, ConstInt32(1));
+    builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
+    builder_->SetInsertPoint(assert_false_kernel);
+    AssertFreeVars();
+    builder_->CreateRet(ConstInt32(1));
+    builder_->SetInsertPoint(assert_true_kernel);
+  }
   return ret_val;
 }
 
@@ -1549,17 +1560,20 @@ void CodeGenLLVM::VisitStmt_(const KernelStmt* op) {
   }
   llvm::Function* f = module_->getFunction(op->name);
   builder_->CreateCall(f, arg_value);
-  llvm::BasicBlock* assert_true_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
-  llvm::BasicBlock* assert_false_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
-  llvm::Value* cond =
-      builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
-  builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
-  builder_->SetInsertPoint(assert_false_kernel);
-  AssertFreeVars();
-  builder_->CreateRet(ConstInt32(1));
-  builder_->SetInsertPoint(assert_true_kernel);
+  if (kernel_has_assert_[op->name]) {
+    llvm::BasicBlock* assert_true_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
+    llvm::BasicBlock* assert_false_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
+    llvm::Value* assert_flag =
+        builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
+    llvm::Value* cond = builder_->CreateICmpEQ(assert_flag, ConstInt32(1));
+    builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
+    builder_->SetInsertPoint(assert_false_kernel);
+    AssertFreeVars();
+    builder_->CreateRet(ConstInt32(1));
+    builder_->SetInsertPoint(assert_true_kernel);
+  }
 }
 
 void CodeGenLLVM::VisitStmt_(const Return* op) {
@@ -1636,6 +1650,7 @@ void CodeGenLLVM::VisitStmt_(const MultiBlock* op) {
 }
 
 void CodeGenLLVM::VisitStmt_(const Assert* op) {
+  has_assert_ = true;
   std::vector<llvm::Value*> values;
   std::vector<Type> types;
   std::vector<llvm::Type*> llvm_types;
@@ -1682,15 +1697,17 @@ void CodeGenLLVM::VisitStmt_(const Assert* op) {
   builder_->CreateCall(printf_call, printf_args);
   AssertFreeVars();
   builder_->CreateStore(ConstInt32(0), assert_global_ptr_);
-  builder_->CreateRet(ConstInt32(1));
+  if (assert_ret_void_) {
+    builder_->CreateRetVoid();
+  } else {
+    builder_->CreateRet(ConstInt32(1));
+  }
   builder_->SetInsertPoint(assertstmt_true);
   builder_->CreateStore(ConstInt32(1), assert_global_ptr_);
 }
 
 void CodeGenLLVM::AssertFreeVars() {
   from_assert_ = true;
-  std::string if_then_name = "if_then_";
-  std::string if_end_name = "if_end_";
   for (size_t num_free = 0; num_free < assert_alloc_mem_.size(); num_free++) {
     Expr free_op =
         Call::make(Int(32), "TVMBackendFreeWorkspace",
@@ -1698,17 +1715,7 @@ void CodeGenLLVM::AssertFreeVars() {
                     cast(Int(32), assert_alloc_mem_[num_free].dev_id_),
                     assert_alloc_mem_[num_free].buffer_var_},
                    Call::Extern);
-    llvm::Value* v = MakeValue(free_op);
-    llvm::Value* ne = builder_->CreateICmpNE(v, ConstInt32(0));
-    llvm::BasicBlock* if_true_ = llvm::BasicBlock::Create(
-        *ctx_, if_then_name + std::to_string(num_free), function_);
-    llvm::BasicBlock* if_end_ = llvm::BasicBlock::Create(
-        *ctx_, if_end_name + std::to_string(num_free), function_);
-    builder_->CreateCondBr(ne, if_end_, if_true_);
-    builder_->SetInsertPoint(if_end_);
-    builder_->CreateRet(ConstInt32(-1));
-    builder_->CreateBr(if_true_);
-    builder_->SetInsertPoint(if_true_);
+    MakeValue(free_op);
   }
   from_assert_ = false;
 }

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -230,14 +230,16 @@ void CodeGenLLVM::Optimize() {
   llvm::PassManagerBuilder builder;
   builder.OptLevel = 3;
 
+  /*
 #if TVM_LLVM_VERSION >= 50
   builder.Inliner =
       llvm::createFunctionInliningPass(builder.OptLevel, 0, false);
 #else
   builder.Inliner = llvm::createFunctionInliningPass(builder.OptLevel, 0);
 #endif
-  // builder.LoopVectorize = true;
-  // builder.SLPVectorize = true;
+  builder.LoopVectorize = true;
+  builder.SLPVectorize = true;
+  */
   this->InitPassManagerBuilder(&builder);
 
 #if TVM_LLVM_VERSION >= 50
@@ -1474,6 +1476,9 @@ void CodeGenLLVM::VisitStmt_(const ProducerConsumer* op) {
 void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   this->SaveFuncState();
   const UIntImm* is_void = op->ret_void.as<UIntImm>();
+  bool orig_assert_ret_void = assert_ret_void_;
+  has_assert_ = false;
+  assert_ret_void_ = is_void->value;
   std::unordered_map<const Variable*, llvm::Value*> var_map_old(var_map_);
   std::string name = function_->getName();
 
@@ -1495,6 +1500,7 @@ void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   function->setCallingConv(llvm::CallingConv::C);
   function->setDLLStorageClass(
       llvm::GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
+  function->addFnAttr(llvm::Attribute::NoInline);
   auto arg_it = function->arg_begin();
   for (size_t i = 0; i < op->args.size(); ++i, ++arg_it) {
     llvm::Argument* v = &(*arg_it);
@@ -1515,6 +1521,8 @@ void CodeGenLLVM::VisitStmt_(const KernelDef* op) {
   this->RestoreFuncState();
   function_ = module_->getFunction(name);
   builder_->SetInsertPoint(end);
+  assert_ret_void_ = orig_assert_ret_void;
+  kernel_has_assert_[op->name] = has_assert_;
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
@@ -1526,17 +1534,20 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const KernelExpr* op) {
   }
   llvm::Function* f = module_->getFunction(op->name);
   llvm::Value* ret_val = builder_->CreateCall(f, arg_value);
-  llvm::BasicBlock* assert_true_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
-  llvm::BasicBlock* assert_false_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
-  llvm::Value* cond =
-      builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
-  builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
-  builder_->SetInsertPoint(assert_false_kernel);
-  AssertFreeVars();
-  builder_->CreateRet(ConstInt32(0));
-  builder_->SetInsertPoint(assert_true_kernel);
+  if (kernel_has_assert_[op->name]) {
+    llvm::BasicBlock* assert_true_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
+    llvm::BasicBlock* assert_false_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
+    llvm::Value* assert_flag =
+        builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
+    llvm::Value* cond = builder_->CreateICmpEQ(assert_flag, ConstInt32(1));
+    builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
+    builder_->SetInsertPoint(assert_false_kernel);
+    AssertFreeVars();
+    builder_->CreateRet(ConstInt32(1));
+    builder_->SetInsertPoint(assert_true_kernel);
+  }
   return ret_val;
 }
 
@@ -1549,17 +1560,20 @@ void CodeGenLLVM::VisitStmt_(const KernelStmt* op) {
   }
   llvm::Function* f = module_->getFunction(op->name);
   builder_->CreateCall(f, arg_value);
-  llvm::BasicBlock* assert_true_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
-  llvm::BasicBlock* assert_false_kernel =
-      llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
-  llvm::Value* cond =
-      builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
-  builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
-  builder_->SetInsertPoint(assert_false_kernel);
-  AssertFreeVars();
-  builder_->CreateRet(ConstInt32(0));
-  builder_->SetInsertPoint(assert_true_kernel);
+  if (kernel_has_assert_[op->name]) {
+    llvm::BasicBlock* assert_true_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_true_kernel", function_);
+    llvm::BasicBlock* assert_false_kernel =
+        llvm::BasicBlock::Create(*ctx_, "assert_false_kernel", function_);
+    llvm::Value* assert_flag =
+        builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_), assert_global_ptr_);
+    llvm::Value* cond = builder_->CreateICmpEQ(assert_flag, ConstInt32(1));
+    builder_->CreateCondBr(cond, assert_true_kernel, assert_false_kernel);
+    builder_->SetInsertPoint(assert_false_kernel);
+    AssertFreeVars();
+    builder_->CreateRet(ConstInt32(1));
+    builder_->SetInsertPoint(assert_true_kernel);
+  }
 }
 
 void CodeGenLLVM::VisitStmt_(const Return* op) {
@@ -1636,6 +1650,7 @@ void CodeGenLLVM::VisitStmt_(const MultiBlock* op) {
 }
 
 void CodeGenLLVM::VisitStmt_(const Assert* op) {
+  has_assert_ = true;
   std::vector<llvm::Value*> values;
   std::vector<Type> types;
   std::vector<llvm::Type*> llvm_types;
@@ -1682,15 +1697,17 @@ void CodeGenLLVM::VisitStmt_(const Assert* op) {
   builder_->CreateCall(printf_call, printf_args);
   AssertFreeVars();
   builder_->CreateStore(ConstInt32(0), assert_global_ptr_);
-  builder_->CreateRet(ConstInt32(0));
+  if (assert_ret_void_) {
+    builder_->CreateRetVoid();
+  } else {
+    builder_->CreateRet(ConstInt32(1));
+  }
   builder_->SetInsertPoint(assertstmt_true);
   builder_->CreateStore(ConstInt32(1), assert_global_ptr_);
 }
 
 void CodeGenLLVM::AssertFreeVars() {
   from_assert_ = true;
-  std::string if_then_name = "if_then_";
-  std::string if_end_name = "if_end_";
   for (size_t num_free = 0; num_free < assert_alloc_mem_.size(); num_free++) {
     Expr free_op =
         Call::make(Int(32), "TVMBackendFreeWorkspace",
@@ -1698,17 +1715,7 @@ void CodeGenLLVM::AssertFreeVars() {
                     cast(Int(32), assert_alloc_mem_[num_free].dev_id_),
                     assert_alloc_mem_[num_free].buffer_var_},
                    Call::Extern);
-    llvm::Value* v = MakeValue(free_op);
-    llvm::Value* ne = builder_->CreateICmpNE(v, ConstInt32(0));
-    llvm::BasicBlock* if_true_ = llvm::BasicBlock::Create(
-        *ctx_, if_then_name + std::to_string(num_free), function_);
-    llvm::BasicBlock* if_end_ = llvm::BasicBlock::Create(
-        *ctx_, if_end_name + std::to_string(num_free), function_);
-    builder_->CreateCondBr(ne, if_end_, if_true_);
-    builder_->SetInsertPoint(if_end_);
-    builder_->CreateRet(ConstInt32(-1));
-    builder_->CreateBr(if_true_);
-    builder_->SetInsertPoint(if_true_);
+    MakeValue(free_op);
   }
   from_assert_ = false;
 }

--- a/tvm/src/codegen/llvm/codegen_llvm.h
+++ b/tvm/src/codegen/llvm/codegen_llvm.h
@@ -292,6 +292,9 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const Expr&)>,
   std::vector<assert_alloc_free_> assert_alloc_mem_;
   bool assert_save_buffer_{false};
   bool from_assert_{false};
+  bool assert_ret_void_{false};
+  bool has_assert_{false};
+  std::map<std::string, bool> kernel_has_assert_;
   llvm::Constant* assert_global_ptr_;
 
   // for kernel use

--- a/tvm/src/codegen/llvm/llvm_module.cc
+++ b/tvm/src/codegen/llvm/llvm_module.cc
@@ -49,7 +49,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
       int ret = (*faddr)((void*)args.values,     // NOLINT(*)
                          (int*)args.type_codes,  // NOLINT(*)
                          args.num_args);
-      CHECK_EQ(ret, 0) << TVMGetLastError();
+      *rv = ret;
     });
   }
 


### PR DESCRIPTION
**Fixed issue:** #413 

**Detailed description:** 
Now when `hcl.assert` failed, an exception will be raised. Users can turn off the exception by setting `hcl.init(raise_assert_exception=False)`. An example program to catch the assertion fail looks like this

```python
def kernel(...):
    ...
    hcl.assert_(xxx)

s = hcl.create_schedule()
f = hcl.build(s)

try:
    f(args)
except hcl.debug.AssertError:
    # handle the exception
```

**Link to the tests:** 
Add one test under test_api_assert.py.

