### PR TITLE
[CI] Fix CI formatting

### DIFF
--- a/.circleci/task_lint.sh
+++ b/.circleci/task_lint.sh
@@ -8,9 +8,11 @@ set -o pipefail
 
 echo "Check license header..."
 python3 scripts/lint/check_license_header.py HEAD~1
+python3 scripts/lint/check_license_header.py origin/main
 
 echo "Check Python formats using black..."
 bash ./scripts/lint/git-black.sh HEAD~1
+bash ./scripts/lint/git-black.sh origin/main
 
 echo "Running pylint on heterocl"
 python3 -m pylint heterocl --rcfile=./scripts/lint/pylintrc

--- a/heterocl/ast/ast.py
+++ b/heterocl/ast/ast.py
@@ -773,9 +773,7 @@ class ConstantTensorOp(Expr):
     def __repr__(self):
         code_str = ""
         code_str += print_indent(code_str, self.level)
-        code_str += (
-            f"{self.name} = constant_tensor({self.values.shape}, {self.dtype})"
-        )
+        code_str += f"{self.name} = constant_tensor({self.values.shape}, {self.dtype})"
         return code_str
 
 

--- a/scripts/lint/git-black.sh
+++ b/scripts/lint/git-black.sh
@@ -41,7 +41,7 @@ if [ -z ${FILES+x} ]; then
     echo "No changes in Python files"
     exit 0
 fi
-echo "Files: $FILES"
+echo "Files: $FILES[@]"
 
 if [[ ${INPLACE_FORMAT} -eq 1 ]]; then
     echo "Running black on Python files against revision" $1:


### PR DESCRIPTION
The current CI script only compares the format with the previous commit in the current branch, but does not compare it with the main branch, causing the failure of #481. This PR adds format checking with the main branch, and updates the corresponding hcl-dialect commit to depict the latest license change.