### PR TITLE
[Fix] Formatting and insertion point

### DIFF
--- a/docs/source/genindex.rst
+++ b/docs/source/genindex.rst
@@ -1,4 +1,4 @@
-..  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+..  Copyright HeteroCL authors. All Rights Reserved.
     SPDX-License-Identifier: Apache-2.0
 
 Index

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1482,7 +1482,7 @@ class IRBuilder:
             initial_value=value_attr,
             constant=True,
             alignment=None,
-            ip=InsertionPoint(self.module.body),
+            ip=InsertionPoint(self._ast.top_func.ir_op),
             loc=loc,
         )
         const_tensor.attributes["constant"] = UnitAttr.get()

--- a/scripts/lint/git-black.sh
+++ b/scripts/lint/git-black.sh
@@ -41,7 +41,7 @@ if [ -z ${FILES+x} ]; then
     echo "No changes in Python files"
     exit 0
 fi
-echo "Files: $FILES[@]"
+echo "Files: ${FILES[@]}"
 
 if [[ ${INPLACE_FORMAT} -eq 1 ]]; then
     echo "Running black on Python files against revision" $1:

--- a/setup.py
+++ b/setup.py
@@ -120,9 +120,7 @@ class CMakeBuild(build_py):
 
     def run(self):
         self.src_dir = os.path.abspath(os.path.dirname(__file__))
-        self.llvm_dir = os.path.join(
-            self.src_dir, "hcl-dialect/externals/llvm-project"
-        )
+        self.llvm_dir = os.path.join(self.src_dir, "hcl-dialect/externals/llvm-project")
         if not os.path.exists(os.path.join(self.llvm_dir, "llvm")):
             raise RuntimeError(
                 "`llvm-project` not found. Please run `git submodule update --init --recursive` first"


### PR DESCRIPTION
This PR fixes the failure in #486 (which is because the PR branch is not up-to-date and does not cover necessary CI formatting tests).

Also, it fixes the insertion point for `GlobalOp`. We should follow C/C++ convention that declare all the required variables **before** usage. For example, instead of

```mlir
module {
  func.func @top(%arg0: memref<1x16x30x30xi32>) -> memref<1x16x30x30x!hcl.Fixed<26, 20>> attributes {itypes = "s", otypes = "_"} {
    ...
  }
  memref.global "private" constant @bn_weight : memref<16xi64> = dense<[...]>
  memref.global "private" constant @bn_bias : memref<16xi64> = dense<[...]>
}
```

We should do the following

```mlir
module {
  memref.global "private" constant @bn_weight : memref<16xi64> = dense<[...]>
  memref.global "private" constant @bn_bias : memref<16xi64> = dense<[...]>
  func.func @top(%arg0: memref<1x16x30x30xi32>) -> memref<1x16x30x30x!hcl.Fixed<26, 20>> attributes {itypes = "s", otypes = "_"} {
    ...
  }
}
```

This would also simplify the backend HLS codegen.