### PR TITLE
[Fix] Issue #458: Add SHLS Support for hcl.assert_

### DIFF
--- a/tests/issues/test_issue_458.py
+++ b/tests/issues/test_issue_458.py
@@ -1,15 +1,14 @@
 import heterocl as hcl
 
 def test():
-    # generates: assert ((uint32)0 < uint32(A[0]));
-    # the second uint32 is oddly specified ...
     def func(A):
         hcl.assert_(A[0] > 0, "")
 
     A = hcl.placeholder((2,), "A", dtype=hcl.UInt(16))
     s = hcl.create_schedule([A], func)
-    m = hcl.build(s, "shls")
-    print(m)
+    code = hcl.build(s, "shls")
+    assert "SC_ASSERT" in code
+    assert "uint32" not in code
 
 if __name__ == "__main__":
     test()

--- a/tests/issues/test_issue_458.py
+++ b/tests/issues/test_issue_458.py
@@ -1,0 +1,15 @@
+import heterocl as hcl
+
+def test():
+    # generates: assert ((uint32)0 < uint32(A[0]));
+    # the second uint32 is oddly specified ...
+    def func(A):
+        hcl.assert_(A[0] > 0, "")
+
+    A = hcl.placeholder((2,), "A", dtype=hcl.UInt(16))
+    s = hcl.create_schedule([A], func)
+    m = hcl.build(s, "shls")
+    print(m)
+
+if __name__ == "__main__":
+    test()

--- a/tvm/src/codegen/code_analysis.cc
+++ b/tvm/src/codegen/code_analysis.cc
@@ -977,5 +977,7 @@ void CodeAnalysis::VisitStmt_(const ExternModule* op) {
 
 void CodeAnalysis::VisitStmt_(const Print* op) {}
 
+void CodeAnalysis::VisitStmt_(const Assert* op) {}
+
 }  // namespace codegen
 }  // namespace TVM

--- a/tvm/src/codegen/code_analysis.h
+++ b/tvm/src/codegen/code_analysis.h
@@ -134,6 +134,7 @@ class CodeAnalysis : public ExprFunctor<void(const Expr&, std::ostream&)>,
   void VisitStmt_(const ExternModule* op) override;
   void VisitStmt_(const StreamStmt* op) override;
   void VisitStmt_(const Print* op) override;
+  void VisitStmt_(const Assert* op) override;
   /*!
    * Print Type represetnation of type t.
    * \param t The type representation.

--- a/tvm/src/codegen/hlsc/codegen_shls.cc
+++ b/tvm/src/codegen/hlsc/codegen_shls.cc
@@ -11,9 +11,9 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include "../../pass/ir_util.h"
 #include "../../pass/stencil.h"
 #include "../build_common.h"
-#include "../../pass/ir_util.h"
 #include "../build_soda.h"
 #include "../codegen_soda.h"
 #include "codegen_shls.h"
@@ -1277,7 +1277,9 @@ void CodeGenStratusHLS::VisitStmt_(const Return* op) {
 
 void CodeGenStratusHLS::VisitStmt_(const Assert* op) {
   PrintIndent();
-  this->stream << "assert " << op->condition << ";\n";
+  this->stream << "SC_ASSERT ";
+  PrintExpr(op->condition, stream);
+  this->stream << ";\n";
 }
 
 void CodeGenStratusHLS::VisitExpr_(const SetSlice* op, std::ostream& os) {


### PR DESCRIPTION
### Add SHLS Support for `hcl.assert_`

**Fixed issue:** #458

**Detailed description:** 

This PR fixes two things:
- The `code_analysis.h` pass doesn't have `Assert` stmt visitor, which causes an error saying that it doesn't support this node. This PR adds this visitor.
- SHLS's implementation of `Assert` node was wrong, we should use `SC_ASSERT` instead of `assert`.

**Link to the tests:** [tests/issues/test_issue_458.py](https://github.com/zzzDavid/heterocl/blob/issue458/tests/issues/test_issue_458.py)
