### PR TITLE
[Fix] Halide IR Simplify pass wrongly optimizes away if condition 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
         run: |
           ls ${{ github.workspace }}
           export CXX=/usr/bin/g++
+          sed 's/install/develop/g' Makefile
           make -j`nproc`
           cp tvm/lib/* .
       - run: echo "This job's status is ${{ job.status }}."
@@ -28,4 +29,3 @@ jobs:
           source /opt/xilinx/xrt/setup.sh
           export LOCAL_CI_TEST=1
           python tests/test_cont_integration.py
-          pip uninstall heterocl hlib -y

--- a/tests/issues/test_issue_450.py
+++ b/tests/issues/test_issue_450.py
@@ -1,0 +1,24 @@
+import heterocl as hcl
+import numpy as np
+
+def test_mask():
+
+    def two_stage(A):
+        var = hcl.scalar(0, "v", dtype=hcl.UInt(32))
+        var.v = 1
+        with hcl.if_(var == 0):
+            hcl.print((),"A\n")
+        with hcl.else_():
+            var.v = var - 1
+            # this condition should not be optimized away
+            with hcl.if_(var == 0):
+                hcl.print((),"B\n")
+        A[0] = var
+        return A
+
+    A = hcl.placeholder((2,), "A", dtype=hcl.UInt(16))
+    s = hcl.create_schedule([A], two_stage)
+    print(hcl.lower(s))
+
+if __name__ == "__main__":
+    test_mask()

--- a/tvm/HalideIR/src/arithmetic/Simplify.cpp
+++ b/tvm/HalideIR/src/arithmetic/Simplify.cpp
@@ -3231,12 +3231,14 @@ class Simplify : public IRMutator {
       Expr next = stack.back();
       stack.pop_back();
 
-      if (!or_chain) {
-        then_case = substitute(next, const_true(), then_case);
-      }
-      if (!and_chain) {
-        else_case = substitute(next, const_false(), else_case);
-      }
+      // TODO (hecmay): avoid substituting the expression directly 
+      //    since the value may have been updated before the condition
+      // if (!or_chain) {
+      //   then_case = substitute(next, const_true(), then_case);
+      // }
+      // if (!and_chain) {
+      //   else_case = substitute(next, const_false(), else_case);
+      // }
 
       if (const And *a = next.as<And>()) {
         if (!or_chain) {

--- a/tvm/HalideIR/src/arithmetic/Simplify.cpp
+++ b/tvm/HalideIR/src/arithmetic/Simplify.cpp
@@ -3231,7 +3231,7 @@ class Simplify : public IRMutator {
       Expr next = stack.back();
       stack.pop_back();
 
-      // TODO (hecmay): avoid substituting the expression directly 
+      // TODO(hecmay): avoid substituting the expression directly
       //    since the value may have been updated before the condition
       // if (!or_chain) {
       //   then_case = substitute(next, const_true(), then_case);


### PR DESCRIPTION
### For fixing issues

**Fixed issue:** #450 

**Detailed description:** 

Minimal test case: in the top-level `else` branch, the `var` has been updated before going in another if statement. Namely, the second `with hcl.if_(var == 0)` is not always false, and should not be optimized away.

```python
def two_stage(A):
    var = hcl.scalar(0, "v", dtype=hcl.UInt(32))
    var.v = 1
    with hcl.if_(var == 0):
        hcl.print((),"A\n")
    with hcl.else_():
        var.v = var - 1
        with hcl.if_(var == 0):
            hcl.print((),"B\n")
    return A
```

This is the buggy IR generated by HCL before the ifx.

```c++
// generated IR
produce _top {
  // attr [0] extern_scope = 0
  // attr [v] storage_scope = "global"
  allocate v[uint32 * 1]
  produce v {
    // attr [0] extern_scope = 0
    for "stage_name"="v" (x, 0, 1) {
      v[x] = (uint32)0
    }
  }
  v[0] = (uint32)1
  if ((v[0] == (uint32)0)) {
    print:
  } else {
    v[0] = (v[0] - (uint32)1)
  }
}
```

Here is the expected IR that should be generated after applying the fix.
```c++
// Expected IR
produce _top {                                                                                                                                                                         [76/1883]
  // attr [0] extern_scope = 0
  // attr [v] storage_scope = "global"
  allocate v[uint32 * 1]
  produce v {
    // attr [0] extern_scope = 0
    for "stage_name"="v" (x, 0, 1) {
      v[x] = (uint32)0
    }
  }
  v[0] = (uint32)1
  if ((v[0] == (uint32)0)) {
    print:
  } else {
    v[0] = (v[0] - (uint32)1)
    if ((v[0] == (uint32)0)) {
      print:
    }
  }
}
```

**Link to the tests:**  tests/issues/test_issue_450.py
