### PR TITLE
[Op] Add math operations

### DIFF
--- a/heterocl/ast/ast.py
+++ b/heterocl/ast/ast.py
@@ -1760,10 +1760,17 @@ class TypeInference:
             return self.infer(expr.rets[0])
         if isinstance(expr, Neg):
             return self.infer(expr.expr)
-        if isinstance(expr, (MathTanhOp, MathLogOp, MathLog2Op, MathLog10Op)):
-            return self.infer_unary(expr)
+        # math ops
+        if isinstance(expr, (
+            MathExpOp, MathPowOp, MathLogOp,
+            MathLog2Op, MathLog10Op, MathSqrtOp,
+            MathSinOp, MathCosOp, MathTanOp,
+            MathTanhOp,
+        )):
+            return self.infer_math(expr)
+        
         raise APIError(
-            f"Type inference not defined for expression of type: {type(expr)}"
+            f"Type inference method not defined for expression of type: {type(expr)} in TypeInference.infer"
         )
 
     def infer_binary(self, expr):
@@ -1783,7 +1790,7 @@ class TypeInference:
                 res_type = Int(128) if isinstance(res_type, Int) else UInt(128)
         return res_type
     
-    def infer_unary(self, expr):
+    def infer_math(self, expr):
         input_type = self.infer(expr.expr)
         if isinstance(input_type, tuple):
             input_type = input_type[-1]

--- a/heterocl/ast/ast.py
+++ b/heterocl/ast/ast.py
@@ -633,7 +633,7 @@ class BitCastOp(UnaryOp):
         super().__init__("bit_cast", expr, loc)
         self.dtype = dtype
 
-
+@register_type_rules(intrin_rule)
 class MathExpOp(UnaryOp):
     """Mathematical exponential operation."""
 
@@ -674,7 +674,7 @@ class MathLog10Op(UnaryOp):
         super().__init__("log10", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
-
+@register_type_rules(intrin_rule)
 class MathSqrtOp(UnaryOp):
     """Mathematical square root operation."""
 
@@ -682,7 +682,7 @@ class MathSqrtOp(UnaryOp):
         super().__init__("sqrt", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
-
+@register_type_rules(intrin_rule)
 class MathSinOp(UnaryOp):
     """Mathematical sine operation."""
 
@@ -690,7 +690,7 @@ class MathSinOp(UnaryOp):
         super().__init__("sin", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
-
+@register_type_rules(intrin_rule)
 class MathCosOp(UnaryOp):
     """Mathematical cosine operation."""
 
@@ -698,7 +698,7 @@ class MathCosOp(UnaryOp):
         super().__init__("cos", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
-
+@register_type_rules(intrin_rule)
 class MathTanhOp(UnaryOp):
     """Mathematical tangent operation."""
 

--- a/heterocl/ast/ast.py
+++ b/heterocl/ast/ast.py
@@ -633,6 +633,7 @@ class BitCastOp(UnaryOp):
         super().__init__("bit_cast", expr, loc)
         self.dtype = dtype
 
+
 @register_type_rules(intrin_rule)
 class MathExpOp(UnaryOp):
     """Mathematical exponential operation."""
@@ -650,6 +651,7 @@ class MathPowOp(BinaryOp):
         super().__init__("pow", lhs, rhs, loc)
         self.dtype = self.tinf_engine.infer(self)
 
+
 @register_type_rules(intrin_rule)
 class MathLogOp(UnaryOp):
     """Mathematical log operation."""
@@ -657,6 +659,7 @@ class MathLogOp(UnaryOp):
     def __init__(self, expr, loc):
         super().__init__("log", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
+
 
 @register_type_rules(intrin_rule)
 class MathLog2Op(UnaryOp):
@@ -666,6 +669,7 @@ class MathLog2Op(UnaryOp):
         super().__init__("log2", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
+
 @register_type_rules(intrin_rule)
 class MathLog10Op(UnaryOp):
     """Mathematical log10 operation."""
@@ -673,6 +677,7 @@ class MathLog10Op(UnaryOp):
     def __init__(self, expr, loc):
         super().__init__("log10", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
+
 
 @register_type_rules(intrin_rule)
 class MathSqrtOp(UnaryOp):
@@ -682,6 +687,7 @@ class MathSqrtOp(UnaryOp):
         super().__init__("sqrt", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
+
 @register_type_rules(intrin_rule)
 class MathSinOp(UnaryOp):
     """Mathematical sine operation."""
@@ -689,6 +695,7 @@ class MathSinOp(UnaryOp):
     def __init__(self, expr, loc):
         super().__init__("sin", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
+
 
 @register_type_rules(intrin_rule)
 class MathCosOp(UnaryOp):
@@ -698,6 +705,7 @@ class MathCosOp(UnaryOp):
         super().__init__("cos", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
 
+
 @register_type_rules(intrin_rule)
 class MathTanOp(UnaryOp):
     """Mathematical tangent operation."""
@@ -705,6 +713,7 @@ class MathTanOp(UnaryOp):
     def __init__(self, expr, loc):
         super().__init__("tan", expr, loc)
         self.dtype = self.tinf_engine.infer(self)
+
 
 @register_type_rules(intrin_rule)
 class MathTanhOp(UnaryOp):
@@ -1761,14 +1770,23 @@ class TypeInference:
         if isinstance(expr, Neg):
             return self.infer(expr.expr)
         # math ops
-        if isinstance(expr, (
-            MathExpOp, MathPowOp, MathLogOp,
-            MathLog2Op, MathLog10Op, MathSqrtOp,
-            MathSinOp, MathCosOp, MathTanOp,
-            MathTanhOp,
-        )):
+        if isinstance(
+            expr,
+            (
+                MathExpOp,
+                MathPowOp,
+                MathLogOp,
+                MathLog2Op,
+                MathLog10Op,
+                MathSqrtOp,
+                MathSinOp,
+                MathCosOp,
+                MathTanOp,
+                MathTanhOp,
+            ),
+        ):
             return self.infer_math(expr)
-        
+
         raise APIError(
             f"Type inference method not defined for expression of type: {type(expr)} in TypeInference.infer"
         )
@@ -1789,7 +1807,7 @@ class TypeInference:
                 DTypeWarning("Modulo only supports integer <= 128 bits").warn()
                 res_type = Int(128) if isinstance(res_type, Int) else UInt(128)
         return res_type
-    
+
     def infer_math(self, expr):
         input_type = self.infer(expr.expr)
         if isinstance(input_type, tuple):

--- a/heterocl/ast/ast.py
+++ b/heterocl/ast/ast.py
@@ -699,8 +699,16 @@ class MathCosOp(UnaryOp):
         self.dtype = self.tinf_engine.infer(self)
 
 @register_type_rules(intrin_rule)
-class MathTanhOp(UnaryOp):
+class MathTanOp(UnaryOp):
     """Mathematical tangent operation."""
+
+    def __init__(self, expr, loc):
+        super().__init__("tan", expr, loc)
+        self.dtype = self.tinf_engine.infer(self)
+
+@register_type_rules(intrin_rule)
+class MathTanhOp(UnaryOp):
+    """Mathematical hyperbolic tangent operation."""
 
     def __init__(self, expr, loc):
         super().__init__("tanh", expr, loc)

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -212,7 +212,7 @@ def get_op_class(op, typ):
     if isinstance(op, ast.MathTanhOp):
         if isinstance(typ, htypes.Float):
             return math_d.TanhOp
-        raise APIError(f"Unsupported type for MathTanOp: {typ}")
+        raise APIError(f"Unsupported type for MathTanhOp: {typ}")
     raise APIError(f"Unsupported op in get_op_class: {op}")
 
 

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -254,6 +254,8 @@ class IRBuilder:
             self.build_binary_op(op, ip)
         elif isinstance(op, ast.MathTanhOp):
             self.build_math_tanh_op(op, ip)
+        elif isinstance(op, ast.MathLog2Op): # TODO: merge
+            self.build_math_log2_op(op, ip)
         elif isinstance(op, ast.BitCastOp):
             self.build_bitcast_op(op, ip)
         elif isinstance(op, ast.LoadOp):
@@ -666,6 +668,15 @@ class IRBuilder:
         tanh_op = math_d.TanhOp(casted.result, ip=ip, loc=loc)
         op.result = tanh_op.result
         op.ir_op = tanh_op
+
+    def build_math_log2_op(self, op: ast.MathLog2Op, ip):
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        self.build_visitor(op.expr, ip)
+        casted = ast.CastOp(op.expr, op.dtype, loc)
+        self.build_visitor(casted, ip)
+        log2_op = math_d.Log2Op(casted.result, ip=ip, loc=loc)
+        op.result = log2_op.result
+        op.ir_op = log2_op
 
     def build_neg_op(self, op, ip):
         loc = Location.file(op.loc.filename, op.loc.lineno, 0)

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -173,6 +173,46 @@ def get_op_class(op, typ):
         if isinstance(typ, htypes.UInt):
             return arith_d.ShRUIOp
         raise APIError(f"Unsupported type for RightShiftOp: {typ}")
+    if isinstance(op, ast.MathExpOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.ExpOp
+        raise APIError(f"Unsupported type for MathExpOp: {typ}")
+    if isinstance(op, ast.MathPowOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.PowFOp
+        raise APIError(f"Unsupported type for MathPowOp: {typ}")
+    if isinstance(op, ast.MathLogOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.LogOp
+        raise APIError(f"Unsupported type for MathLogOp: {typ}")
+    if isinstance(op, ast.MathLog2Op):
+        if isinstance(typ, htypes.Float):
+            return math_d.Log2Op
+        raise APIError(f"Unsupported type for MathLog2Op: {typ}")
+    if isinstance(op, ast.MathLog10Op):
+        if isinstance(typ, htypes.Float):
+            return math_d.Log10Op
+        raise APIError(f"Unsupported type for MathLog10Op: {typ}")
+    if isinstance(op, ast.MathSqrtOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.SqrtOp
+        raise APIError(f"Unsupported type for MathSqrtOp: {typ}")
+    if isinstance(op, ast.MathSinOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.SinOp
+        raise APIError(f"Unsupported type for MathSinOp: {typ}")
+    if isinstance(op, ast.MathCosOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.CosOp
+        raise APIError(f"Unsupported type for MathCosOp: {typ}")
+    if isinstance(op, ast.MathTanOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.TanOp
+        raise APIError(f"Unsupported type for MathTanOp: {typ}")
+    if isinstance(op, ast.MathTanhOp):
+        if isinstance(typ, htypes.Float):
+            return math_d.TanhOp
+        raise APIError(f"Unsupported type for MathTanOp: {typ}")
     raise APIError(f"Unsupported op in get_op_class: {op}")
 
 
@@ -252,10 +292,14 @@ class IRBuilder:
             self.build_cmp_op(op, ip)
         elif isinstance(op, ast.BinaryOp):
             self.build_binary_op(op, ip)
-        elif isinstance(op, ast.MathTanhOp):
-            self.build_math_tanh_op(op, ip)
-        elif isinstance(op, ast.MathLog2Op): # TODO: merge
-            self.build_math_log2_op(op, ip)
+        elif isinstance(op, (
+            ast.MathExpOp, ast.MathPowOp, ast.MathLogOp,
+            ast.MathLog2Op, ast.MathLog10Op, ast.MathSqrtOp,
+            ast.MathSinOp, ast.MathCosOp, ast.MathTanOp,
+            ast.MathTanhOp,
+            # ast.PowOp is covered by build_binary_op
+        )):
+            self.build_math_op(op, ip)
         elif isinstance(op, ast.BitCastOp):
             self.build_bitcast_op(op, ip)
         elif isinstance(op, ast.LoadOp):
@@ -660,23 +704,15 @@ class IRBuilder:
             op.result = select.result
             op.ir_op = select
 
-    def build_math_tanh_op(self, op: ast.MathTanhOp, ip):
-        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-        self.build_visitor(op.expr, ip)
-        casted = ast.CastOp(op.expr, htypes.Float(64), loc)
-        self.build_visitor(casted, ip)
-        tanh_op = math_d.TanhOp(casted.result, ip=ip, loc=loc)
-        op.result = tanh_op.result
-        op.ir_op = tanh_op
-
-    def build_math_log2_op(self, op: ast.MathLog2Op, ip):
+    def build_math_op(self, op, ip):
         loc = Location.file(op.loc.filename, op.loc.lineno, 0)
         self.build_visitor(op.expr, ip)
         casted = ast.CastOp(op.expr, op.dtype, loc)
         self.build_visitor(casted, ip)
-        log2_op = math_d.Log2Op(casted.result, ip=ip, loc=loc)
-        op.result = log2_op.result
-        op.ir_op = log2_op
+        op_class = get_op_class(op, op.dtype)
+        math_op = op_class(casted.result, ip=ip, loc=loc)
+        op.result = math_op.result
+        op.ir_op = math_op
 
     def build_neg_op(self, op, ip):
         loc = Location.file(op.loc.filename, op.loc.lineno, 0)

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -292,13 +292,22 @@ class IRBuilder:
             self.build_cmp_op(op, ip)
         elif isinstance(op, ast.BinaryOp):
             self.build_binary_op(op, ip)
-        elif isinstance(op, (
-            ast.MathExpOp, ast.MathPowOp, ast.MathLogOp,
-            ast.MathLog2Op, ast.MathLog10Op, ast.MathSqrtOp,
-            ast.MathSinOp, ast.MathCosOp, ast.MathTanOp,
-            ast.MathTanhOp,
-            # ast.PowOp is covered by build_binary_op
-        )):
+        elif isinstance(
+            op,
+            (
+                ast.MathExpOp,
+                ast.MathPowOp,
+                ast.MathLogOp,
+                ast.MathLog2Op,
+                ast.MathLog10Op,
+                ast.MathSqrtOp,
+                ast.MathSinOp,
+                ast.MathCosOp,
+                ast.MathTanOp,
+                ast.MathTanhOp,
+                # ast.PowOp is covered by build_binary_op
+            ),
+        ):
             self.build_math_op(op, ip)
         elif isinstance(op, ast.BitCastOp):
             self.build_bitcast_op(op, ip)

--- a/heterocl/ast/type_rules.py
+++ b/heterocl/ast/type_rules.py
@@ -541,3 +541,15 @@ def pow_rule():
         (Float, UInt): lambda t1, t2: t1 if isinstance(t1, Float) else t2,
     }
     return TypeRule([int_rules, float_rules])
+
+
+def intrin_rule():
+    unaryrules = {
+        (Float,): lambda t1: t1,
+        (Int,): lambda t1: Float(64),
+        (UInt,): lambda t1: Float(64),
+        (Index,): lambda t1: Float(64),
+        (Fixed,): lambda t1: Float(64),
+        (UFixed,): lambda t1: Float(64),
+    }
+    return TypeRule([unaryrules])

--- a/heterocl/ast/type_rules.py
+++ b/heterocl/ast/type_rules.py
@@ -529,7 +529,11 @@ def logic_op_rule():
 
 
 def pow_rule():
-    select_float = lambda t1, t2: Float(32) if t1.bits <= 32 else Float(64)
+    def select_float(t1, _):
+        if t1.bits <= 32:
+            return Float(32)
+        return Float(64)
+
     int_rule = {
         (Int, Int): select_float,
         (Int, UInt): select_float,

--- a/heterocl/ast/type_rules.py
+++ b/heterocl/ast/type_rules.py
@@ -536,30 +536,27 @@ def pow_rule():
         (Int, Index): select_float,
         (Int, Fixed): select_float,
         (Int, UFixed): select_float,
-        (Int, Float): select_float
+        (Int, Float): select_float,
     }
     uint_rule = {
         (UInt, UInt): select_float,
         (UInt, Index): select_float,
         (UInt, Fixed): select_float,
         (UInt, UFixed): select_float,
-        (UInt, Float): select_float
+        (UInt, Float): select_float,
     }
     index_rule = {
         (Index, Index): select_float,
         (Index, Fixed): select_float,
         (Index, UFixed): select_float,
-        (Index, Float): select_float
+        (Index, Float): select_float,
     }
     fixed_rule = {
         (Fixed, Fixed): select_float,
         (Fixed, UFixed): select_float,
-        (Fixed, Float): select_float
+        (Fixed, Float): select_float,
     }
-    ufixed_rule = {
-        (UFixed, UFixed): select_float,
-        (UFixed, Float): select_float
-    }
+    ufixed_rule = {(UFixed, UFixed): select_float, (UFixed, Float): select_float}
     float_rule = {
         (Float, Float): lambda t1, t2: Float(max(t1.bits, t2.bits)),
     }
@@ -574,7 +571,7 @@ def pow_rule():
 
 
 def intrin_rule():
-    # covers: 
+    # covers:
     # expr, log, log2, log10, sqrt,
     # sin, cos, tanh
     unaryrules = {

--- a/heterocl/ast/type_rules.py
+++ b/heterocl/ast/type_rules.py
@@ -529,27 +529,60 @@ def logic_op_rule():
 
 
 def pow_rule():
-    int_rules = {
-        (Int, Int): lambda t1, t2: Float(64),
-        (Int, UInt): lambda t1, t2: Float(64),
-        (Int, Index): lambda t1, t2: Float(64),
-        (UInt, UInt): lambda t1, t2: Float(64),
+    select_float = lambda t1, t2: Float(32) if t1.bits <= 32 else Float(64)
+    int_rule = {
+        (Int, Int): select_float,
+        (Int, UInt): select_float,
+        (Int, Index): select_float,
+        (Int, Fixed): select_float,
+        (Int, UFixed): select_float,
+        (Int, Float): select_float
     }
-    float_rules = {
+    uint_rule = {
+        (UInt, UInt): select_float,
+        (UInt, Index): select_float,
+        (UInt, Fixed): select_float,
+        (UInt, UFixed): select_float,
+        (UInt, Float): select_float
+    }
+    index_rule = {
+        (Index, Index): select_float,
+        (Index, Fixed): select_float,
+        (Index, UFixed): select_float,
+        (Index, Float): select_float
+    }
+    fixed_rule = {
+        (Fixed, Fixed): select_float,
+        (Fixed, UFixed): select_float,
+        (Fixed, Float): select_float
+    }
+    ufixed_rule = {
+        (UFixed, UFixed): select_float,
+        (UFixed, Float): select_float
+    }
+    float_rule = {
         (Float, Float): lambda t1, t2: Float(max(t1.bits, t2.bits)),
-        (Float, Int): lambda t1, t2: t1 if isinstance(t1, Float) else t2,
-        (Float, UInt): lambda t1, t2: t1 if isinstance(t1, Float) else t2,
     }
-    return TypeRule([int_rules, float_rules])
+    # Commutative=True here doesn't mean that power operation is commutative.
+    # It means that the type rule is commutative, to reduce the number of rules.
+    # e.g. hcl.power(a, b) and hcl.power(b, a) will have the same type rule.
+    # because MLIR math op in LLVM 15 only has float pow op.
+    return TypeRule(
+        [int_rule, uint_rule, index_rule, fixed_rule, ufixed_rule, float_rule],
+        commutative=True,
+    )
 
 
 def intrin_rule():
+    # covers: 
+    # expr, log, log2, log10, sqrt,
+    # sin, cos, tanh
     unaryrules = {
-        (Float,): lambda t1: t1,
-        (Int,): lambda t1: Float(64),
-        (UInt,): lambda t1: Float(64),
-        (Index,): lambda t1: Float(64),
-        (Fixed,): lambda t1: Float(64),
-        (UFixed,): lambda t1: Float(64),
+        (Float,): lambda t: t,
+        (Int,): lambda t: Float(32) if t.bits <= 32 else Float(64),
+        (UInt,): lambda t: Float(32) if t.bits <= 32 else Float(64),
+        (Index,): lambda t: Float(32) if t.bits <= 32 else Float(64),
+        (Fixed,): lambda t: Float(32) if t.bits <= 32 else Float(64),
+        (UFixed,): lambda t: Float(32) if t.bits <= 32 else Float(64),
     }
     return TypeRule([unaryrules])

--- a/heterocl/intrin.py
+++ b/heterocl/intrin.py
@@ -52,6 +52,10 @@ def cos(x):
     loc = ast.Location(filename, lineno)
     return ast.MathCosOp(x, loc)
 
+def tan(x):
+    filename, lineno = get_src_loc()
+    loc = ast.Location(filename, lineno)
+    return ast.MathTanOp(x, loc)
 
 def tanh(x):
     filename, lineno = get_src_loc()

--- a/heterocl/intrin.py
+++ b/heterocl/intrin.py
@@ -1,9 +1,10 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from hcl_mlir.exceptions import MLIRLimitationError
+
 from .ast import ast
 from .utils import get_src_loc
-from hcl_mlir.exceptions import MLIRLimitationError
 
 
 def exp(x):
@@ -56,11 +57,12 @@ def cos(x):
 
 def tan(x):
     raise MLIRLimitationError(
-        "LLVM 15.0 does not support math.tan lowering. Please write tan as sin/cos for now. tan will be added in future releases."
+        "LLVM 15.0 does not support math.tan lowering."
+        + " Please write tan as sin/cos for now. tan will be added in future releases."
     )
-    filename, lineno = get_src_loc()
-    loc = ast.Location(filename, lineno)
-    return ast.MathTanOp(x, loc)
+    # filename, lineno = get_src_loc()
+    # loc = ast.Location(filename, lineno)
+    # return ast.MathTanOp(x, loc)
 
 
 def tanh(x):

--- a/heterocl/intrin.py
+++ b/heterocl/intrin.py
@@ -3,7 +3,7 @@
 
 from .ast import ast
 from .utils import get_src_loc
-
+from hcl_mlir.exceptions import MLIRLimitationError
 
 def exp(x):
     filename, lineno = get_src_loc()
@@ -53,6 +53,7 @@ def cos(x):
     return ast.MathCosOp(x, loc)
 
 def tan(x):
+    raise MLIRLimitationError("LLVM 15.0 does not support math.tan lowering. Please write tan as sin/cos for now. tan will be added in future releases.")
     filename, lineno = get_src_loc()
     loc = ast.Location(filename, lineno)
     return ast.MathTanOp(x, loc)

--- a/heterocl/intrin.py
+++ b/heterocl/intrin.py
@@ -5,6 +5,7 @@ from .ast import ast
 from .utils import get_src_loc
 from hcl_mlir.exceptions import MLIRLimitationError
 
+
 def exp(x):
     filename, lineno = get_src_loc()
     loc = ast.Location(filename, lineno)
@@ -52,11 +53,15 @@ def cos(x):
     loc = ast.Location(filename, lineno)
     return ast.MathCosOp(x, loc)
 
+
 def tan(x):
-    raise MLIRLimitationError("LLVM 15.0 does not support math.tan lowering. Please write tan as sin/cos for now. tan will be added in future releases.")
+    raise MLIRLimitationError(
+        "LLVM 15.0 does not support math.tan lowering. Please write tan as sin/cos for now. tan will be added in future releases."
+    )
     filename, lineno = get_src_loc()
     loc = ast.Location(filename, lineno)
     return ast.MathTanOp(x, loc)
+
 
 def tanh(x):
     filename, lineno = get_src_loc()


### PR DESCRIPTION
## Summary
This PR adds support for math operations including `expr`, `pow`, `log`, `log2`, `log10`, `sin`, `cos`, `tanh`.

## Changes
- Type rules for math operations
- IRBuilder method for math operations

## Limitation
`hcl.tan` is not available at the moment. This is because LLVM 15.0 misses this rewrite pattern: 
[populateExpandTanPattern](https://mlir.llvm.org/doxygen/namespacemlir.html#a84e85fbc0b8884dd2405be7b78b0c8e7). `hcl.tan` will be added in future releases after we bump LLVM version.