### PR TITLE
[Fix] Fix for Complex Select Expression: issue #383

### DIFF
--- a/tests/issues/test_issue_383.py
+++ b/tests/issues/test_issue_383.py
@@ -1,0 +1,25 @@
+import heterocl as hcl
+
+def test_complex_select():
+
+    hcl.init(hcl.Int(32))
+    a = hcl.placeholder((10,), name="a")
+    b = hcl.placeholder((10,), name="b")
+    c = hcl.placeholder((10,), name="c")
+    d = hcl.placeholder((10,), name="d")
+    
+    def kernel_select(a, b, c, d):
+        use_imm = hcl.scalar(1)
+        with hcl.for_(0, 10, name="i") as i:
+            src = hcl.select(use_imm == 1, hcl.cast(hcl.Int(16), (c[i] + b[i])), 
+                                           hcl.cast(hcl.Int(32), (c[i] - b[i]))
+                                           )
+            dst = hcl.cast(hcl.Int(32), (2 * (c[i] + b[i])))
+            d[i] = hcl.select(dst >= (-1 * src),
+                    hcl.select(dst <= src, a[i], src),
+                    (-1 * src))
+    s = hcl.create_schedule([a, b, c, d], kernel_select)
+    hcl.build(s, target="vhls")
+
+if __name__ == "__main__":
+    test_complex_select()

--- a/tests/issues/test_issue_383.py
+++ b/tests/issues/test_issue_383.py
@@ -19,7 +19,8 @@ def test_complex_select():
                     hcl.select(dst <= src, a[i], src),
                     (-1 * src))
     s = hcl.create_schedule([a, b, c, d], kernel_select)
-    hcl.build(s, target="vhls")
+    code = hcl.build(s, target="vhls")
+    assert code.count("?") == 6
 
 if __name__ == "__main__":
     test_complex_select()

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -45,12 +45,8 @@ Type ExtractDType(Expr expr, bool& flag) {
     flag = false;
     return v->type;
   } else if (auto v = expr.as<Select>()) {
-    // When the condition variable itself is a Select node
-    // we must first check its true and false values
-    // they should have the same data type
     return v->type;
   } else if (auto v = expr.as<Call>()) {
-    // case for a Call node
     return v->type;
   }
   LOG(FATAL) << "unknown type of " << expr->type_key();

--- a/tvm/src/codegen/codegen_c.cc
+++ b/tvm/src/codegen/codegen_c.cc
@@ -44,8 +44,16 @@ Type ExtractDType(Expr expr, bool& flag) {
   } else if (auto v = expr.as<Cast>()) {
     flag = false;
     return v->type;
+  } else if (auto v = expr.as<Select>()) {
+    // When the condition variable itself is a Select node
+    // we must first check its true and false values
+    // they should have the same data type
+    return v->type;
+  } else if (auto v = expr.as<Call>()) {
+    // case for a Call node
+    return v->type;
   }
-  LOG(FATAL) << "unknown type of " << expr;
+  LOG(FATAL) << "unknown type of " << expr->type_key();
   return Type(Type::UInt, 32, 0);
 }
 


### PR DESCRIPTION
### Complex Select Expression

**Fixed issue:** #383

**Detailed description:**  

The `ExtractDType` function that returns data type for given expression did not take `Select` and `Call` into consideration. This PR adds these cases and a corresponding test case. 

**Link to the tests:** `tests/issues/test_issue_383.py`