### PR TITLE
[TEST] CD/CI test with EDA tools on local servers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,3 +11,4 @@ build-job:
     - source $VITIS/settings64.sh
     - source /opt/xilinx/xrt/setup.sh
     - which v++
+    - pwd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+build-job:
+  stage: build
+  tags:
+    - local
+  script:
+    - echo "Hello, $GITLAB_USER_LOGIN!"
+    - echo "[CI/CD] setup local environment..."
+    - unset LM_LICENSE_FILE
+    - export XILINXD_LICENSE_FILE=2100@flex.ece.cornell.edu
+    - export VITIS=/opt/xilinx/Xilinx_Vivado_vitis_2020.2/Vitis/2020.2
+    - source $VITIS/settings64.sh
+    - source /opt/xilinx/xrt/setup.sh
+    - which v++


### PR DESCRIPTION
### For adding new features

**Add feature:** add CD/CI testing on our local server. Right now, some test cases requiring EDA tools are skipped in CD/CI testing on CircleCI servers. This PR will add CI/CD testing on our local server, which enables us to verify our design with EDA tools like Vivado HLS or AOC.

**How to use the new feature:** The local CI/CD testing process is completely automatic. 

**Detailed description:**. For each commit, the web hook on github will automatically inform the local CI/CD runner installed on our local server to pull back the latest changes and run the test cases. The test result will be sent back to github repo and be displayed as the status (i.e., passed or failed) of the commit.

**Link to the tests:** TBA
