### PR TITLE
[Primitive] Extensible primitives and transformations in Python

### DIFF
--- a/heterocl/__init__.py
+++ b/heterocl/__init__.py
@@ -3,6 +3,7 @@
 # pylint: disable=redefined-builtin
 
 from .schedule import Schedule, customize, create_schedule
+from .primitives.base import Primitive, register_primitive
 from .primitives.partition import Partition
 from .scheme import Scheme, create_scheme, create_schedule_from_scheme
 from .build_module import lower, build

--- a/heterocl/__init__.py
+++ b/heterocl/__init__.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=redefined-builtin
 
-from .schedule import Schedule, customize, create_schedule, Partition
+from .schedule import Schedule, customize, create_schedule
+from .primitives.partition import Partition
 from .scheme import Scheme, create_scheme, create_schedule_from_scheme
 from .build_module import lower, build
 from .operation import *

--- a/heterocl/ast/ir_builder.py
+++ b/heterocl/ast/ir_builder.py
@@ -469,6 +469,7 @@ class IRBuilder:
         # as the same argument object may be refered in multiple functions
         # we need to make sure that the result is not reused
         for arg in op.args:
+            arg.prev_result = arg.result
             arg.result = None
 
     def build_call_op(self, op: ast.CallOp, ip):

--- a/heterocl/build_module.py
+++ b/heterocl/build_module.py
@@ -51,25 +51,23 @@ def lower(
     """Lowering step before build into target
     by applying optimization pass
     """
-    if schedule.is_lowered():
-        raise APIError(
-            "The module has been lowered. Please apply schedule primitives before the lowering process."
-        )
-    # HeteroCL Transformation Pipeline
-    ast_pm = ast_pass_manager()
-    ast_pm.add_pass(NestElseIf)
-    ast_pm.add_pass(PromoteFunc)
-    device_agnostic_ast = ast_pm.run(schedule.ast)
-    schedule._ast = device_agnostic_ast
+    # if schedule.is_lowered():
+    #     raise APIError(
+    #         "The module has been lowered. Please apply schedule primitives before the lowering process."
+    #     )
+    # # HeteroCL Transformation Pipeline
+    # ast_pm = ast_pass_manager()
+    # ast_pm.add_pass(NestElseIf)
+    # ast_pm.add_pass(PromoteFunc)
+    # device_agnostic_ast = ast_pm.run(schedule.ast)
+    # schedule._ast = device_agnostic_ast
 
-    # Build MLIR IR
-    set_context()
-    agnostic_ir_builder = IRBuilder(device_agnostic_ast)
-    agnostic_ir_builder.build()
-    agnostic_module = agnostic_ir_builder.module
-    schedule._module = _mlir_lower_pipeline(agnostic_module)
-    schedule._top_func = agnostic_ir_builder.top_func
-    exit_context()
+    # # Build MLIR IR
+    # set_context()
+    # agnostic_ir_builder = IRBuilder(device_agnostic_ast)
+    # agnostic_ir_builder.build()
+    # agnostic_module = agnostic_ir_builder.module
+    schedule._module = _mlir_lower_pipeline(schedule._module)
 
     schedule.set_lowered()
     return schedule.module

--- a/heterocl/build_module.py
+++ b/heterocl/build_module.py
@@ -51,24 +51,7 @@ def lower(
     """Lowering step before build into target
     by applying optimization pass
     """
-    # if schedule.is_lowered():
-    #     raise APIError(
-    #         "The module has been lowered. Please apply schedule primitives before the lowering process."
-    #     )
-    # # HeteroCL Transformation Pipeline
-    # ast_pm = ast_pass_manager()
-    # ast_pm.add_pass(NestElseIf)
-    # ast_pm.add_pass(PromoteFunc)
-    # device_agnostic_ast = ast_pm.run(schedule.ast)
-    # schedule._ast = device_agnostic_ast
-
-    # # Build MLIR IR
-    # set_context()
-    # agnostic_ir_builder = IRBuilder(device_agnostic_ast)
-    # agnostic_ir_builder.build()
-    # agnostic_module = agnostic_ir_builder.module
     schedule._module = _mlir_lower_pipeline(schedule._module)
-
     schedule.set_lowered()
     return schedule.module
 

--- a/heterocl/build_module.py
+++ b/heterocl/build_module.py
@@ -24,9 +24,6 @@ from .module import HCLModule, HCLSuperModule
 from .runtime import copy_build_files
 from .schedule import Schedule
 from .utils import hcl_dtype_to_mlir
-from .passes.pass_manager import PassManager as ast_pass_manager
-from .passes.nest_if import NestElseIf
-from .passes.promote_func import PromoteFunc
 from .ast.ir_builder import IRBuilder
 from .ast.build_cleaner import ASTCleaner
 from .ast import ast

--- a/heterocl/ir/__init__.py
+++ b/heterocl/ir/__init__.py
@@ -1,0 +1,2 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/heterocl/ir/transform.py
+++ b/heterocl/ir/transform.py
@@ -1,0 +1,17 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import hcl_mlir
+from hcl_mlir import UnitAttr
+
+
+def get_affine_loop_nests(func):
+    loops = hcl_mlir.get_affine_loop_nests(func)[0]
+    res = []
+    for item in loops:
+        res.append((item["name"], item["body"]))
+    return res
+
+
+def annotate(op, name):
+    op.attributes[name] = UnitAttr.get()

--- a/heterocl/ir/transform.py
+++ b/heterocl/ir/transform.py
@@ -2,16 +2,51 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hcl_mlir
-from hcl_mlir import UnitAttr
+from hcl_mlir import UnitAttr, StringAttr, InsertionPoint, MemRefType
+from hcl_mlir.dialects import memref as memref_d
 
 
 def get_affine_loop_nests(func):
-    loops = hcl_mlir.get_affine_loop_nests(func)[0]
+    loops = hcl_mlir.get_affine_loop_nests(func)
     res = []
-    for item in loops:
-        res.append((item["name"], item["body"]))
+    for loop in loops:
+        res.append([(item["name"], item["body"]) for item in loop])
     return res
 
 
 def annotate(op, name):
     op.attributes[name] = UnitAttr.get()
+
+
+def create_buffer(tensor, name, ip):
+    with InsertionPoint(ip):
+        alloc_op = memref_d.AllocOp(tensor.type, [], [])
+        alloc_op.attributes["name"] = StringAttr.get(name)
+        shape = MemRefType(tensor.type).shape
+        for_loops = []
+
+        def recursive_for(for_handle, idx):
+            if idx == len(shape):
+                return
+            with InsertionPoint(for_handle.body.operations[0]):
+                new_for = hcl_mlir.make_for(
+                    0, shape[idx], name=name + f"_l_{idx}", stage="S_" + name
+                )
+                for_loops.append(new_for)
+                recursive_for(new_for, idx + 1)
+
+        for_handle = hcl_mlir.make_for(
+            0, shape[0], name=name + "_l_0", stage="S_" + name
+        )
+        for_loops.append(for_handle)
+        recursive_for(for_handle, 1)
+        induction_vars = [for_loop.induction_variable for for_loop in for_loops]
+        with InsertionPoint(for_loops[-1].body.operations[0]):
+            load = memref_d.LoadOp(tensor, induction_vars)
+            memref_d.StoreOp(
+                load.result,
+                alloc_op.result,
+                induction_vars,
+            )
+        # TODO: Upgrade LLVM version and use the following code
+        # tensor.replace_all_uses_with(alloc_op.result)

--- a/heterocl/ir/transform.py
+++ b/heterocl/ir/transform.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, no-value-for-parameter
 
 import hcl_mlir
 from hcl_mlir import UnitAttr, StringAttr, InsertionPoint, MemRefType

--- a/heterocl/ir/transform.py
+++ b/heterocl/ir/transform.py
@@ -19,35 +19,46 @@ def annotate(op, name):
     op.attributes[name] = UnitAttr.get()
 
 
+def build_for_loops(grid, ip, name="loop"):
+    for_loops = []
+    if isinstance(name, str):
+        names = [name + f"_l_{i}" for i in range(len(grid))]
+        stage_name = "S_" + name
+    else:  # list
+        names = name
+        stage_name = "S_" + "_".join(names)
+    assert len(grid) >= 1
+
+    def recursive_for(for_handle, idx):
+        if idx == len(grid):
+            return
+        with InsertionPoint(for_handle.body.operations[0]):
+            new_for = hcl_mlir.make_for(0, grid[idx], name=names[idx])
+            for_loops.append(new_for)
+            recursive_for(new_for, idx + 1)
+
+    if not isinstance(ip, InsertionPoint):
+        ip = InsertionPoint(ip)
+    with ip:
+        for_handle = hcl_mlir.make_for(0, grid[0], name=names[0], stage=stage_name)
+    for_loops.append(for_handle)
+    recursive_for(for_handle, 1)
+    return for_loops
+
+
 def create_buffer(tensor, name, ip):
     with InsertionPoint(ip):
         alloc_op = memref_d.AllocOp(tensor.type, [], [])
         alloc_op.attributes["name"] = StringAttr.get(name)
         shape = MemRefType(tensor.type).shape
-        for_loops = []
-
-        def recursive_for(for_handle, idx):
-            if idx == len(shape):
-                return
-            with InsertionPoint(for_handle.body.operations[0]):
-                new_for = hcl_mlir.make_for(
-                    0, shape[idx], name=name + f"_l_{idx}", stage="S_" + name
-                )
-                for_loops.append(new_for)
-                recursive_for(new_for, idx + 1)
-
-        for_handle = hcl_mlir.make_for(
-            0, shape[0], name=name + "_l_0", stage="S_" + name
+    for_loops = build_for_loops(shape, ip, name)
+    induction_vars = [for_loop.induction_variable for for_loop in for_loops]
+    with InsertionPoint(for_loops[-1].body.operations[0]):
+        load = memref_d.LoadOp(tensor, induction_vars)
+        memref_d.StoreOp(
+            load.result,
+            alloc_op.result,
+            induction_vars,
         )
-        for_loops.append(for_handle)
-        recursive_for(for_handle, 1)
-        induction_vars = [for_loop.induction_variable for for_loop in for_loops]
-        with InsertionPoint(for_loops[-1].body.operations[0]):
-            load = memref_d.LoadOp(tensor, induction_vars)
-            memref_d.StoreOp(
-                load.result,
-                alloc_op.result,
-                induction_vars,
-            )
-        # TODO: Upgrade LLVM version and use the following code
-        # tensor.replace_all_uses_with(alloc_op.result)
+    # TODO: Upgrade LLVM version and use the following code
+    # tensor.replace_all_uses_with(alloc_op.result)

--- a/heterocl/primitives/__init__.py
+++ b/heterocl/primitives/__init__.py
@@ -1,0 +1,21 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Schedule primitives."""
+
+import os
+from os.path import abspath, dirname, join, isfile
+from inspect import getsourcefile, getmembers
+from importlib import import_module
+
+from .base import register_primitive, PRIMITIVES, Primitive
+
+path = dirname(abspath(getsourcefile(lambda: 0)))
+files = [
+    f
+    for f in os.listdir(path)
+    if isfile(join(path, f)) and f not in {"__init__.py", "base.py"}
+]
+for file in files:
+    mod = import_module(f".{file.split('.')[0]}", package="heterocl.primitives")
+    # register the schedule primitive using the decorator
+    getmembers(mod)

--- a/heterocl/primitives/base.py
+++ b/heterocl/primitives/base.py
@@ -1,0 +1,41 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Schedule primitive base."""
+from __future__ import annotations
+from abc import ABCMeta, abstractmethod
+
+PRIMITIVES = {}
+STAGE_PRIMITIVES = {}
+
+
+def register_primitive():
+    """Register a primitive to the schedule."""
+
+    def dectorator(cls):
+        if cls.name in PRIMITIVES:
+            raise ValueError(f"Primitive {cls.name} already registered")
+        if not issubclass(cls, Primitive):
+            raise ValueError(f"Class {cls} is not a subclass of Primitive")
+        if hasattr(cls, "is_stage_primitive") and cls.is_stage_primitive:
+            STAGE_PRIMITIVES[cls.name] = cls
+        else:
+            PRIMITIVES[cls.name] = cls
+        return cls
+
+    return dectorator
+
+
+class Primitive(metaclass=ABCMeta):
+    """A base class of schedule primitives."""
+
+    @property
+    @abstractmethod
+    def name():
+        """The name of the primitive."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def apply(sch, *args, **kwargs):
+        """Apply the primitive to the schedule."""
+        raise NotImplementedError

--- a/heterocl/primitives/base.py
+++ b/heterocl/primitives/base.py
@@ -1,6 +1,8 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Schedule primitive base."""
+# pylint: disable=no-method-argument
+
 from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 

--- a/heterocl/primitives/buffer_at.py
+++ b/heterocl/primitives/buffer_at.py
@@ -4,9 +4,18 @@
 from hcl_mlir.exceptions import (
     APIError,
 )
+from hcl_mlir.ir import (
+    Location,
+    InsertionPoint,
+    F32Type,
+    MemRefType,
+)
+from hcl_mlir.dialects import hcl as hcl_d
 from ..ast import ast
+from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
+from ..context import get_context, get_location
 
 
 @register_primitive()
@@ -23,4 +32,18 @@ class BufferAtPrimitive(Primitive):
         loc = ast.Location(filename, lineno)
         buffer_at_op = ast.BufferAtOp(target, axis, loc)
         sch.ast.top_func.body.append(buffer_at_op)
+        op = buffer_at_op
+        with get_context(), get_location():
+            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+            ir_builder = IRBuilder(sch._ast)
+            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+            ir_builder.build_visitor(op.target, ip)
+            ir_builder.build_visitor(op.axis, ip)
+            f32 = F32Type.get()
+            memref_type = MemRefType.get((1,), f32, loc=loc)
+            buffer_at_op = hcl_d.BufferAtOp(
+                memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
+            )
+            op.ir_op = buffer_at_op
+            op.result = buffer_at_op.result
         return buffer_at_op

--- a/heterocl/primitives/buffer_at.py
+++ b/heterocl/primitives/buffer_at.py
@@ -1,0 +1,26 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class BufferAtPrimitive(Primitive):
+    name = "buffer_at"
+
+    @staticmethod
+    def apply(sch, target, parent, axis, name=None):
+        """Create a write buffer reusing the output of current stage"""
+        if sch.is_lowered():
+            raise APIError(".buffer_at() must be called before lowering")
+
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        buffer_at_op = ast.BufferAtOp(target, axis, loc)
+        sch.ast.top_func.body.append(buffer_at_op)
+        return buffer_at_op

--- a/heterocl/primitives/buffer_at.py
+++ b/heterocl/primitives/buffer_at.py
@@ -16,7 +16,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/buffer_at.py
+++ b/heterocl/primitives/buffer_at.py
@@ -45,5 +45,5 @@ class BufferAtPrimitive(Primitive):
             memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
         )
         op.ir_op = hcl_buffer_at_op
-        op.result = hcl_buffer_at_op.resultå
+        op.result = hcl_buffer_at_op.result
         return buffer_at_op

--- a/heterocl/primitives/buffer_at.py
+++ b/heterocl/primitives/buffer_at.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ, unused-argument
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -41,9 +42,9 @@ class BufferAtPrimitive(Primitive):
             ir_builder.build_visitor(op.axis, ip)
             f32 = F32Type.get()
             memref_type = MemRefType.get((1,), f32, loc=loc)
-            buffer_at_op = hcl_d.BufferAtOp(
+            hcl_buffer_at_op = hcl_d.BufferAtOp(
                 memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
             )
-            op.ir_op = buffer_at_op
-            op.result = buffer_at_op.result
+            op.ir_op = hcl_buffer_at_op
+            op.result = hcl_buffer_at_op.result
         return buffer_at_op

--- a/heterocl/primitives/buffer_at.py
+++ b/heterocl/primitives/buffer_at.py
@@ -34,17 +34,16 @@ class BufferAtPrimitive(Primitive):
         buffer_at_op = ast.BufferAtOp(target, axis, loc)
         sch.ast.top_func.body.append(buffer_at_op)
         op = buffer_at_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            ir_builder.build_visitor(op.axis, ip)
-            f32 = F32Type.get()
-            memref_type = MemRefType.get((1,), f32, loc=loc)
-            hcl_buffer_at_op = hcl_d.BufferAtOp(
-                memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
-            )
-            op.ir_op = hcl_buffer_at_op
-            op.result = hcl_buffer_at_op.result
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        ir_builder.build_visitor(op.axis, ip)
+        f32 = F32Type.get()
+        memref_type = MemRefType.get((1,), f32, loc=loc)
+        hcl_buffer_at_op = hcl_d.BufferAtOp(
+            memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
+        )
+        op.ir_op = hcl_buffer_at_op
+        op.result = hcl_buffer_at_op.resultå
         return buffer_at_op

--- a/heterocl/primitives/compute_at.py
+++ b/heterocl/primitives/compute_at.py
@@ -14,7 +14,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/compute_at.py
+++ b/heterocl/primitives/compute_at.py
@@ -1,0 +1,33 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ComputeAtPrimitive(Primitive):
+    name = "compute_at"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, parent, axis):
+        """Attach the stage at parent's scope"""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".compute_at() must be called before lowering")
+        if isinstance(axis, int):
+            axis = parent.tensor.axis[axis]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        compute_at_op = ast.ComputeAtOp(
+            stage.stage_handle, parent.stage_handle, axis, loc
+        )
+        sch.ast.top_func.body.append(compute_at_op)

--- a/heterocl/primitives/compute_at.py
+++ b/heterocl/primitives/compute_at.py
@@ -39,14 +39,13 @@ class ComputeAtPrimitive(Primitive):
         )
         sch.ast.top_func.body.append(compute_at_op)
         op = compute_at_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.stage, ip)
-            ir_builder.build_visitor(op.parent, ip)
-            ir_builder.build_visitor(op.axis, ip)
-            hcl_compute_at_op = hcl_d.ComputeAtOp(
-                op.stage.result, op.parent.result, op.axis.result, ip=ip, loc=loc
-            )
-            op.ir_op = hcl_compute_at_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.stage, ip)
+        ir_builder.build_visitor(op.parent, ip)
+        ir_builder.build_visitor(op.axis, ip)
+        hcl_compute_at_op = hcl_d.ComputeAtOp(
+            op.stage.result, op.parent.result, op.axis.result, ip=ip, loc=loc
+        )
+        op.ir_op = hcl_compute_at_op

--- a/heterocl/primitives/compute_at.py
+++ b/heterocl/primitives/compute_at.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -45,7 +46,7 @@ class ComputeAtPrimitive(Primitive):
             ir_builder.build_visitor(op.stage, ip)
             ir_builder.build_visitor(op.parent, ip)
             ir_builder.build_visitor(op.axis, ip)
-            compute_at_op = hcl_d.ComputeAtOp(
+            hcl_compute_at_op = hcl_d.ComputeAtOp(
                 op.stage.result, op.parent.result, op.axis.result, ip=ip, loc=loc
             )
-            op.ir_op = compute_at_op
+            op.ir_op = hcl_compute_at_op

--- a/heterocl/primitives/fuse.py
+++ b/heterocl/primitives/fuse.py
@@ -14,7 +14,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/fuse.py
+++ b/heterocl/primitives/fuse.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -47,7 +48,7 @@ class FusePrimitive(Primitive):
             for arg in op.arg_list:
                 ir_builder.build_visitor(arg, ip)
             arg_results = [arg.result for arg in op.arg_list]
-            fuse_op = hcl_d.FuseOp(arg_results, ip=ip, loc=loc)
-            op.ir_op = fuse_op
-            op.result = fuse_op.result
+            hcl_fuse_op = hcl_d.FuseOp(arg_results, ip=ip, loc=loc)
+            op.ir_op = hcl_fuse_op
+            op.result = hcl_fuse_op.result
         return fuse_op

--- a/heterocl/primitives/fuse.py
+++ b/heterocl/primitives/fuse.py
@@ -41,14 +41,13 @@ class FusePrimitive(Primitive):
         fuse_op = ast.FuseOp(args, loc)
         sch.ast.top_func.body.append(fuse_op)
         op = fuse_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            for arg in op.arg_list:
-                ir_builder.build_visitor(arg, ip)
-            arg_results = [arg.result for arg in op.arg_list]
-            hcl_fuse_op = hcl_d.FuseOp(arg_results, ip=ip, loc=loc)
-            op.ir_op = hcl_fuse_op
-            op.result = hcl_fuse_op.result
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        for arg in op.arg_list:
+            ir_builder.build_visitor(arg, ip)
+        arg_results = [arg.result for arg in op.arg_list]
+        hcl_fuse_op = hcl_d.FuseOp(arg_results, ip=ip, loc=loc)
+        op.ir_op = hcl_fuse_op
+        op.result = hcl_fuse_op.result
         return fuse_op

--- a/heterocl/primitives/fuse.py
+++ b/heterocl/primitives/fuse.py
@@ -1,0 +1,36 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class FusePrimitive(Primitive):
+    name = "fuse"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, *args):
+        """Fuse multiple consecutive iteration variables into a single iteration variable."""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".fuse() must be called before lowering")
+        assert len(args) >= 1, "Length of the arguments must be >=1 for fuse."
+        args = list(args)
+        # pylint: disable=consider-using-enumerate
+        for i in range(len(args)):
+            if isinstance(args[i], int):
+                args[i] = stage.tensor.axis[args[i]]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        fuse_op = ast.FuseOp(args, loc)
+        sch.ast.top_func.body.append(fuse_op)
+        return fuse_op

--- a/heterocl/primitives/parallel.py
+++ b/heterocl/primitives/parallel.py
@@ -37,10 +37,9 @@ class ParallelPrimitive(Primitive):
         parallel_op = ast.ParallelOp(var, loc)
         sch.ast.top_func.body.append(parallel_op)
         op = parallel_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            hcl_parallel_op = hcl_d.ParallelOp(op.target.result, ip=ip, loc=loc)
-            op.ir_op = hcl_parallel_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        hcl_parallel_op = hcl_d.ParallelOp(op.target.result, ip=ip, loc=loc)
+        op.ir_op = hcl_parallel_op

--- a/heterocl/primitives/parallel.py
+++ b/heterocl/primitives/parallel.py
@@ -14,7 +14,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/parallel.py
+++ b/heterocl/primitives/parallel.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -41,5 +42,5 @@ class ParallelPrimitive(Primitive):
             ir_builder = IRBuilder(sch._ast)
             ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
             ir_builder.build_visitor(op.target, ip)
-            parallel_op = hcl_d.ParallelOp(op.target.result, ip=ip, loc=loc)
-            op.ir_op = parallel_op
+            hcl_parallel_op = hcl_d.ParallelOp(op.target.result, ip=ip, loc=loc)
+            op.ir_op = hcl_parallel_op

--- a/heterocl/primitives/parallel.py
+++ b/heterocl/primitives/parallel.py
@@ -1,0 +1,31 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ParallelPrimitive(Primitive):
+    name = "parallel"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, var):
+        """Parallelize the iteration."""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".parallel() must be called before lowering")
+        if isinstance(var, int):
+            var = stage.tensor.axis[var]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        parallel_op = ast.ParallelOp(var, loc)
+        sch.ast.top_func.body.append(parallel_op)

--- a/heterocl/primitives/partition.py
+++ b/heterocl/primitives/partition.py
@@ -17,7 +17,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 class Partition:

--- a/heterocl/primitives/partition.py
+++ b/heterocl/primitives/partition.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     HCLValueError,
@@ -67,7 +68,7 @@ class ParitionPrimitive(Primitive):
                 op.tensor.result = op.tensor.prev_result
             ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
             ir_builder.build_visitor(op.tensor, ip)
-            partition_op = hcl_d.PartitionOp(
+            hcl_partition_op = hcl_d.PartitionOp(
                 op.tensor.result,
                 partition_kind=partition_type,
                 dim=dim,
@@ -75,4 +76,4 @@ class ParitionPrimitive(Primitive):
                 ip=ip,
                 loc=loc,
             )
-            op.ir_op = partition_op
+            op.ir_op = hcl_partition_op

--- a/heterocl/primitives/partition.py
+++ b/heterocl/primitives/partition.py
@@ -55,25 +55,24 @@ class ParitionPrimitive(Primitive):
         partition_op = ast.PartitionOp(target, partition_type, dim, factor, loc)
         sch.ast.top_func.body.append(partition_op)
         op = partition_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            i32 = IntegerType.get_signless(32)
-            ui32 = IntegerType.get_unsigned(32)
-            partition_type = IntegerAttr.get(i32, op.kind)
-            dim = IntegerAttr.get(ui32, op.dim)
-            factor = IntegerAttr.get(ui32, op.factor)
-            ir_builder = IRBuilder(sch._ast)
-            # Be careful, since arg.result has been removed when building func op
-            if op.tensor.result is None:
-                op.tensor.result = op.tensor.prev_result
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.tensor, ip)
-            hcl_partition_op = hcl_d.PartitionOp(
-                op.tensor.result,
-                partition_kind=partition_type,
-                dim=dim,
-                factor=factor,
-                ip=ip,
-                loc=loc,
-            )
-            op.ir_op = hcl_partition_op
+        i32 = IntegerType.get_signless(32)
+        ui32 = IntegerType.get_unsigned(32)
+        partition_type = IntegerAttr.get(i32, op.kind)
+        dim = IntegerAttr.get(ui32, op.dim)
+        factor = IntegerAttr.get(ui32, op.factor)
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        # Be careful, since arg.result has been removed when building func op
+        if op.tensor.result is None:
+            op.tensor.result = op.tensor.prev_result
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.tensor, ip)
+        hcl_partition_op = hcl_d.PartitionOp(
+            op.tensor.result,
+            partition_kind=partition_type,
+            dim=dim,
+            factor=factor,
+            ip=ip,
+            loc=loc,
+        )
+        op.ir_op = hcl_partition_op

--- a/heterocl/primitives/partition.py
+++ b/heterocl/primitives/partition.py
@@ -1,0 +1,47 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    HCLValueError,
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+class Partition:
+    Complete = 0
+    Block = 1
+    Cyclic = 2
+
+
+@register_primitive()
+class ParitionPrimitive(Primitive):
+    name = "partition"
+
+    @staticmethod
+    def apply(sch, target, partition_type=Partition.Complete, dim=0, factor=0):
+        """Partition a Tensor into smaller Tensors or even registers"""
+        if sch.is_lowered():
+            raise APIError(".partition() must be called before lowering")
+        if partition_type > 2:
+            raise HCLValueError("Invalid partition type")
+        if dim < 0:
+            raise HCLValueError("Invalid dimension")
+        if factor < 0:
+            raise HCLValueError("Invalid factor")
+
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        if partition_type == Partition.Complete:
+            partition_type = 0
+        elif partition_type == Partition.Block:
+            partition_type = 1
+        elif partition_type == Partition.Cyclic:
+            partition_type = 2
+        else:
+            raise HCLValueError("Not supported partition type")
+        partition_op = ast.PartitionOp(target, partition_type, dim, factor, loc)
+        sch.ast.top_func.body.append(partition_op)

--- a/heterocl/primitives/pipeline.py
+++ b/heterocl/primitives/pipeline.py
@@ -1,0 +1,31 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class PipelinePrimitive(Primitive):
+    name = "pipeline"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, var, initiation_interval=1):
+        """Pipeline the iteration."""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".pipeline() must be called before lowering")
+        if isinstance(var, int):
+            var = stage.tensor.axis[var]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        pipeline_op = ast.PipelineOp(var, initiation_interval, loc)
+        sch.ast.top_func.body.append(pipeline_op)

--- a/heterocl/primitives/pipeline.py
+++ b/heterocl/primitives/pipeline.py
@@ -16,7 +16,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/pipeline.py
+++ b/heterocl/primitives/pipeline.py
@@ -4,10 +4,18 @@
 from hcl_mlir.exceptions import (
     APIError,
 )
-
+from hcl_mlir.ir import (
+    Location,
+    InsertionPoint,
+    IntegerType,
+    IntegerAttr,
+)
+from hcl_mlir.dialects import hcl as hcl_d
 from ..ast import ast
+from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
+from ..context import get_context, get_location
 
 
 @register_primitive()
@@ -29,3 +37,13 @@ class PipelinePrimitive(Primitive):
         loc = ast.Location(filename, lineno)
         pipeline_op = ast.PipelineOp(var, initiation_interval, loc)
         sch.ast.top_func.body.append(pipeline_op)
+        op = pipeline_op
+        with get_context(), get_location():
+            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+            ir_builder = IRBuilder(sch._ast)
+            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+            ir_builder.build_visitor(op.target, ip)
+            i32 = IntegerType.get_unsigned(32)
+            ii = IntegerAttr.get(i32, op.ii)
+            pipeline_op = hcl_d.PipelineOp(op.target.result, ii=ii, ip=ip, loc=loc)
+            op.ir_op = pipeline_op

--- a/heterocl/primitives/pipeline.py
+++ b/heterocl/primitives/pipeline.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -45,5 +46,5 @@ class PipelinePrimitive(Primitive):
             ir_builder.build_visitor(op.target, ip)
             i32 = IntegerType.get_unsigned(32)
             ii = IntegerAttr.get(i32, op.ii)
-            pipeline_op = hcl_d.PipelineOp(op.target.result, ii=ii, ip=ip, loc=loc)
-            op.ir_op = pipeline_op
+            hcl_pipeline_op = hcl_d.PipelineOp(op.target.result, ii=ii, ip=ip, loc=loc)
+            op.ir_op = hcl_pipeline_op

--- a/heterocl/primitives/pipeline.py
+++ b/heterocl/primitives/pipeline.py
@@ -39,12 +39,11 @@ class PipelinePrimitive(Primitive):
         pipeline_op = ast.PipelineOp(var, initiation_interval, loc)
         sch.ast.top_func.body.append(pipeline_op)
         op = pipeline_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            i32 = IntegerType.get_unsigned(32)
-            ii = IntegerAttr.get(i32, op.ii)
-            hcl_pipeline_op = hcl_d.PipelineOp(op.target.result, ii=ii, ip=ip, loc=loc)
-            op.ir_op = hcl_pipeline_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        i32 = IntegerType.get_unsigned(32)
+        ii = IntegerAttr.get(i32, op.ii)
+        hcl_pipeline_op = hcl_d.PipelineOp(op.target.result, ii=ii, ip=ip, loc=loc)
+        op.ir_op = hcl_pipeline_op

--- a/heterocl/primitives/reform.py
+++ b/heterocl/primitives/reform.py
@@ -1,0 +1,24 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ReformPrimitive(Primitive):
+    name = "reform"
+
+    @staticmethod
+    def apply(sch, target, layout):
+        """Change the layout of a tensor"""
+        if sch.is_lowered():
+            raise APIError(".reform() must be called before lowering")
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        reform_op = ast.ReformOp(target, layout, loc)
+        sch.ast.top_func.body.append(reform_op)

--- a/heterocl/primitives/reform.py
+++ b/heterocl/primitives/reform.py
@@ -34,18 +34,17 @@ class ReformPrimitive(Primitive):
         reform_op = ast.ReformOp(target, layout, loc)
         sch.ast.top_func.body.append(reform_op)
         op = reform_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            if op.layout == "nhwc":
-                attr = AffineMap.get_permutation([0, 2, 3, 1])
-            else:
-                raise RuntimeError("Not supported layout")
-            memref_type = MemRefType.get(op.target.shape, op.target.ir_op.dtype)
-            hcl_reform_op = hcl_d.ReformOp(
-                memref_type, op.target.result, ip=ip, loc=loc
-            )
-            hcl_reform_op.attributes["layout"] = AffineMapAttr.get(attr)
-            op.ir_op = hcl_reform_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        if op.layout == "nhwc":
+            attr = AffineMap.get_permutation([0, 2, 3, 1])
+        else:
+            raise RuntimeError("Not supported layout")
+        memref_type = MemRefType.get(op.target.shape, op.target.ir_op.dtype)
+        hcl_reform_op = hcl_d.ReformOp(
+            memref_type, op.target.result, ip=ip, loc=loc
+        )
+        hcl_reform_op.attributes["layout"] = AffineMapAttr.get(attr)
+        op.ir_op = hcl_reform_op

--- a/heterocl/primitives/reform.py
+++ b/heterocl/primitives/reform.py
@@ -4,9 +4,19 @@
 from hcl_mlir.exceptions import (
     APIError,
 )
+from hcl_mlir.ir import (
+    Location,
+    InsertionPoint,
+    AffineMap,
+    AffineMapAttr,
+    MemRefType,
+)
+from hcl_mlir.dialects import hcl as hcl_d
 from ..ast import ast
+from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
+from ..context import get_context, get_location
 
 
 @register_primitive()
@@ -22,3 +32,17 @@ class ReformPrimitive(Primitive):
         loc = ast.Location(filename, lineno)
         reform_op = ast.ReformOp(target, layout, loc)
         sch.ast.top_func.body.append(reform_op)
+        op = reform_op
+        with get_context(), get_location():
+            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+            ir_builder = IRBuilder(sch._ast)
+            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+            ir_builder.build_visitor(op.target, ip)
+            if op.layout == "nhwc":
+                attr = AffineMap.get_permutation([0, 2, 3, 1])
+            else:
+                raise RuntimeError("Not supported layout")
+            memref_type = MemRefType.get(op.target.shape, op.target.ir_op.dtype)
+            reform_op = hcl_d.ReformOp(memref_type, op.target.result, ip=ip, loc=loc)
+            reform_op.attributes["layout"] = AffineMapAttr.get(attr)
+            op.ir_op = reform_op

--- a/heterocl/primitives/reform.py
+++ b/heterocl/primitives/reform.py
@@ -17,7 +17,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/reform.py
+++ b/heterocl/primitives/reform.py
@@ -43,8 +43,6 @@ class ReformPrimitive(Primitive):
         else:
             raise RuntimeError("Not supported layout")
         memref_type = MemRefType.get(op.target.shape, op.target.ir_op.dtype)
-        hcl_reform_op = hcl_d.ReformOp(
-            memref_type, op.target.result, ip=ip, loc=loc
-        )
+        hcl_reform_op = hcl_d.ReformOp(memref_type, op.target.result, ip=ip, loc=loc)
         hcl_reform_op.attributes["layout"] = AffineMapAttr.get(attr)
         op.ir_op = hcl_reform_op

--- a/heterocl/primitives/reform.py
+++ b/heterocl/primitives/reform.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -43,6 +44,8 @@ class ReformPrimitive(Primitive):
             else:
                 raise RuntimeError("Not supported layout")
             memref_type = MemRefType.get(op.target.shape, op.target.ir_op.dtype)
-            reform_op = hcl_d.ReformOp(memref_type, op.target.result, ip=ip, loc=loc)
-            reform_op.attributes["layout"] = AffineMapAttr.get(attr)
-            op.ir_op = reform_op
+            hcl_reform_op = hcl_d.ReformOp(
+                memref_type, op.target.result, ip=ip, loc=loc
+            )
+            hcl_reform_op.attributes["layout"] = AffineMapAttr.get(attr)
+            op.ir_op = hcl_reform_op

--- a/heterocl/primitives/reorder.py
+++ b/heterocl/primitives/reorder.py
@@ -14,7 +14,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/reorder.py
+++ b/heterocl/primitives/reorder.py
@@ -1,0 +1,34 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ReorderPrimitive(Primitive):
+    name = "reorder"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, *args):
+        """reorder the arguments in the specified order."""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".reorder() must be called before lowering")
+        args = list(args)
+        # pylint: disable=consider-using-enumerate
+        for i in range(len(args)):
+            if isinstance(args[i], int):
+                args[i] = stage.tensor.axis[args[i]]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        reorder_op = ast.ReorderOp(args, loc)
+        sch.ast.top_func.body.append(reorder_op)

--- a/heterocl/primitives/reorder.py
+++ b/heterocl/primitives/reorder.py
@@ -40,12 +40,11 @@ class ReorderPrimitive(Primitive):
         reorder_op = ast.ReorderOp(args, loc)
         sch.ast.top_func.body.append(reorder_op)
         op = reorder_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            for arg in op.args:
-                ir_builder.build_visitor(arg, ip)
-            arg_results = [arg.result for arg in op.args]
-            hcl_reorder_op = hcl_d.ReorderOp(arg_results, ip=ip, loc=loc)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ir_builder = IRBuilder(sch._ast)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        for arg in op.args:
+            ir_builder.build_visitor(arg, ip)
+        arg_results = [arg.result for arg in op.args]
+        hcl_reorder_op = hcl_d.ReorderOp(arg_results, ip=ip, loc=loc)
         op.ir_op = hcl_reorder_op

--- a/heterocl/primitives/reorder.py
+++ b/heterocl/primitives/reorder.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -46,5 +47,5 @@ class ReorderPrimitive(Primitive):
             for arg in op.args:
                 ir_builder.build_visitor(arg, ip)
             arg_results = [arg.result for arg in op.args]
-            reorder_op = hcl_d.ReorderOp(arg_results, ip=ip, loc=loc)
-        op.ir_op = reorder_op
+            hcl_reorder_op = hcl_d.ReorderOp(arg_results, ip=ip, loc=loc)
+        op.ir_op = hcl_reorder_op

--- a/heterocl/primitives/replace.py
+++ b/heterocl/primitives/replace.py
@@ -14,7 +14,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/replace.py
+++ b/heterocl/primitives/replace.py
@@ -32,13 +32,12 @@ class ReplacePrimitive(Primitive):
         replace_op = ast.ReplaceOp(src, dst, loc)
         sch.ast.top_func.body.append(replace_op)
         op = replace_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            ir_builder.build_visitor(op.src, ip)
-            hcl_replace_op = hcl_d.ReplaceOp(
-                op.target.result, op.src.result, ip=ip, loc=loc
-            )
-            op.ir_op = hcl_replace_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        ir_builder.build_visitor(op.src, ip)
+        hcl_replace_op = hcl_d.ReplaceOp(
+            op.target.result, op.src.result, ip=ip, loc=loc
+        )
+        op.ir_op = hcl_replace_op

--- a/heterocl/primitives/replace.py
+++ b/heterocl/primitives/replace.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -37,7 +38,7 @@ class ReplacePrimitive(Primitive):
             ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
             ir_builder.build_visitor(op.target, ip)
             ir_builder.build_visitor(op.src, ip)
-            replace_op = hcl_d.ReplaceOp(
+            hcl_replace_op = hcl_d.ReplaceOp(
                 op.target.result, op.src.result, ip=ip, loc=loc
             )
-            op.ir_op = replace_op
+            op.ir_op = hcl_replace_op

--- a/heterocl/primitives/replace.py
+++ b/heterocl/primitives/replace.py
@@ -4,10 +4,16 @@
 from hcl_mlir.exceptions import (
     APIError,
 )
-
+from hcl_mlir.ir import (
+    Location,
+    InsertionPoint,
+)
+from hcl_mlir.dialects import hcl as hcl_d
 from ..ast import ast
+from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
+from ..context import get_context, get_location
 
 
 @register_primitive()
@@ -24,3 +30,14 @@ class ReplacePrimitive(Primitive):
         loc = ast.Location(filename, lineno)
         replace_op = ast.ReplaceOp(src, dst, loc)
         sch.ast.top_func.body.append(replace_op)
+        op = replace_op
+        with get_context(), get_location():
+            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+            ir_builder = IRBuilder(sch._ast)
+            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+            ir_builder.build_visitor(op.target, ip)
+            ir_builder.build_visitor(op.src, ip)
+            replace_op = hcl_d.ReplaceOp(
+                op.target.result, op.src.result, ip=ip, loc=loc
+            )
+            op.ir_op = replace_op

--- a/heterocl/primitives/replace.py
+++ b/heterocl/primitives/replace.py
@@ -1,0 +1,26 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ReplacePrimitive(Primitive):
+    name = "replace"
+
+    @staticmethod
+    def apply(sch, src, dst):
+        """Replace a Tensor with another Tensor"""
+        if sch.is_lowered():
+            raise APIError(".replace() must be called before lowering")
+
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        replace_op = ast.ReplaceOp(src, dst, loc)
+        sch.ast.top_func.body.append(replace_op)

--- a/heterocl/primitives/reshape.py
+++ b/heterocl/primitives/reshape.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 import functools
 
@@ -49,5 +50,7 @@ class ReshapePrimitive(Primitive):
             ir_builder.build_visitor(op.tensor, ip)
             eletype = hcl_dtype_to_mlir(op.tensor.dtype)
             memref_type = MemRefType.get(op.shape, eletype, loc=loc)
-            reshape_op = hcl_d.ReshapeOp(memref_type, op.tensor.result, ip=ip, loc=loc)
-            op.ir_op = reshape_op
+            hcl_reshape_op = hcl_d.ReshapeOp(
+                memref_type, op.tensor.result, ip=ip, loc=loc
+            )
+            op.ir_op = hcl_reshape_op

--- a/heterocl/primitives/reshape.py
+++ b/heterocl/primitives/reshape.py
@@ -40,17 +40,16 @@ class ReshapePrimitive(Primitive):
         reshape_op = ast.ReshapeOp(target, shape, loc)
         sch.ast.top_func.body.append(reshape_op)
         op = reshape_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            # Be careful, since arg.result has been removed when building func op
-            if op.tensor.result is None:
-                op.tensor.result = op.tensor.prev_result
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.tensor, ip)
-            eletype = hcl_dtype_to_mlir(op.tensor.dtype)
-            memref_type = MemRefType.get(op.shape, eletype, loc=loc)
-            hcl_reshape_op = hcl_d.ReshapeOp(
-                memref_type, op.tensor.result, ip=ip, loc=loc
-            )
-            op.ir_op = hcl_reshape_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        # Be careful, since arg.result has been removed when building func op
+        if op.tensor.result is None:
+            op.tensor.result = op.tensor.prev_result
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.tensor, ip)
+        eletype = hcl_dtype_to_mlir(op.tensor.dtype)
+        memref_type = MemRefType.get(op.shape, eletype, loc=loc)
+        hcl_reshape_op = hcl_d.ReshapeOp(
+            memref_type, op.tensor.result, ip=ip, loc=loc
+        )
+        op.ir_op = hcl_reshape_op

--- a/heterocl/primitives/reshape.py
+++ b/heterocl/primitives/reshape.py
@@ -49,7 +49,5 @@ class ReshapePrimitive(Primitive):
         ir_builder.build_visitor(op.tensor, ip)
         eletype = hcl_dtype_to_mlir(op.tensor.dtype)
         memref_type = MemRefType.get(op.shape, eletype, loc=loc)
-        hcl_reshape_op = hcl_d.ReshapeOp(
-            memref_type, op.tensor.result, ip=ip, loc=loc
-        )
+        hcl_reshape_op = hcl_d.ReshapeOp(memref_type, op.tensor.result, ip=ip, loc=loc)
         op.ir_op = hcl_reshape_op

--- a/heterocl/primitives/reshape.py
+++ b/heterocl/primitives/reshape.py
@@ -1,0 +1,32 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import functools
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ReshapePrimitive(Primitive):
+    name = "reshape"
+
+    @staticmethod
+    def apply(sch, target, shape):
+        """Reshape a Tensor to a specified new shape"""
+        if sch.is_lowered():
+            raise APIError(".reshape() must be called before lowering")
+        ori_size = functools.reduce(lambda a, b: a * b, target.shape, 1)
+        new_size = functools.reduce(lambda a, b: a * b, shape, 1)
+        if ori_size != new_size:
+            raise RuntimeError(
+                "The reshaped tensor should have the same total size with the original tensor"
+            )
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        reshape_op = ast.ReshapeOp(target, shape, loc)
+        sch.ast.top_func.body.append(reshape_op)

--- a/heterocl/primitives/reshape.py
+++ b/heterocl/primitives/reshape.py
@@ -17,7 +17,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc, hcl_dtype_to_mlir
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/reuse_at.py
+++ b/heterocl/primitives/reuse_at.py
@@ -38,20 +38,19 @@ class ReuseAtPrimitive(Primitive):
         ast_reuse_at_op = ast.ReuseAtOp(target, axis, loc)
         sch.ast.top_func.body.append(ast_reuse_at_op)
         op = ast_reuse_at_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            # Be careful, since arg.result has been removed when building func op
-            if op.target.result is None:
-                op.target.result = op.target.prev_result
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            ir_builder.build_visitor(op.axis, ip)
-            f32 = F32Type.get()
-            memref_type = MemRefType.get((1,), f32, loc=loc)
-            reuse_at_op = hcl_d.ReuseAtOp(
-                memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
-            )
-            op.ir_op = reuse_at_op
-            op.result = reuse_at_op.result
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        # Be careful, since arg.result has been removed when building func op
+        if op.target.result is None:
+            op.target.result = op.target.prev_result
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        ir_builder.build_visitor(op.axis, ip)
+        f32 = F32Type.get()
+        memref_type = MemRefType.get((1,), f32, loc=loc)
+        reuse_at_op = hcl_d.ReuseAtOp(
+            memref_type, op.target.result, op.axis.result, ip=ip, loc=loc
+        )
+        op.ir_op = reuse_at_op
+        op.result = reuse_at_op.result
         return ast_reuse_at_op

--- a/heterocl/primitives/reuse_at.py
+++ b/heterocl/primitives/reuse_at.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ, unused-argument
 
 from hcl_mlir.exceptions import (
     APIError,

--- a/heterocl/primitives/reuse_at.py
+++ b/heterocl/primitives/reuse_at.py
@@ -17,7 +17,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/reuse_at.py
+++ b/heterocl/primitives/reuse_at.py
@@ -1,0 +1,30 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+    DTypeError,
+)
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ReuseAtPrimitive(Primitive):
+    name = "reuse_at"
+
+    @staticmethod
+    def apply(sch, target, parent, axis, name=None):
+        if sch.is_lowered():
+            raise APIError(".reuse_at() must be called before lowering")
+        if not isinstance(axis, ast.LoopHandle):
+            raise DTypeError(f"reuse_at() got invalid axis of type {type(axis)}")
+        if not isinstance(target, (ast.AllocOp, ast.ReuseAtOp)):
+            raise DTypeError(f"reuse_at() got invalid target of type {type(target)}")
+
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        reuse_at_op = ast.ReuseAtOp(target, axis, loc)
+        sch.ast.top_func.body.append(reuse_at_op)
+        return reuse_at_op

--- a/heterocl/primitives/split.py
+++ b/heterocl/primitives/split.py
@@ -1,0 +1,35 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+    HCLNotImplementedError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class SplitPrimitive(Primitive):
+    name = "split"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, parent, factor=None, nparts=None, mode="transform"):
+        """Split the stage either by factor providing outer scope, or both"""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".split() must be called before lowering")
+        if nparts is not None or mode != "transform":
+            raise HCLNotImplementedError(f"nparts={nparts}, mode={mode} not supported")
+        if isinstance(parent, int):
+            parent = stage.tensor.axis[parent]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        split_op = ast.SplitOp(stage.stage_handle, parent, factor, loc)
+        sch.ast.top_func.body.append(split_op)
+        return split_op.results[0], split_op.results[1]

--- a/heterocl/primitives/split.py
+++ b/heterocl/primitives/split.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -49,8 +50,8 @@ class SplitPrimitive(Primitive):
             ir_builder.build_visitor(op.parent, ip)
             i32 = IntegerType.get_unsigned(32)
             factor = IntegerAttr.get(i32, op.factor)
-            split_op = hcl_d.SplitOp(op.parent.result, factor, ip=ip, loc=loc)
-            op.ir_op = split_op
-            for result_loop_hdl, hdl_result in zip(op.results, split_op.results):
+            hcl_split_op = hcl_d.SplitOp(op.parent.result, factor, ip=ip, loc=loc)
+            op.ir_op = hcl_split_op
+            for result_loop_hdl, hdl_result in zip(op.results, hcl_split_op.results):
                 result_loop_hdl.result = hdl_result
         return res0, res1

--- a/heterocl/primitives/split.py
+++ b/heterocl/primitives/split.py
@@ -5,10 +5,18 @@ from hcl_mlir.exceptions import (
     APIError,
     HCLNotImplementedError,
 )
-
+from hcl_mlir.ir import (
+    Location,
+    InsertionPoint,
+    IntegerType,
+    IntegerAttr,
+)
+from hcl_mlir.dialects import hcl as hcl_d
 from ..ast import ast
+from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
+from ..context import get_context, get_location
 
 
 @register_primitive()
@@ -32,4 +40,17 @@ class SplitPrimitive(Primitive):
         loc = ast.Location(filename, lineno)
         split_op = ast.SplitOp(stage.stage_handle, parent, factor, loc)
         sch.ast.top_func.body.append(split_op)
-        return split_op.results[0], split_op.results[1]
+        op = split_op
+        res0, res1 = split_op.results[0], split_op.results[1]
+        with get_context(), get_location():
+            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+            ir_builder = IRBuilder(sch._ast)
+            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+            ir_builder.build_visitor(op.parent, ip)
+            i32 = IntegerType.get_unsigned(32)
+            factor = IntegerAttr.get(i32, op.factor)
+            split_op = hcl_d.SplitOp(op.parent.result, factor, ip=ip, loc=loc)
+            op.ir_op = split_op
+            for result_loop_hdl, hdl_result in zip(op.results, split_op.results):
+                result_loop_hdl.result = hdl_result
+        return res0, res1

--- a/heterocl/primitives/split.py
+++ b/heterocl/primitives/split.py
@@ -43,15 +43,14 @@ class SplitPrimitive(Primitive):
         sch.ast.top_func.body.append(split_op)
         op = split_op
         res0, res1 = split_op.results[0], split_op.results[1]
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.parent, ip)
-            i32 = IntegerType.get_unsigned(32)
-            factor = IntegerAttr.get(i32, op.factor)
-            hcl_split_op = hcl_d.SplitOp(op.parent.result, factor, ip=ip, loc=loc)
-            op.ir_op = hcl_split_op
-            for result_loop_hdl, hdl_result in zip(op.results, hcl_split_op.results):
-                result_loop_hdl.result = hdl_result
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.parent, ip)
+        i32 = IntegerType.get_unsigned(32)
+        factor = IntegerAttr.get(i32, op.factor)
+        hcl_split_op = hcl_d.SplitOp(op.parent.result, factor, ip=ip, loc=loc)
+        op.ir_op = hcl_split_op
+        for result_loop_hdl, hdl_result in zip(op.results, hcl_split_op.results):
+            result_loop_hdl.result = hdl_result
         return res0, res1

--- a/heterocl/primitives/split.py
+++ b/heterocl/primitives/split.py
@@ -17,7 +17,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/systolic.py
+++ b/heterocl/primitives/systolic.py
@@ -1,10 +1,7 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from hcl_mlir.exceptions import (
-    APIError,
-)
-
+from hcl_mlir.ir import UnitAttr
 from ..ast import ast
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
@@ -23,3 +20,5 @@ class SystolicPrimitive(Primitive):
         systolic_op = ast.SystolicOp(stage.tensor, loc)
         schedule = sch._CurrentSchedule
         schedule.ast.top_func.body.append(systolic_op)
+        op = systolic_op
+        op.target.ir_op.attributes["systolic"] = UnitAttr.get()

--- a/heterocl/primitives/systolic.py
+++ b/heterocl/primitives/systolic.py
@@ -1,0 +1,25 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class SystolicPrimitive(Primitive):
+    name = "systolic"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(sch, stage):
+        """Wrap the current stage as a systolic array"""
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        systolic_op = ast.SystolicOp(stage.tensor, loc)
+        schedule = sch._CurrentSchedule
+        schedule.ast.top_func.body.append(systolic_op)

--- a/heterocl/primitives/systolic.py
+++ b/heterocl/primitives/systolic.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.ir import UnitAttr
 from ..ast import ast

--- a/heterocl/primitives/tile.py
+++ b/heterocl/primitives/tile.py
@@ -16,7 +16,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/tile.py
+++ b/heterocl/primitives/tile.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -53,7 +54,7 @@ class TilePrimitive(Primitive):
             y_factor = IntegerAttr.get(i32, op.y_factor)
             ir_builder.build_visitor(op.x_parent, ip)
             ir_builder.build_visitor(op.y_parent, ip)
-            tile_op = hcl_d.TileOp(
+            hcl_tile_op = hcl_d.TileOp(
                 op.x_parent.result,
                 op.y_parent.result,
                 x_factor,
@@ -61,7 +62,7 @@ class TilePrimitive(Primitive):
                 ip=ip,
                 loc=loc,
             )
-            op.ir_op = tile_op
-            for result_loop_hdl, hdl_result in zip(op.results, tile_op.results):
+            op.ir_op = hcl_tile_op
+            for result_loop_hdl, hdl_result in zip(op.results, hcl_tile_op.results):
                 result_loop_hdl.result = hdl_result
         return (res0, res1, res2, res3)

--- a/heterocl/primitives/tile.py
+++ b/heterocl/primitives/tile.py
@@ -1,0 +1,37 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class TilePrimitive(Primitive):
+    name = "tile"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, x_parent, y_parent, x_factor, y_factor):
+        """Perform tiling on two dimensions"""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".tile() must be called before lowering")
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        tile_op = ast.TileOp(
+            stage.stage_handle, x_parent, y_parent, x_factor, y_factor, loc
+        )
+        sch.ast.top_func.body.append(tile_op)
+        return (
+            tile_op.results[0],
+            tile_op.results[1],
+            tile_op.results[2],
+            tile_op.results[3],
+        )

--- a/heterocl/primitives/tile.py
+++ b/heterocl/primitives/tile.py
@@ -45,24 +45,23 @@ class TilePrimitive(Primitive):
             tile_op.results[2],
             tile_op.results[3],
         )
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            i32 = IntegerType.get_unsigned(32)
-            x_factor = IntegerAttr.get(i32, op.x_factor)
-            y_factor = IntegerAttr.get(i32, op.y_factor)
-            ir_builder.build_visitor(op.x_parent, ip)
-            ir_builder.build_visitor(op.y_parent, ip)
-            hcl_tile_op = hcl_d.TileOp(
-                op.x_parent.result,
-                op.y_parent.result,
-                x_factor,
-                y_factor,
-                ip=ip,
-                loc=loc,
-            )
-            op.ir_op = hcl_tile_op
-            for result_loop_hdl, hdl_result in zip(op.results, hcl_tile_op.results):
-                result_loop_hdl.result = hdl_result
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        i32 = IntegerType.get_unsigned(32)
+        x_factor = IntegerAttr.get(i32, op.x_factor)
+        y_factor = IntegerAttr.get(i32, op.y_factor)
+        ir_builder.build_visitor(op.x_parent, ip)
+        ir_builder.build_visitor(op.y_parent, ip)
+        hcl_tile_op = hcl_d.TileOp(
+            op.x_parent.result,
+            op.y_parent.result,
+            x_factor,
+            y_factor,
+            ip=ip,
+            loc=loc,
+        )
+        op.ir_op = hcl_tile_op
+        for result_loop_hdl, hdl_result in zip(op.results, hcl_tile_op.results):
+            result_loop_hdl.result = hdl_result
         return (res0, res1, res2, res3)

--- a/heterocl/primitives/unroll.py
+++ b/heterocl/primitives/unroll.py
@@ -16,7 +16,6 @@ from ..ast import ast
 from ..ast.ir_builder import IRBuilder
 from ..utils import get_src_loc
 from .base import Primitive, register_primitive
-from ..context import get_context, get_location
 
 
 @register_primitive()

--- a/heterocl/primitives/unroll.py
+++ b/heterocl/primitives/unroll.py
@@ -45,7 +45,5 @@ class UnrollPrimitive(Primitive):
         ir_builder.build_visitor(op.target, ip)
         i32 = IntegerType.get_unsigned(32)
         factor = IntegerAttr.get(i32, op.factor)
-        hcl_unroll_op = hcl_d.UnrollOp(
-            op.target.result, factor=factor, ip=ip, loc=loc
-        )
+        hcl_unroll_op = hcl_d.UnrollOp(op.target.result, factor=factor, ip=ip, loc=loc)
         op.ir_op = hcl_unroll_op

--- a/heterocl/primitives/unroll.py
+++ b/heterocl/primitives/unroll.py
@@ -1,0 +1,31 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.exceptions import (
+    APIError,
+)
+
+from ..ast import ast
+from ..utils import get_src_loc
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class UnrollPrimitive(Primitive):
+    name = "unroll"
+    is_stage_primitive = True
+
+    @staticmethod
+    def apply(stage, var, factor=0):
+        """Unroll the iteration."""
+        from ..schedule import Schedule
+
+        sch = Schedule._CurrentSchedule
+        if sch.is_lowered():
+            raise APIError(".unroll() must be called before lowering")
+        if isinstance(var, int):
+            var = stage.tensor.axis[var]
+        filename, lineno = get_src_loc()
+        loc = ast.Location(filename, lineno)
+        unroll_op = ast.UnrollOp(var, factor, loc)
+        sch.ast.top_func.body.append(unroll_op)

--- a/heterocl/primitives/unroll.py
+++ b/heterocl/primitives/unroll.py
@@ -1,5 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, arguments-differ
 
 from hcl_mlir.exceptions import (
     APIError,
@@ -45,5 +46,7 @@ class UnrollPrimitive(Primitive):
             ir_builder.build_visitor(op.target, ip)
             i32 = IntegerType.get_unsigned(32)
             factor = IntegerAttr.get(i32, op.factor)
-            unroll_op = hcl_d.UnrollOp(op.target.result, factor=factor, ip=ip, loc=loc)
-            op.ir_op = unroll_op
+            hcl_unroll_op = hcl_d.UnrollOp(
+                op.target.result, factor=factor, ip=ip, loc=loc
+            )
+            op.ir_op = hcl_unroll_op

--- a/heterocl/primitives/unroll.py
+++ b/heterocl/primitives/unroll.py
@@ -39,14 +39,13 @@ class UnrollPrimitive(Primitive):
         unroll_op = ast.UnrollOp(var, factor, loc)
         sch.ast.top_func.body.append(unroll_op)
         op = unroll_op
-        with get_context(), get_location():
-            loc = Location.file(op.loc.filename, op.loc.lineno, 0)
-            ir_builder = IRBuilder(sch._ast)
-            ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
-            ir_builder.build_visitor(op.target, ip)
-            i32 = IntegerType.get_unsigned(32)
-            factor = IntegerAttr.get(i32, op.factor)
-            hcl_unroll_op = hcl_d.UnrollOp(
-                op.target.result, factor=factor, ip=ip, loc=loc
-            )
-            op.ir_op = hcl_unroll_op
+        ir_builder = IRBuilder(sch._ast)
+        loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+        ip = InsertionPoint.at_block_terminator(sch.top_func.entry_block)
+        ir_builder.build_visitor(op.target, ip)
+        i32 = IntegerType.get_unsigned(32)
+        factor = IntegerAttr.get(i32, op.factor)
+        hcl_unroll_op = hcl_d.UnrollOp(
+            op.target.result, factor=factor, ip=ip, loc=loc
+        )
+        op.ir_op = hcl_unroll_op

--- a/heterocl/schedule.py
+++ b/heterocl/schedule.py
@@ -153,7 +153,18 @@ class Schedule:
 
         # Register primitives.
         for pname, cls in PRIMITIVES.items():
-            setattr(self, pname, functools.partial(cls.apply, self))
+            setattr(
+                self,
+                pname,
+                functools.partial(
+                    self.wrapped_apply, functools.partial(cls.apply, self)
+                ),
+            )
+
+    def wrapped_apply(self, apply_fn, *args, **kwargs):
+        filename, lineno = get_src_loc()
+        with get_context(), Location.file(filename, lineno, 0):
+            return apply_fn(*args, **kwargs)
 
     @property
     def device_module(self):
@@ -334,8 +345,15 @@ class Stage:
             setattr(
                 self,
                 pname,
-                functools.partial(cls.apply, self),
+                functools.partial(
+                    self.wrapped_apply, functools.partial(cls.apply, self)
+                ),
             )
+
+    def wrapped_apply(self, apply_fn, *args, **kwargs):
+        filename, lineno = get_src_loc()
+        with get_context(), Location.file(filename, lineno, 0):
+            return apply_fn(*args, **kwargs)
 
     @staticmethod
     def lookup(name):

--- a/heterocl/schedule.py
+++ b/heterocl/schedule.py
@@ -1,6 +1,6 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, no-name-in-module
 
 import functools
 
@@ -28,7 +28,6 @@ from .passes.pass_manager import PassManager as ast_pass_manager
 from .passes.nest_if import NestElseIf
 from .passes.promote_func import PromoteFunc
 from .context import set_context, get_context, exit_context, get_location
-from .ast.ir_builder import IRBuilder
 
 
 def _build_ast(inputs, func=None, name=""):
@@ -280,12 +279,12 @@ class Schedule:
                 for stage_hdl in op.stage_hdls:
                     ir_builder.build_visitor(stage_hdl, ip)
                 hdl_results = [hdl.result for hdl in op.stage_hdls]
-                outline_op = hcl_d.OutlineOp(hdl_results, ip=ip, loc=loc)
+                hcl_outline_op = hcl_d.OutlineOp(hdl_results, ip=ip, loc=loc)
                 if op.unify is not None:
-                    outline_op.attributes["unify"] = StringAttr.get(op.unify)
+                    hcl_outline_op.attributes["unify"] = StringAttr.get(op.unify)
                 if op.axis is not None:
-                    outline_op.attributes["axis"] = StringAttr.get(op.axis)
-                op.ir_op = outline_op
+                    hcl_outline_op.attributes["axis"] = StringAttr.get(op.axis)
+                op.ir_op = hcl_outline_op
         return results if len(results) > 1 else results[0]
 
 
@@ -371,16 +370,16 @@ class Stage:
         op = outline_op
         with get_context(), get_location():
             loc = Location.file(op.loc.filename, op.loc.lineno, 0)
+            ip = InsertionPoint.at_block_terminator(self.top_func.entry_block)
             for stage_hdl in op.stage_hdls:
                 self.build_visitor(stage_hdl, ip)
             hdl_results = [hdl.result for hdl in op.stage_hdls]
-            ip = InsertionPoint.at_block_terminator(self.top_func.entry_block)
-            outline_op = hcl_d.OutlineOp(hdl_results, ip=ip, loc=loc)
+            hcl_outline_op = hcl_d.OutlineOp(hdl_results, ip=ip, loc=loc)
             if op.unify is not None:
-                outline_op.attributes["unify"] = StringAttr.get(op.unify)
+                hcl_outline_op.attributes["unify"] = StringAttr.get(op.unify)
             if op.axis is not None:
-                outline_op.attributes["axis"] = StringAttr.get(op.axis)
-            op.ir_op = outline_op
+                hcl_outline_op.attributes["axis"] = StringAttr.get(op.axis)
+            op.ir_op = hcl_outline_op
         return StageFunction(stage.name)
 
 

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -1,0 +1,66 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test user-defined primitives"""
+
+import heterocl as hcl
+import hcl_mlir
+from hcl_mlir.ir import *
+from hcl_mlir.dialects import hcl as hcl_d
+from hcl_mlir.dialects import arith as arith_d
+from hcl_mlir.dialects import memref as memref_d
+from heterocl.context import get_context, get_location
+import heterocl.ir.transform as hir
+
+
+@hcl.register_primitive()
+class BufferRootPrimitive(hcl.Primitive):
+    name = "buffer_root"
+
+    @staticmethod
+    def apply(sch):
+        mod = sch.module
+        i32 = IntegerType.get_signless(32)
+        for op in mod.body.operations[0].body.blocks[0].operations:
+            if isinstance(op, memref_d.AllocOp):
+                with op.location:
+                    with InsertionPoint(op):
+                        hcl_mlir.GlobalInsertionPoint.save(InsertionPoint(op))
+                        cst = hcl_mlir.ConstantOp(i32, 0)
+                        arith_d.AddIOp(cst.result, cst.result)
+
+
+@hcl.register_primitive()
+class AnnotatePrimitive(hcl.Primitive):
+    name = "annotate"
+
+    @staticmethod
+    def apply(sch):
+        loops = hir.get_affine_loop_nests(sch.top_func)
+        for i, (name, loop) in enumerate(loops):
+            hir.annotate(loop, f"Loop_{i}")
+
+
+def test_gemm_buffer(M=32, N=32, K=32, dtype=hcl.Int(), target=None):
+    hcl.init(hcl.Float())
+    A = hcl.placeholder((M, K), name="A")
+    B = hcl.placeholder((K, N), name="B")
+
+    def gemm(A, B):
+        k = hcl.reduce_axis(0, K, name="k")
+        C = hcl.compute((M, N), lambda i, j: hcl.sum(A[i, k] * B[k, j], axis=k), "C")
+        return C
+
+    s = hcl.create_schedule([A, B], gemm)
+
+    # optimization
+    C = gemm.C
+    s[C].reorder(C.axis[1], C.axis[0])
+    s.buffer_root()
+    s.annotate()
+    print(s.module)
+    hcl.build(s, target="vhls")
+    print(s.module)
+
+
+if __name__ == "__main__":
+    test_gemm_buffer()


### PR DESCRIPTION
This PR refactors the schedule primitives by decoupling them from the `Schedule` and `Stage` classes and maintaining each of them in a separate file. It makes the code structure more clear and enables users to plug in their customizations as a primitive.

The following code shows an example that creates buffers for each function argument. Users can inherit from our base `Primitive` class and define their own primitive by implementing the `apply` function. We provide several helper functions in `heterocl.ir.transform` to conduct program transformations, so users can write a few lines of code to create intermediate buffers or implement more complicated optimizations. After implementing the transformation, users only need to call the `register_primitive` decorator, and HeteroCL will automatically register it during runtime.

```python
import heterocl as hcl
import heterocl.ir.transform as hir

@hcl.register_primitive()
class BufferRootPrimitive(hcl.Primitive):
    name = "buffer_root"

    @staticmethod
    def apply(sch):
        loops = hir.get_affine_loop_nests(sch.top_func)[0]
        for i, arg in enumerate(sch.top_func.arguments):
            hir.create_buffer(arg, f"arg_{i}", ip=loops[0][1])
```

In the main function, users can apply their newly defined primitives as what builtin primitives do. In this example, users can call `s.buffer_root()` to invoke the primitive. In this way, the primitives are more modular, extensible, and reusable, providing more optimization opportunities in the future.

```python
def test_gemm_buffer(M=32, N=32, K=32, dtype=hcl.Int(), target=None):
    hcl.init(hcl.Float())
    A = hcl.placeholder((M, K), name="A")
    B = hcl.placeholder((K, N), name="B")

    def gemm(A, B):
        k = hcl.reduce_axis(0, K, name="k")
        C = hcl.compute((M, N), lambda i, j: hcl.sum(A[i, k] * B[k, j], axis=k), "C")
        return C

    s = hcl.create_schedule([A, B], gemm)

    # optimization
    C = gemm.C
    s[C].reorder(C.axis[1], C.axis[0])
    s.buffer_root()
    hcl.build(s, target="vhls")
    print(s.module)