### PR TITLE
[Type] Fix type comparison (Fix #492)

### DIFF
--- a/heterocl/types.py
+++ b/heterocl/types.py
@@ -41,7 +41,7 @@ class Type:
             return False
         other = dtype_to_hcl(other)
         # check if self and other are the same type
-        if not isinstance(self, type(other)):
+        if not type(self) is type(other):
             return False
         return other.bits == self.bits and other.fracs == self.fracs
 

--- a/heterocl/types.py
+++ b/heterocl/types.py
@@ -40,6 +40,9 @@ class Type:
         if other is None:
             return False
         other = dtype_to_hcl(other)
+        # check if self and other are the same type
+        if not isinstance(self, type(other)):
+            return False
         return other.bits == self.bits and other.fracs == self.fracs
 
 
@@ -69,6 +72,16 @@ class Index(UInt):
 
 class Float(Type):
     """Floating points"""
+
+    def __init__(self, bits=32):
+        if bits == 32:
+            super().__init__(bits=32, fracs=23)
+            self.exponent = 8
+        elif bits == 64:
+            super().__init__(bits=64, fracs=52)
+            self.exponent = 11
+        else:
+            raise APIError("Unsupported floating point type")
 
     def __repr__(self):
         return "Float(" + str(self.bits) + ")"

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -6,6 +6,28 @@ import numpy as np
 import pytest
 
 
+def test_type_comparison():
+    # float type attributes
+    assert hcl.Float(32).fracs == 23
+    assert hcl.Float(32).exponent == 8
+    assert hcl.Float(32).bits == 32
+    assert hcl.Float(64).fracs == 52
+    assert hcl.Float(64).exponent == 11
+    assert hcl.Float(64).bits == 64
+    # type comparision
+    list_of_types = [hcl.Float(32), hcl.Float(64)]
+    list_of_types += [hcl.Int(i) for i in range(2, 66, 4)]
+    list_of_types += [hcl.UInt(i) for i in range(2, 66, 4)]
+    list_of_types += [hcl.Fixed(i, i - 2) for i in range(2, 66, 4)]
+    list_of_types += [hcl.UFixed(i, i - 2) for i in range(2, 66, 4)]
+    for i in range(len(list_of_types)):
+        for j in range(len(list_of_types)):
+            if i == j:
+                assert list_of_types[i] == list_of_types[j]
+            else:
+                assert list_of_types[i] != list_of_types[j]
+
+
 def test_dtype_basic_uint():
     def _test_dtype(dtype):
         hcl.init(dtype)


### PR DESCRIPTION
## Summary
This PR fixes #492, the `__eq__` implementation of `Type` class. The previous implementation did not compare the type of `Type` instances. 

## Changes
- Added type comparision in `Type.__eq__`
- Added `fracs` and `exponent` attr in float32 and float64 types

## Test
`tests/test_dtype.py::test_type_comparision`