### PR TITLE
[Fix] Issue459: SHLS Backend Big UInt Type Printing

### DIFF
--- a/tests/issues/test_issue_459.py
+++ b/tests/issues/test_issue_459.py
@@ -1,0 +1,35 @@
+import heterocl as hcl
+
+def reduce(b, w, q):
+    bw  = hcl.get_bitwidth(q.dtype)
+    bwh = bw // 2
+    mask = (1 << bwh) - 1
+
+    b = hcl.scalar(b, "b", dtype=hcl.UInt(bw))
+    w = hcl.scalar(w, "w", dtype=hcl.UInt(bw))
+    q = hcl.scalar(q, "q", dtype=hcl.UInt(bw))
+
+    a = w * b
+    for i in range(2):
+        t = (-a) & mask
+        s = (a + (t*q)) >> bwh
+        a = s
+    a = hcl.select(a < q, a, a - q)
+    res = hcl.scalar(a, "reduce", dtype=hcl.UInt(bw))
+    return res
+
+
+def test():
+
+    def func(A,B):
+        B[0] = reduce(A[0], A[1], A[2])
+
+    A = hcl.placeholder((5,), "A", dtype=hcl.UInt(32))
+    B = hcl.placeholder((2,), "B", dtype=hcl.UInt(32))
+    s = hcl.create_schedule([A,B], func)
+
+    code = hcl.build(s, "shls")
+    assert "(sc_biguint<131>)" in code
+
+if __name__ == "__main__":
+    test()

--- a/tvm/src/codegen/hlsc/codegen_shls.cc
+++ b/tvm/src/codegen/hlsc/codegen_shls.cc
@@ -800,7 +800,6 @@ void CodeGenStratusHLS::PrintType(Type t, std::ostream& os) {
 
 void CodeGenStratusHLS::PrintType(Type t, std::ostream& os, bool is_index) {
   bool big = t.bits() > 64;
-  LOG(INFO) << "PrintType: " << t << " " << t.bits() << ", big=" << big;
   if (big && is_index) {
     LOG(FATAL)
         << "Stratus HLS doesn't support index expression bitwidth wider than "

--- a/tvm/src/codegen/hlsc/codegen_shls.cc
+++ b/tvm/src/codegen/hlsc/codegen_shls.cc
@@ -794,7 +794,12 @@ void CodeGenStratusHLS::AddFunction(
   printTclFile();
 }
 
+/// Override the PrintType function inherited from CodeGenVHLS
+/// And re-direct to StratusHLS's PrintType function.
 void CodeGenStratusHLS::PrintType(Type t, std::ostream& os) {
+  // False here means that this function does not print type
+  // of array index expression. Array index expression type is
+  // handled by PrintType(Type t, std::ostream& os, bool is_index)
   PrintType(t, os, false);
 }
 

--- a/tvm/src/codegen/hlsc/codegen_shls.cc
+++ b/tvm/src/codegen/hlsc/codegen_shls.cc
@@ -11,9 +11,9 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include "../../pass/ir_util.h"
 #include "../../pass/stencil.h"
 #include "../build_common.h"
-#include "../../pass/ir_util.h"
 #include "../build_soda.h"
 #include "../codegen_soda.h"
 #include "codegen_shls.h"
@@ -795,14 +795,16 @@ void CodeGenStratusHLS::AddFunction(
 }
 
 void CodeGenStratusHLS::PrintType(Type t, std::ostream& os) {
-  PrintType(t, os, true);
+  PrintType(t, os, false);
 }
 
 void CodeGenStratusHLS::PrintType(Type t, std::ostream& os, bool is_index) {
   bool big = t.bits() > 64;
+  LOG(INFO) << "PrintType: " << t << " " << t.bits() << ", big=" << big;
   if (big && is_index) {
-    LOG(WARNING) << "index expression doesn't support bitwidth wider than "
-                 << " 64 bit.";
+    LOG(FATAL)
+        << "Stratus HLS doesn't support index expression bitwidth wider than "
+        << " 64 bit.";
     return;
   }
   if (t.is_uint() || t.is_int() || t.is_fixed() || t.is_ufixed()) {


### PR DESCRIPTION
## Fix SHLS Backend Big UInt Type Printing

**Fixed issue:** #459

**Detailed description:**
Issue #459 was caused by `big_uint` and `big_int` not printed. This PR fixes this issue and verifies that `big_int` and `big_uint` are printed. 

**Link to the tests:** [tests/issues/test_issue_459.py](https://github.com/zzzDavid/heterocl/blob/issue459/tests/issues/test_issue_459.py)