### PR TITLE
[Fix] Remove CastRemover for Tensor Indices (issue #386)

### DIFF
--- a/python/heterocl/tensor.py
+++ b/python/heterocl/tensor.py
@@ -148,7 +148,6 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
         if not isinstance(indices, tuple):
             indices = (indices,)
         indices = self.indices + indices
-        indices = util.CastRemover().mutate(indices)
         index, bit, _ = util.get_index(self.tensor.shape, indices, 0)
         if not Stage.get_len():
             raise TensorError("Cannot set tensor elements without compute APIs")
@@ -238,7 +237,6 @@ class TensorSlice(NodeGeneric, _expr.ExprOp):
     def asnode(self):
         if len(self.indices) < len(self.tensor.shape):
             raise TensorError("Accessing a slice of tensor is not allowed")
-        self.indices = util.CastRemover().mutate(self.indices)
         index, bit, _ = util.get_index(self.tensor.shape, self.indices, 0)
         if bit is None:
             return _make.Load(self._dtype, self.tensor.buf.data, index)
@@ -343,7 +341,6 @@ class Tensor(NodeGeneric, _expr.ExprOp):
         return "Tensor('" + self.name + "', " + str(self.shape) + ", " + str(self.dtype) + ")"
 
     def __getitem__(self, indices):
-        indices = util.CastRemover().mutate(indices)
         if Stage.get_len():
             Stage.get_current().input_stages.add(self.last_update)
         if not isinstance(indices, tuple):
@@ -351,12 +348,10 @@ class Tensor(NodeGeneric, _expr.ExprOp):
         return TensorSlice(self, indices)
 
     def __setitem__(self, indices, expr):
-        indices = util.CastRemover().mutate(indices)
         Stage.get_current().input_stages.add(self.last_update)
         Stage.get_current().lhs_tensors.add(self)
         if not isinstance(indices, tuple):
             indices = (indices,)
-        indices = util.CastRemover().mutate(indices)
         if len(indices) < len(self.shape):
             raise TensorError("Accessing a slice of tensor is not allowed")
         else:

--- a/tests/issues/test_issue_386.py
+++ b/tests/issues/test_issue_386.py
@@ -1,0 +1,23 @@
+import heterocl as hcl
+
+def test_cast_removal():
+    hcl.init()
+    
+    A = hcl.placeholder((10,10), dtype=hcl.UInt(16), name="A")
+    B = hcl.placeholder((10,10), dtype=hcl.Int(16), name="B")
+
+    def algo(A, B):
+        def f_mutate(i,j):
+            factor = hcl.scalar(B[0][0][13:11], name="factor")
+            idx = hcl.scalar(B[0][0][11:0], dtype=hcl.UInt(16), name="idx")
+            idx += i * hcl.cast(hcl.UInt(16), factor.v) 
+            A[idx][j] = B[idx][j]
+        bound = hcl.scalar(5, dtype=hcl.Int(32))
+        domain = (hcl.cast(hcl.UInt(32), bound.v), hcl.cast(hcl.UInt(32), bound.v))
+        hcl.mutate(domain, f_mutate)
+    
+    s = hcl.create_schedule([A, B], algo)
+    f = hcl.build(s, target="vhls")
+
+if __name__ == '__main__':
+    test_cast_removal()

--- a/tvm/src/codegen/llvm/codegen_llvm.cc
+++ b/tvm/src/codegen/llvm/codegen_llvm.cc
@@ -972,7 +972,11 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const Load* op) {
   Type t = op->type;
   bool is_volatile = volatile_buf_.count(op->buffer_var.get());
   llvm::Value* buffer = MakeValue(op->buffer_var);
+  // Make sure index is int32 type since we removed CastRemover pass.
+  // check op->index's datatype, if it is not int32, cast it to int32
   llvm::Value* index = MakeValue(op->index);
+  if (op->index.type() != Int(32))
+    index = CreateCast(op->index.type(), Int(32), index);
 
   if (t.lanes() == 1) {
     int alignment, native_bits;
@@ -1256,6 +1260,11 @@ void CodeGenLLVM::VisitStmt_(const Store* op) {
   llvm::Value* buffer = MakeValue(op->buffer_var);
   llvm::Value* index = MakeValue(op->index);
   llvm::Value* value = MakeValue(op->value);
+
+  // Make sure index is int32 type since we removed CastRemover pass.
+  // check op->index's datatype, if it is not int32, cast it to int32
+  if (op->index.type() != Int(32))
+    index = CreateCast(op->index.type(), Int(32), index);
 
   if (t.lanes() == 1) {
     int alignment, native_bits;

--- a/tvm/src/pass/generate_reuse_buffer.cc
+++ b/tvm/src/pass/generate_reuse_buffer.cc
@@ -8,6 +8,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/ir_visitor.h>
 #include <tvm/operation.h>
+#include "ir_util.h"
 
 namespace TVM {
 namespace ir {
@@ -53,124 +54,6 @@ class ModulusRemover final : public IRMutator {
  private:
   Expr mod_;
   std::map<const Variable*, Expr>& range_;
-};
-
-// Remove cast in binary expressions
-// Example: (cast(x) + cast(y)) -> (x + y)
-// Usage: CastRemover castRemover;
-//        Expr expr = castRemover.Mutate(expr);
-class CastRemover final : public IRMutator {
- public:
-  CastRemover() {}
-
-  Expr Mutate_(const Cast* op, const Expr& e) {
-    return op->value;
-  }
-
-  Expr Mutate_(const Add* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Add::make(a, b);
-  }
-
-  Expr Mutate_(const Sub* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Sub::make(a, b);
-  }
-
-  Expr Mutate_(const Mul* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Mul::make(a, b);
-  }
-
-  Expr Mutate_(const Div* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Div::make(a, b);
-  }
-
-  Expr Mutate_(const Mod* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Mod::make(a, b);
-  }
-
-  Expr Mutate_(const Min* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Min::make(a, b);
-  }
-
-  Expr Mutate_(const Max* op, const Expr& e) {
-    Expr a = this->Mutate(op->a);
-    Expr b = this->Mutate(op->b);
-    if (const Cast* ca = a.as<Cast>()) {
-      a = ca->value;
-    }
-    if (const Cast* cb = b.as<Cast>()) {
-      b = cb->value;
-    }
-    if (a.type() != b.type())
-      LOG(FATAL) << "CastRemover: type mismatch "
-        << a.type() << " vs " << b.type();
-    return Max::make(a, b);
-  }
 };
 
 // recover a 1D index back to multi-dimensional index

--- a/tvm/src/pass/generate_reuse_buffer.cc
+++ b/tvm/src/pass/generate_reuse_buffer.cc
@@ -55,6 +55,10 @@ class ModulusRemover final : public IRMutator {
   std::map<const Variable*, Expr>& range_;
 };
 
+// Remove cast in binary expressions
+// Example: (cast(x) + cast(y)) -> (x + y)
+// Usage: CastRemover castRemover;
+//        Expr expr = castRemover.Mutate(expr);
 class CastRemover final : public IRMutator {
  public:
   CastRemover() {}
@@ -72,6 +76,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Add::make(a, b);
   }
 
@@ -84,6 +91,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Sub::make(a, b);
   }
 
@@ -96,6 +106,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Mul::make(a, b);
   }
 
@@ -108,6 +121,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Div::make(a, b);
   }
 
@@ -120,6 +136,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Mod::make(a, b);
   }
 
@@ -132,6 +151,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Min::make(a, b);
   }
 
@@ -144,6 +166,9 @@ class CastRemover final : public IRMutator {
     if (const Cast* cb = b.as<Cast>()) {
       b = cb->value;
     }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
     return Max::make(a, b);
   }
 };

--- a/tvm/src/pass/ir_util.h
+++ b/tvm/src/pass/ir_util.h
@@ -8,6 +8,7 @@
 
 #include <tvm/ir.h>
 #include <tvm/runtime/device_api.h>
+#include <tvm/ir_mutator.h>
 #include <vector>
 
 namespace TVM {
@@ -154,6 +155,124 @@ inline int GetTempAllocaAlignment(Type type, int32_t const_size) {
   }
   return align;
 }
+
+// Remove cast in binary expressions
+// Example: (cast(x) + cast(y)) -> (x + y)
+// Usage: CastRemover castRemover;
+//        Expr expr = castRemover.Mutate(expr);
+class CastRemover final : public IRMutator {
+ public:
+  CastRemover() {}
+
+  Expr Mutate_(const Cast* op, const Expr& e) {
+    return op->value;
+  }
+
+  Expr Mutate_(const Add* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Add::make(a, b);
+  }
+
+  Expr Mutate_(const Sub* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Sub::make(a, b);
+  }
+
+  Expr Mutate_(const Mul* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Mul::make(a, b);
+  }
+
+  Expr Mutate_(const Div* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Div::make(a, b);
+  }
+
+  Expr Mutate_(const Mod* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Mod::make(a, b);
+  }
+
+  Expr Mutate_(const Min* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Min::make(a, b);
+  }
+
+  Expr Mutate_(const Max* op, const Expr& e) {
+    Expr a = this->Mutate(op->a);
+    Expr b = this->Mutate(op->b);
+    if (const Cast* ca = a.as<Cast>()) {
+      a = ca->value;
+    }
+    if (const Cast* cb = b.as<Cast>()) {
+      b = cb->value;
+    }
+    if (a.type() != b.type())
+      LOG(FATAL) << "CastRemover: type mismatch "
+        << a.type() << " vs " << b.type();
+    return Max::make(a, b);
+  }
+};
 }  // namespace ir
 }  // namespace TVM
 #endif  // PASS_IR_UTIL_H_


### PR DESCRIPTION
### Remove CastRemover for Tensor Indices 

**Fixed issue:** #386 

**Detailed description:** 

The cast operations on tensor indices are incorrectly removed by `CastRemover`, which causes binary operation data type mismatch. This PR fixes this issue by removing the CastRemovers and enforcing indices to have i32 data type for LLVM backend. 

**Link to the tests:** `tests/issues/test_issue_386.py`

