### PR TITLE
[CI/CD] Fix scipy version to be 1.7.2 in CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ test: &test
         key: v1.04-libhcl-
     - run: make build-python
     - run: source .circleci/install_tvm.sh
-    - run: pip install --user pytest imageio tabulate xmltodict pandas
+    - run: pip install --user pytest imageio tabulate xmltodict pandas networkx
     - run: python -m pytest tests
     - run: pip install --user mxnet==1.7.0.post2
     - run: python -m pytest samples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ test: &test
         key: v1.04-libhcl-
     - run: make build-python
     - run: source .circleci/install_tvm.sh
-    - run: pip install --user pytest imageio tabulate xmltodict pandas networkx
+    - run: pip install --user pytest imageio tabulate xmltodict pandas networkx sodac
     - run: python -m pytest tests
     - run: pip install --user mxnet==1.7.0.post2
     - run: python -m pytest samples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ test: &test
         key: v1.04-libhcl-
     - run: make build-python
     - run: source .circleci/install_tvm.sh
-    - run: pip install --user pytest imageio tabulate xmltodict
+    - run: pip install --user pytest imageio tabulate xmltodict pandas
     - run: python -m pytest tests
     - run: pip install --user mxnet==1.7.0.post2
     - run: python -m pytest samples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build-hcl:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - checkout
       - restore_cache:
           key: v1.04-heterocl-{{ checksum "Makefile" }}-{{ checksum "Makefile.config" }}
-      - run: make -j4
+      - run: make -j`nproc`
       - save_cache:
           key: v1.04-heterocl-{{ checksum "Makefile" }}-{{ checksum "Makefile.config" }}
           paths:
@@ -38,11 +38,11 @@ jobs:
             - ~/project/tvm/lib
   test-python-3:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     <<: *test
   test-cpplint:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run: pip install --user cpplint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ test: &test
     - run: source .circleci/install_tvm.sh
     - run: pip install --user pytest 
     - run: pip install --user imageio
+    - run: pip install --user xmltodict
     - run: python -m pytest tests
     - run: pip install --user mxnet==1.7.0.post2
     - run: python -m pytest samples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ test: &test
         key: v1.04-libhcl-
     - run: make build-python
     - run: source .circleci/install_tvm.sh
-    - run: pip install --user pytest 
-    - run: pip install --user imageio
-    - run: pip install --user xmltodict
+    - run: pip install --user pytest imageio tabulate xmltodict
     - run: python -m pytest tests
     - run: pip install --user mxnet==1.7.0.post2
     - run: python -m pytest samples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ version: 2
 jobs:
   build-hcl:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
     steps:
       - checkout
       - restore_cache:
           key: v1.04-heterocl-{{ checksum "Makefile" }}-{{ checksum "Makefile.config" }}
-      - run: make -j`nproc`
+      - run: make -j4
       - save_cache:
           key: v1.04-heterocl-{{ checksum "Makefile" }}-{{ checksum "Makefile.config" }}
           paths:
@@ -38,11 +38,11 @@ jobs:
             - ~/project/tvm/lib
   test-python-3:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
     <<: *test
   test-cpplint:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run: pip install --user cpplint

--- a/hlib/python/setup.py
+++ b/hlib/python/setup.py
@@ -37,6 +37,7 @@ setup(
   packages = find_packages(),
   install_requires=[
       'numpy==1.18.5',
+      'scipy==1.7.2',
       'matplotlib',
       'backports.functools_lru_cache',
       'ordered_set',

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,10 +36,10 @@ setup(
   version = "0.3",
   packages = find_packages(),
   install_requires=[
-      'scipy=1.7.2',
       'numpy==1.18.5',
       'decorator==4.4.2',
       'networkx==2.5.1',
+      'scipy==1.7.2',
       'matplotlib',
       'backports.functools_lru_cache',
       'ordered_set',

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,6 +36,7 @@ setup(
   version = "0.3",
   packages = find_packages(),
   install_requires=[
+      'scipy=1.7.2',
       'numpy==1.18.5',
       'decorator==4.4.2',
       'networkx==2.5.1',

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,7 +39,6 @@ setup(
       'numpy==1.18.5',
       'decorator==4.4.2',
       'networkx==2.5.1',
-      'scipy==1.7.2',
       'matplotlib',
       'backports.functools_lru_cache',
       'ordered_set',


### PR DESCRIPTION
### For fixing issues

**Fixed issue:** the install script automatically chooses the latest version of scipy, and this will result in a version conflict and installation error

**Detailed description:** fix scipy version to be 1.7.2

**Link to the tests:** N/A

