### PR TITLE
[CI] Add attrs and specify black, pylint version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Formatting Check
           command: |
-            python3 -m pip install black pylint
+            python3 -m pip install black==23.1.0 pylint==2.17.1
             bash ./.circleci/task_lint.sh
       - run: 
           name: HeteroCL Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas
 imageio
 psutil
 sympy
+attrs


### PR DESCRIPTION
`attrs` is added to the dependency to solve this issue:
```
heterocl/devices.py:9:0: E0401: Unable to import 'attr' (import-error)
heterocl/tools.py:7:0: E0401: Unable to import 'attr' (import-error)
```

I think we should also specify a version of black and pylint to use. Pylint and black may have different check results with different versions. The undergrad team has encountered this issue a few time, I think it's easier to just fix a version on CI and local test copy.