### PR TITLE
[IRBuilder] Fix FP to Index cast

### DIFF
--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -1032,6 +1032,13 @@ class IRBuilder:
             CastOpClass = arith_d.UIToFPOp
         elif isinstance(src_type, htypes.Float) and isinstance(res_type, htypes.Int):
             CastOpClass = arith_d.FPToSIOp
+        elif isinstance(src_type, htypes.Float) and isinstance(res_type, htypes.Index):
+            # FP to Index is not supported in MLIR
+            # we need to cast to UInt first, then cast to Index
+            cast_to_uint = ast.CastOp(op.expr, htypes.UInt(res_type.bits), op.loc)
+            self.build_cast_op(cast_to_uint, ip)  # build cast to uint
+            op.expr = cast_to_uint  # replace expr with cast to uint
+            CastOpClass = arith_d.IndexCastOp  # proceed to build cast to index
         elif isinstance(src_type, htypes.Float) and isinstance(res_type, htypes.UInt):
             CastOpClass = arith_d.FPToUIOp
         elif isinstance(src_type, (htypes.Int, htypes.UInt)) and isinstance(

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import heterocl as hcl
+from hcl_mlir import DTypeError
 import numpy as np
 import pytest
 
@@ -693,11 +694,36 @@ def test_int_to_fixed_cast():
                 assert False, "test failed, see failed test case above"
 
 
+def test_expected_fp_as_index_error():
+    def fp_as_slice_idx(A):
+        a = hcl.scalar(0)
+        b = hcl.scalar(2)
+        idx = hcl.power(b.v, a.v)
+        # idx is float, should raise DTypeError when used as index
+        B = hcl.compute((1,), lambda _: A[idx])
+        return B
+
+    def fp_as_bit_idx(A):
+        start = hcl.scalar(0, dtype=hcl.Float())
+        end = hcl.scalar(2, dtype=hcl.Float())
+        B = hcl.compute((1,), lambda _: A[0][start.v : end.v])
+        return B
+
+    with pytest.raises(DTypeError):
+        A = hcl.placeholder((2,), "A")
+        hcl.customize([A], fp_as_slice_idx)
+
+    with pytest.raises(DTypeError):
+        A = hcl.placeholder((1,), "A", dtype=hcl.UInt(32))
+        hcl.customize([A], fp_as_bit_idx)
+
+
 def test_fp_to_index_cast():
     def kernel(A):
         a = hcl.scalar(0)
         b = hcl.scalar(2)
         idx = hcl.power(b.v, a.v)
+        idx = hcl.cast(hcl.Index(), idx)
         B = hcl.compute((1,), lambda _: A[idx])
         return B
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -693,5 +693,22 @@ def test_int_to_fixed_cast():
                 assert False, "test failed, see failed test case above"
 
 
+def test_fp_to_index_cast():
+    def kernel(A):
+        a = hcl.scalar(0)
+        b = hcl.scalar(2)
+        idx = hcl.power(b.v, a.v)
+        B = hcl.compute((1,), lambda _: A[idx])
+        return B
+
+    A = hcl.placeholder((2,), "A")
+    s = hcl.create_schedule([A], kernel)
+    f = hcl.build(s)
+    np_A = hcl.asarray([0b10101100, 0b01100101])
+    np_B = hcl.asarray([0])
+    f(np_A, np_B)
+    assert np_B.asnumpy().tolist() == [0b01100101]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR fixes an issue with FP to Index type cast op. 

Building `arith.fptoui` for fp -> index cast fails at MLIR verification with message:
```
arith.fptoui result #0 must be signless-fixed-width-integer-like, but got index
```

The solution is to cast FP to UI first, then use `arith.index_cast` to cast UI to Index.