### PR TITLE
[Op] Remove redundant cast op for integer const_tensor

### DIFF
--- a/heterocl/ast/ast.py
+++ b/heterocl/ast/ast.py
@@ -774,7 +774,7 @@ class ConstantTensorOp(Expr):
         code_str = ""
         code_str += print_indent(code_str, self.level)
         code_str += (
-            f"{self.name} = constant_tensor({self.values.shape}, {self.values.dtype})"
+            f"{self.name} = constant_tensor({self.values.shape}, {self.dtype})"
         )
         return code_str
 

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1426,6 +1426,11 @@ class IRBuilder:
                 array = np.packbits(val, axis=None, bitorder="little")
                 value_attr = DenseElementsAttr.get(array, shape=val.shape, type=dtype)
             else:
+                # Here we construct a customized NumPy dtype, "f0", "f1", "f2", etc.
+                # are the field names, and the entire data type is `op.values.dtype`.
+                # This can be viewed as a `union` type in C/C++.
+                # Please refer to the documentation for more details:
+                # https://numpy.org/doc/stable/reference/arrays.dtypes.html#specifying-and-constructing-data-types
                 decomposed_np_dtype = np.dtype(
                     (
                         op.values.dtype,
@@ -1438,6 +1443,7 @@ class IRBuilder:
                 val = op.values.view(decomposed_np_dtype)
                 # 2. Compose the uint8 array into a structured array of target bitwidth
                 # This is done by taking the first several bytes of the uint8 array
+                # "u1" means one unsigned byte, and "i1" means one signed byte
                 n_bytes = int(np.ceil(dtype.width / 8))
                 new_dtype = np.dtype(
                     {

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1447,10 +1447,11 @@ class IRBuilder:
             val = val.view(np.dtype(new_dtype))
             # -> reshape: 6*6*i24
             val = val.reshape(shape)
+            # Pass in the numpy array to get the MLIR attribute
+            value_attr = DenseElementsAttr.get(val, shape=val.shape, type=dtype)
         else:
             val = op.values
-        # Pass in the numpy array to get the MLIR attribute
-        value_attr = DenseElementsAttr.get(val, shape=val.shape, type=dtype)
+            value_attr = DenseElementsAttr.get(val)
         sym_name = StringAttr.get(op.name)
         sym_visibility = StringAttr.get("private")
         if isinstance(op.dtype, (htypes.Fixed, htypes.UFixed)):

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -7,6 +7,8 @@
 
 # Import MLIR dialects
 # Naming rule: import dialect as dialect_d
+import numpy as np
+
 from hcl_mlir.dialects import (
     func as func_d,
     hcl as hcl_d,
@@ -1406,8 +1408,46 @@ class IRBuilder:
     def build_constant_tensor_op(self, op: ast.ConstantTensorOp, ip):
         loc = Location.file(op.loc.filename, op.loc.lineno, 0)
         dtype = hcl_dtype_to_mlir(op.dtype, signless=True)
-        val = op.values
-        value_attr = DenseElementsAttr.get(val)
+        shape = op.values.shape
+        # The following code has several steps to convert the numpy array to have
+        # the correct data type in order to create an MLIR constant tensor.
+        # Since MLIR-NumPy Python interface only supports byte-addressable data types,
+        # we need to change the data type of the array to have the minimum number of bytes
+        # that can represent the target bitwidth.
+        # e.g., hcl.const_tensor(arr, dtype=hcl.Int(20)) (6*6 array)
+        #       which requires 20 bits (3 bytes) to represent each element
+        # declaration: 6*6*i20
+        # numpy input: 6*6*i64
+        # 1. Decompose the original i32 or i64 array into a structured array of uint8
+        #  -> decompose: 6*6*8*i8
+        decomposed_np_dtype = np.dtype(
+            (
+                op.values.dtype,
+                {f"f{i}": (np.uint8, i) for i in range(op.values.dtype.itemsize)},
+            )
+        )
+        val = op.values.view(decomposed_np_dtype)
+        # 2. Compose the uint8 array into a structured array of target bitwidth
+        # This is done by taking the first several bytes of the uint8 array
+        n_bytes = int(np.ceil(dtype.width / 8))
+        new_dtype = np.dtype(
+            {
+                "names": [f"f{i}" for i in range(n_bytes)],
+                "formats": ["u1"] * (n_bytes - 1) + (["i1"] if isinstance(dtype, htypes.Int) else ["u1"]),
+                "offsets": list(range(n_bytes)),
+                "itemize": n_bytes,
+            }
+        )
+        # -> compose: 6*6*3*i8
+        val = np.stack([val[f"f{i}"] for i in range(n_bytes)], axis=-1)
+        # -> flatten: 108*i8
+        val = val.flatten()
+        # -> view: 36*i24
+        val = val.view(np.dtype(new_dtype))
+        # -> reshape: 6*6*i24
+        val = val.reshape(shape)
+        # Pass in the numpy array to get the MLIR attribute
+        value_attr = DenseElementsAttr.get(val, shape=val.shape, type=dtype)
         sym_name = StringAttr.get(op.name)
         sym_visibility = StringAttr.get("private")
         if isinstance(op.dtype, (htypes.Fixed, htypes.UFixed)):

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1448,8 +1448,8 @@ class IRBuilder:
                 new_dtype = np.dtype(
                     {
                         "names": [f"f{i}" for i in range(n_bytes)],
-                        "formats": ["u1"] * (n_bytes - 1)
-                        + (["i1"] if isinstance(dtype, htypes.Int) else ["u1"]),
+                        "formats": (["i1"] if isinstance(dtype, htypes.Int) else ["u1"])
+                        + ["u1"] * (n_bytes - 1),
                         "offsets": list(range(n_bytes)),
                         "itemize": n_bytes,
                     }
@@ -1463,6 +1463,7 @@ class IRBuilder:
                 # -> reshape: 6*6*i24
                 val = val.reshape(shape)
                 # Pass in the numpy array to get the MLIR attribute
+                # -> result: 6*6*i20
                 value_attr = DenseElementsAttr.get(val, shape=val.shape, type=dtype)
         else:
             val = op.values

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1409,43 +1409,46 @@ class IRBuilder:
         loc = Location.file(op.loc.filename, op.loc.lineno, 0)
         dtype = hcl_dtype_to_mlir(op.dtype, signless=True)
         shape = op.values.shape
-        # The following code has several steps to convert the numpy array to have
-        # the correct data type in order to create an MLIR constant tensor.
-        # Since MLIR-NumPy Python interface only supports byte-addressable data types,
-        # we need to change the data type of the array to have the minimum number of bytes
-        # that can represent the target bitwidth.
-        # e.g., hcl.const_tensor(arr, dtype=hcl.Int(20)) (6*6 array)
-        #       which requires 20 bits (3 bytes) to represent each element
-        # declaration: 6*6*i20
-        # numpy input: 6*6*i64
-        # 1. Decompose the original i32 or i64 array into a structured array of uint8
-        #  -> decompose: 6*6*8*i8
-        decomposed_np_dtype = np.dtype(
-            (
-                op.values.dtype,
-                {f"f{i}": (np.uint8, i) for i in range(op.values.dtype.itemsize)},
+        if isinstance(op.dtype, (htypes.Int, htypes.UInt)):
+            # The following code has several steps to convert the numpy array to have
+            # the correct data type in order to create an MLIR constant tensor.
+            # Since MLIR-NumPy Python interface only supports byte-addressable data types,
+            # we need to change the data type of the array to have the minimum number of bytes
+            # that can represent the target bitwidth.
+            # e.g., hcl.const_tensor(arr, dtype=hcl.Int(20)) (6*6 array)
+            #       which requires 20 bits (3 bytes) to represent each element
+            # declaration: 6*6*i20
+            # numpy input: 6*6*i64
+            # 1. Decompose the original i32 or i64 array into a structured array of uint8
+            #  -> decompose: 6*6*8*i8
+            decomposed_np_dtype = np.dtype(
+                (
+                    op.values.dtype,
+                    {f"f{i}": (np.uint8, i) for i in range(op.values.dtype.itemsize)},
+                )
             )
-        )
-        val = op.values.view(decomposed_np_dtype)
-        # 2. Compose the uint8 array into a structured array of target bitwidth
-        # This is done by taking the first several bytes of the uint8 array
-        n_bytes = int(np.ceil(dtype.width / 8))
-        new_dtype = np.dtype(
-            {
-                "names": [f"f{i}" for i in range(n_bytes)],
-                "formats": ["u1"] * (n_bytes - 1) + (["i1"] if isinstance(dtype, htypes.Int) else ["u1"]),
-                "offsets": list(range(n_bytes)),
-                "itemize": n_bytes,
-            }
-        )
-        # -> compose: 6*6*3*i8
-        val = np.stack([val[f"f{i}"] for i in range(n_bytes)], axis=-1)
-        # -> flatten: 108*i8
-        val = val.flatten()
-        # -> view: 36*i24
-        val = val.view(np.dtype(new_dtype))
-        # -> reshape: 6*6*i24
-        val = val.reshape(shape)
+            val = op.values.view(decomposed_np_dtype)
+            # 2. Compose the uint8 array into a structured array of target bitwidth
+            # This is done by taking the first several bytes of the uint8 array
+            n_bytes = int(np.ceil(dtype.width / 8))
+            new_dtype = np.dtype(
+                {
+                    "names": [f"f{i}" for i in range(n_bytes)],
+                    "formats": ["u1"] * (n_bytes - 1) + (["i1"] if isinstance(dtype, htypes.Int) else ["u1"]),
+                    "offsets": list(range(n_bytes)),
+                    "itemize": n_bytes,
+                }
+            )
+            # -> compose: 6*6*3*i8
+            val = np.stack([val[f"f{i}"] for i in range(n_bytes)], axis=-1)
+            # -> flatten: 108*i8
+            val = val.flatten()
+            # -> view: 36*i24
+            val = val.view(np.dtype(new_dtype))
+            # -> reshape: 6*6*i24
+            val = val.reshape(shape)
+        else:
+            val = op.values
         # Pass in the numpy array to get the MLIR attribute
         value_attr = DenseElementsAttr.get(val, shape=val.shape, type=dtype)
         sym_name = StringAttr.get(op.name)

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1434,7 +1434,8 @@ class IRBuilder:
             new_dtype = np.dtype(
                 {
                     "names": [f"f{i}" for i in range(n_bytes)],
-                    "formats": ["u1"] * (n_bytes - 1) + (["i1"] if isinstance(dtype, htypes.Int) else ["u1"]),
+                    "formats": ["u1"] * (n_bytes - 1)
+                    + (["i1"] if isinstance(dtype, htypes.Int) else ["u1"]),
                     "offsets": list(range(n_bytes)),
                     "itemize": n_bytes,
                 }

--- a/heterocl/operation.py
+++ b/heterocl/operation.py
@@ -110,17 +110,9 @@ def const_tensor(values, name=None, dtype=None):
     values = np.array(values)
     shape = values.shape
     values = make_const_tensor(values, dtype)
-    realtype = Int(64) if isinstance(dtype, (Int, UInt)) else dtype
-    cst_op = ast.ConstantTensorOp(values, name, shape, realtype, loc)
+    cst_op = ast.ConstantTensorOp(values, name, shape, dtype, loc)
     region = ast.scope.get()
     region.append(cst_op)
-    if isinstance(dtype, (Int, UInt)):
-        return compute(
-            shape,
-            lambda *args: cast(dtype, cst_op.tensor[args]),
-            name=name + "_cast",
-            dtype=dtype,
-        )
     return cst_op.tensor
 
 

--- a/heterocl/utils.py
+++ b/heterocl/utils.py
@@ -133,8 +133,20 @@ def get_src_loc(frame=0):
 def make_const_tensor(val, dtype):
     # val is numpy ndarray
     if isinstance(dtype, (Int, UInt)):
-        if dtype.bits <= 64:
+        if dtype.bits == 1:
+            np_dtype = np.bool_
+        elif dtype.bits <= 8:
+            np_dtype = np.int8
+        elif dtype.bits <= 16:
+            np_dtype = np.int16
+        elif dtype.bits <= 32:
+            np_dtype = np.int32
+        elif dtype.bits <= 64:
             np_dtype = np.int64
+        elif dtype.bits <= 128:
+            np_dtype = np.int128
+        elif dtype.bits <= 256:
+            np_dtype = np.int256
         else:
             raise DTypeError(
                 f"Integer width ({dtype}) too large, not supported by numpy"

--- a/tests/test_compute_basic.py
+++ b/tests/test_compute_basic.py
@@ -328,12 +328,12 @@ def test_const_tensor_int():
     def test_kernel(dtype, size):
         hcl.init(dtype)
 
-        np_A = np.random.randint(10, size=size)
+        np_A = np.random.randint(32, size=size, dtype=np.int32)
         py_A = np_A.tolist()
 
         def kernel():
-            cp1 = hcl.const_tensor(np_A)
-            cp2 = hcl.const_tensor(py_A)
+            cp1 = hcl.const_tensor(np_A, dtype=dtype)
+            cp2 = hcl.const_tensor(py_A, dtype=dtype)
             return hcl.compute(np_A.shape, lambda *x: cp1[x] + cp2[x])
 
         O = hcl.placeholder(np_A.shape)

--- a/tests/test_compute_basic.py
+++ b/tests/test_compute_basic.py
@@ -328,7 +328,7 @@ def test_const_tensor_int():
     def test_kernel(dtype, size):
         hcl.init(dtype)
 
-        np_A = np.random.randint(-32, 32, size=size, dtype=np.int32)
+        np_A = np.random.randint(-15, 15, size=size, dtype=np.int32)
         py_A = np_A.tolist()
 
         def kernel():


### PR DESCRIPTION
This PR fixes #480.

It also provides a way to support arbitrary bitwidth NumPy array as input. Please take a look and see if the function argument part can be changed correspondingly. @zzzDavid 