### PR TITLE
[RT][CodeGen] HCL runtime and host code generation enhancement

### DIFF
--- a/python/heterocl/tools.py
+++ b/python/heterocl/tools.py
@@ -84,7 +84,8 @@ class Vitis(Tool):
         self.xpfm = None
         self.binary = None
         self.build_dir = None
-        
+        self.suported_modes.append("csyn")
+                
 class SDAccel(Vitis):
     pass
 

--- a/python/heterocl/tvm/runtime.py
+++ b/python/heterocl/tvm/runtime.py
@@ -2,6 +2,8 @@ from ._ffi.function import register_func
 import os, subprocess, time, re, glob
 from ..report import parse_xml
 from ..devices import Project
+import glob
+
 debug = True
 
 def replace_text(f_name, prev, new):
@@ -141,6 +143,8 @@ def tvm_callback_exec_evaluate(platform, mode, host_only):
             out = run_process(cmd)
 
     elif platform == "vitis":
+        if mode == "csyn":
+            return str(qor)
         assert os.system("which v++ >> /dev/null") == 0, \
             "cannot find v++ on system path"
         cmd = "cd {}; ".format(Project.path)
@@ -303,7 +307,7 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
         assert "XDEVICE" in os.environ, \
                "vitis platform info missing" 
         os.system("cp " + path + "vitis/* " + Project.path)
-        cmd = "cd {}; make clean; ".format(Project.path)
+        init_cmd = "cd {}; make clean; ".format(Project.path)
 
         if mode == "hw_exe": mode = "hw"
         elif mode == "sw_sim": mode = "sw_emu"
@@ -313,25 +317,55 @@ def copy_and_compile(platform, mode, backend, host_only, cfg, script):
         with open(os.path.join(Project.path,"config.ini"), "w") as fp:
             fp.write(cfg)
 
+        # check env variables
+        env_cmd = ""
+        try:
+            xilinx_vitis = os.environ["XILINX_VITIS"]
+        except:
+            print("[{}] WARNING: Vitis tool not setup. Missing ENV variable XILINX_VITIS".format(time.strftime("%H:%M:%S", time.gmtime())))
+            
+            # automatically locate vitis tool kit
+            vitis_path = "/opt/xilinx/"
+            for directory in os.listdir(vitis_path):
+                if "_vitis_" in directory or "-vitis-" in directory:
+                    env_cmd = f"source {vitis_path}/{directory}/Vivado/2019.2/settings64.sh; source /opt/xilinx/xrt/setup.sh; "
+                    break
+        
+        try:
+            device = os.environ["XDEVICE"].split("/")[-1]
+            device = device.replace(".xpfm", "")
+        except:
+            print("[{}] WARNING: Missing ENV variable XDEVICE. It should be set as path to target XPFM file for target FPGA.".format(time.strftime("%H:%M:%S", time.gmtime())))
+            
+            # automatically locate platform file
+            targets = glob.glob("/opt/xilinx/platforms/*/*.xpfm")
+            assert (targets) > 0, "Cannot locate FPGA XPFM files. Please specify XDEVICE env as the path to XPFM files using export command, and try again"
+
+            env_cmd += "export XDEVICE=" + targets[-1]
+            device = targets[-1].replace(".xpfm", "")
+
         if not host_only:
-            cmd += "make all TARGET=" + mode + " DEVICE=$XDEVICE"
-        else: cmd += "make host"
-        out = run_process(cmd)
+            if mode == "csyn":
+                cmd = init_cmd + f"v++ -t hw_emu --platform $XDEVICE --save-temps --temp_dir _x.temp.{device} -c -k test -o kernel.xo kernel.cpp"
+            else:    
+                cmd = init_cmd + "make all TARGET=" + mode + " DEVICE=$XDEVICE"
+        else: cmd = init_cmd + "make host"
+        out = run_process(env_cmd + cmd)
 
-        # mv combined binary to root and save
-        device = os.environ["XDEVICE"].split("/")[-1]
-        device = device.replace(".xpfm", "")
-        path = os.path.join(Project.path, "build_dir.{}.{}/kernel.xclbin".format(mode, device))
-        assert os.path.exists(path), "Not found {}".format(path)
-        run_process("cp {} ".format(path) + os.path.join(Project.path, "kernel.xclbin"))
+        if mode == "csyn":
+            pass
+        else:
+            path = os.path.join(Project.path, "build_dir.{}.{}/kernel.xclbin".format(mode, device))
+            assert os.path.exists(path), "Not found {}".format(path)
+            run_process("cp {} ".format(path) + os.path.join(Project.   path, "kernel.xclbin"))
 
-        kernel = os.path.join(Project.path,"kernel.cpp")
-        with open(kernel, "r") as fp:
-            regex = "HASH:(\d+)\n"
-            hash_v = re.findall(regex, fp.read())[0]
+            kernel = os.path.join(Project.path, "kernel.cpp")
+            with open(kernel, "r") as fp:
+                regex = "HASH:(\d+)\n"
+                hash_v = re.findall(regex, fp.read())[0]
 
-        cache = os.path.join(Project.path,"save/{}-{}.xclbin".format(mode, hash_v))
-        run_process("cp " + os.path.join(Project.path, "kernel.xclbin") + " {}".format(cache))
+            cache = os.path.join(Project.path,"save/{}-{}.xclbin".format(mode, hash_v))
+            run_process("cp " + os.path.join(Project.path, "kernel. xclbin") + " {}".format(cache))
         return "success"
 
     elif platform == "aocl":

--- a/samples/digitrec/digitrec_main.py
+++ b/samples/digitrec/digitrec_main.py
@@ -65,8 +65,8 @@ from digitrec_data import read_digitrec_data
 
 # Declare some constants and data types. For images, we need unsigned 49-bit
 # integers, while for knn matrices, we need unsigned 6-bit integers.
-N = 7 * 7
-max_bit = int(math.ceil(math.log(N, 2)))
+N = 64 # N = 7 * 7
+max_bit = 8 # max_bit = int(math.ceil(math.log(N, 2)))
 data_size = (10, 1800)
 
 # HeteroCL provides users with a set of bit-accurate data types, which include

--- a/samples/digitrec/digitrec_vitis.py
+++ b/samples/digitrec/digitrec_vitis.py
@@ -1,11 +1,11 @@
 from digitrec_main import *
 
-p = hcl.Platform.aws_f1
-p.config(compiler="vitis", mode="csyn")
-f = top(p)
-
 train_images, _, test_images, test_labels = read_digitrec_data()
 hcl_train_images = hcl.asarray(train_images, dtype_image)
 hcl_knn_mat = hcl.asarray(np.zeros((10, 3)), dtype_knnmat)
-start = time.time()
+
+p = hcl.Platform.aws_f1
+# p.config(compiler="vitis", mode="sw_sim")
+p.config(compiler="vitis", mode="csyn")
+f = top(p)
 f(test_images[0], hcl_train_images, hcl_knn_mat)

--- a/samples/digitrec/digitrec_vitis.py
+++ b/samples/digitrec/digitrec_vitis.py
@@ -1,0 +1,11 @@
+from digitrec_main import *
+
+p = hcl.Platform.aws_f1
+p.config(compiler="vitis", mode="csyn")
+f = top(p)
+
+train_images, _, test_images, test_labels = read_digitrec_data()
+hcl_train_images = hcl.asarray(train_images, dtype_image)
+hcl_knn_mat = hcl.asarray(np.zeros((10, 3)), dtype_knnmat)
+start = time.time()
+f(test_images[0], hcl_train_images, hcl_knn_mat)

--- a/tvm/src/codegen/opencl/codegen_xocl_host.cc
+++ b/tvm/src/codegen/opencl/codegen_xocl_host.cc
@@ -408,7 +408,7 @@ const int bank[MAX_HBM_BANKCOUNT] = {
       }
     }
     std::string delim = "";
-    for (auto& buf_: buffer_array) {
+    for (auto& buf_ : buffer_array) {
       stream << delim << buf_;
       delim = ", ";
     }
@@ -504,7 +504,7 @@ const int bank[MAX_HBM_BANKCOUNT] = {
         if (info.stream_type != StreamType::DMA) continue;
       }
       std::string delim = "";
-      for (auto& buf_: buffer_array) {
+      for (auto& buf_ : buffer_array) {
         stream << delim << buf_;
         delim = ", ";
       }


### PR DESCRIPTION
### For fixing issues

**Fixed issue:** 
- To run synthesis flow in HCL (e.g., Vitis, AOC), programmers are required to source setup scripts for each tool beforehand manually.  
- When using Vitis tool flow in HCL, there is not a mode for programmers to synthesize hardware only (i.e., without generating and compiling host code).

**Detailed description:** 
- HCL auto-locates EDA tools in the system and source required setup scripts 
- Add "csyn" mode for Vitis that allows programmers to synthesize the HLS kernel only.

**Link to the tests:** TBA


