### PR TITLE
[CI] Move format checking up front

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - checkout  # checkout source code to working directory
       - run:
+          name: Formatting Check
+          command: |
+            python3 -m pip install black pylint
+            bash ./.circleci/task_lint.sh
+      - run:
           name: Build HCL-MLIR
           command: |
             export BUILD_DIR=/home/circleci/llvm-project/build
@@ -41,11 +46,6 @@ jobs:
           name: Install HeteroCL Dependencies
           command: |
             python3 -m pip install -r requirements.txt
-      - run:
-          name: Formatting Check
-          command: |
-            python3 -m pip install black pylint
-            bash ./.circleci/task_lint.sh
       - run: 
           name: HeteroCL Tests
           command: |


### PR DESCRIPTION
This PR moves the format checking step before building hcl-dialect to make it quicker to debug linting issues.