### PR TITLE
[TEST] Add CI/CD testing on local servers

### DIFF
--- a/.github/workflows/zhang-21.yml
+++ b/.github/workflows/zhang-21.yml
@@ -1,0 +1,18 @@
+name: Local CI test
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: self-hosted
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+          pwd
+      - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
### For adding new features

**Add feature:** add CD/CI testing on our local server. Right now, some test cases requiring EDA tools are skipped in CD/CI testing on CircleCI servers. This PR will add CI/CD testing on our local server, which enables us to verify our design with EDA tools like Vivado HLS or AOC.

**How to use the new feature:** The local CI/CD testing process is completely automatic. 

**Detailed description:**. For each commit, the web hook on github will automatically inform the local CI/CD runner installed on our local server to pull back the latest changes and run the test cases. The test result will be sent back to github repo and be displayed as the status (i.e., passed or failed) of the commit.

**Link to the tests:** TBA
