### PR TITLE
[Backend] Fix issues in OpenCL/HLSC code generator

### DIFF
--- a/tests/issues/test_issue_194.py
+++ b/tests/issues/test_issue_194.py
@@ -1,0 +1,17 @@
+import heterocl as hcl
+
+def test_hls_function_array_interface():
+    hcl.init()
+    A = hcl.placeholder((10, 32), "A")
+    def kernel(A):
+        B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B")
+        C = hcl.compute(A.shape, lambda *args : B[args] + 1, "C")
+        D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
+        return D
+    
+    target = hcl.Platform.aws_f1
+    s = hcl.create_schedule([A], kernel)
+    target.config(compiler="vivado_hls", mode="debug")
+    f = hcl.build(s, target)
+    assert "void test(int A[10][32], int D[10][32])" in f
+

--- a/tests/issues/test_issue_207.py
+++ b/tests/issues/test_issue_207.py
@@ -1,0 +1,17 @@
+import heterocl as hcl
+
+def test_auto_compute_placement():
+    hcl.init()
+    A = hcl.placeholder((10, 32), "A")
+    def kernel(A):
+        B = hcl.compute(A.shape, lambda *args : A[args] + 1, "B")
+        C = hcl.compute(A.shape, lambda *args : B[args] + 1, "C")
+        D = hcl.compute(A.shape, lambda *args : C[args] * 2, "D")
+        return D
+    
+    target = hcl.Platform.aws_f1
+    s = hcl.create_schedule([A], kernel)
+    target.config(compiler="vivado_hls", mode="debug")
+    f = hcl.build(s, target)
+    assert "void test(int A[10][32], int D[10][32])" in f
+

--- a/tests/issues/test_issue_275.py
+++ b/tests/issues/test_issue_275.py
@@ -1,0 +1,31 @@
+import heterocl as hcl
+import numpy as np
+
+def test_vitis():
+    A = hcl.placeholder((10,), "A")
+    W = hcl.placeholder((10,), "W")
+
+    def kernel(A, W):
+        B = hcl.compute(A.shape, 
+                lambda i: A[i] + 1, "B")
+        C = hcl.compute(B.shape,
+                lambda i: B[i] + W[i], "C")
+        return C
+
+    target = hcl.Platform.aws_f1
+    target.config(compiler="vitis", mode="debug", project="project-vitis.prj")
+    s = hcl.create_schedule([A, W], kernel)
+    s.to([A, W], target.xcel)
+    s.to(kernel.C, target.host)
+    s.to(kernel.B, s[kernel.C])
+    f = hcl.build(s, target)
+    np_A = np.zeros((10,))
+    np_W = np.zeros((10,))
+    np_C = np.zeros((10,))
+    hcl_A = hcl.asarray(np_A)
+    hcl_W = hcl.asarray(np_W)
+    hcl_C = hcl.asarray(np_C)
+    assert "bundle=gmem0" in f
+    assert "bundle=gmem1" in f
+    assert "bundle=gmem2" in f
+

--- a/tests/issues/test_issue_304.py
+++ b/tests/issues/test_issue_304.py
@@ -1,0 +1,20 @@
+import heterocl as hcl
+import numpy as np
+
+def test_zero_allocate():
+
+    def kernel(A):
+        with hcl.for_(0, 10) as i:
+            with hcl.for_(i, 10) as j:
+                A[j] += i
+        return hcl.compute((0,), lambda x: A[x], "B")
+
+    A = hcl.placeholder((10,))
+    s = hcl.create_schedule(A, kernel)
+    p = hcl.Platform.aws_f1
+    p.config(compiler="vitis", mode="debug", backend="vhls")
+    try:
+        f = hcl.build(s, p)
+    except:
+        print("passed")
+

--- a/tests/issues/test_issue_416.py
+++ b/tests/issues/test_issue_416.py
@@ -104,12 +104,10 @@ def test_code_gen_knn():
     # Generate HLS kernel code and OpenCL host code
     hcl.init(dtype_image)
     target = hcl.Platform.aws_f1
-    target.config(compiler="vitis", backend="vhls", mode="hw_sim")
+    target.config(compiler="vitis", backend="vhls", mode="debug")
     code = top(target)
+    assert "buffer_test_image = test_image" in code, code
 
-    hcl_train_images = hcl.asarray(np.zeros((10,1800)), dtype_image)
-    hcl_knn_mat = hcl.asarray(np.zeros((10,3)), dtype_knnmat)
-    code(20, hcl_train_images, hcl_knn_mat)
 
 if __name__ == "__main__":
     test_code_gen_knn()

--- a/tests/issues/test_issue_416.py
+++ b/tests/issues/test_issue_416.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import heterocl as hcl
+import time
+import numpy as np
+import math
+
+N = 7 * 7
+max_bit = int(math.ceil(math.log(N, 2)))
+data_size = (10, 1800)
+dtype_image = hcl.UInt(N)
+dtype_knnmat = hcl.UInt(max_bit)
+hcl.init(dtype_image)
+
+def top(target=None):
+
+    # Algorithm definition (§1)
+    def knn(test_image, train_images):
+
+        # Imperative programming and bit operations (§2)
+        def popcount(num):
+            out = hcl.scalar(0, "out")
+            with hcl.for_(0, train_images.type.bits) as i:
+                # Bit selection operation
+                out.v += num[i]
+            return out.v
+
+        # This function update the candidates, i.e., `knn_mat`. Here we mutate
+        # through the shape of tensor `dist`. For each `dist` value, if it is
+        # smaller than the maximum candidate, we replace it.
+        def update_knn(dist, knn_mat, i, j):
+            max_id = hcl.scalar(0, "max_id")
+            with hcl.for_(0, 3) as k:
+                with hcl.if_(knn_mat[i][k] > knn_mat[i][max_id.v]):
+                    max_id.v = k
+            with hcl.if_(dist[i][j] < knn_mat[i][max_id.v]):
+                knn_mat[i][max_id.v] = dist[i][j]
+
+        # Main algorithm (§3)
+        # Fist step: XOR (§3.1)
+        diff = hcl.compute(train_images.shape,
+                           lambda x, y: train_images[x][y] ^ test_image,
+                           "diff")
+
+        # Second step: popcount (§3.2)
+        dist = hcl.compute(diff.shape,
+                           lambda x, y: popcount(diff[x][y]),
+                           "dist")
+
+
+        # Third step: initialize the candidates (§3.3)
+        knn_mat = hcl.compute((10, 3), lambda x, y: 50, "knn_mat")
+
+
+        # Fourth step: update the candidates (§3.4)
+        hcl.mutate(dist.shape,
+                        lambda x, y: update_knn(dist, knn_mat, x, y),
+                        "knn_update")
+
+        # Final step: return the candidates (§3.5)
+        return knn_mat
+
+    # Inputs/Outputs definition (§4)
+    # Scalars (§4.1)
+    test_image = hcl.placeholder((), "test_image")
+    # Tensors (§4.2)
+    train_images = hcl.placeholder(data_size, "train_images")
+
+    # Data type customization (§5.1)
+    scheme = hcl.create_scheme([test_image, train_images], knn)
+    scheme.downsize([knn.dist, knn.dist.out, knn.knn_mat], dtype_knnmat)
+
+    # Compute customization (§5.2)
+    s = hcl.create_schedule_from_scheme(scheme)
+
+    diff = knn.diff
+    dist = knn.dist
+    knn_update = knn.knn_update
+
+    # Merge loop nests
+    s[diff].compute_at(s[dist], dist.axis[1])
+    s[dist].compute_at(s[knn_update], knn_update.axis[1])
+
+    # Reorder loop to expose more parallelism
+    s[knn_update].reorder(knn_update.axis[1], knn_update.axis[0])
+
+    s[knn.knn_mat].unroll(0)
+    s[knn.knn_mat].unroll(1)
+    # Pipeline the outer loop and let the inner loop unrolled automatically
+    s[knn_update].pipeline(knn_update.axis[1])
+
+    s.partition(train_images, dim=1)
+    s.partition(knn.knn_mat)
+
+    # Move data to and from device
+    if isinstance(target, hcl.Platform):
+        s.to(train_images, target.xcel, burst_len=16)
+        s.to(knn_update.knn_mat, target.host, burst_len=16)
+
+    # At the end, we build the whole offloaded function.
+    return hcl.build(s, target=target)
+
+
+def test_code_gen_knn():
+    # Generate HLS kernel code and OpenCL host code
+    hcl.init(dtype_image)
+    target = hcl.Platform.aws_f1
+    target.config(compiler="vitis", backend="vhls", mode="hw_sim")
+    code = top(target)
+
+    hcl_train_images = hcl.asarray(np.zeros((10,1800)), dtype_image)
+    hcl_knn_mat = hcl.asarray(np.zeros((10,3)), dtype_knnmat)
+    code(20, hcl_train_images, hcl_knn_mat)
+
+if __name__ == "__main__":
+    test_code_gen_knn()

--- a/tvm/src/codegen/hlsc/codegen_vhls.cc
+++ b/tvm/src/codegen/hlsc/codegen_vhls.cc
@@ -615,7 +615,7 @@ void CodeGenVivadoHLS::VisitStmt_(const KernelDef* op) {
             stream << "#pragma HLS INTERFACE axis port=" << info.name << "\n";
           } else {
             stream << "#pragma HLS INTERFACE m_axi port=" << info.name << " "
-                   << "offset=slave bundle=gmem" << info.mem_port << "\n";
+                   << "offset=slave bundle=gmem" << i << "\n";
           }
         }
       }

--- a/tvm/src/codegen/opencl/codegen_xocl_host.cc
+++ b/tvm/src/codegen/opencl/codegen_xocl_host.cc
@@ -266,12 +266,14 @@ void CodeGenXOCLHost::VisitStmt_(const KernelStmt* op) {
       auto v = op->args[k].as<Variable>();
       CHECK(v) << "invalid input var";
       auto shape = var_shape_map_[v];
-      if (shape.size() == 0) {
-        continue;
-      }
-
       auto info = args_info[k];
       auto arg_name = info.name;
+
+      if (shape.size() == 0) {
+        PrintIndent();
+        stream << "auto buffer_" << arg_name << " = " << arg_name << ";\n";
+        continue;
+      }
 
       // TODO(Hecmay): check xrt stream with other storage media
       if (info.storage_type == StorageType::devDRAM) {


### PR DESCRIPTION
### **Fixed issue:** #416 

**Detailed description:** The OpenCL host generator does not generate OpenCL buffer for scalar input/output. 

**Link to the tests:** tests/issues/test_issue_416.py

### **Fixed issue:** #275

**Detailed description:** The HLS code generator binds multiple different off-chip memory accesses to the same AXI controller, and thus the design cannot pass dataflow check. 

**Link to the tests:** tests/issues/test_issue_275.py

### **Fixed issue:** #194

**Detailed description:** Generate multi-dim array for top-level function. This will avoid some synthesis errors that may happen in Vivado HLS of older versions.

**Link to the tests:** tests/issues/test_issue_194.py

### **Fixed issue:** #207 

**Detailed description:** Added auto-data placement (i.e., if programmers do not apply .to primitive at all, the whole program is placed to FPGA by default).

**Link to the tests:** tests/issues/test_issue_207.py

### **Fixed issue:** #304

**Detailed description:** The HLS code generator does not check if the allocate IR node has the size of 0. Solved by adding the checking.

**Link to the tests:** tests/issues/test_issue_304.py
