### PR TITLE
[Python Package] Update Python package settings (Fix #510)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             export PREFIX=/home/circleci/llvm-project/build
             git clone https://github.com/cornell-zhang/hcl-dialect.git
             cd hcl-dialect
+            git checkout f2f5e43a93173f9a86671c8f5004d5fb21cb329b
             mkdir -p build && cd build
             cmake -G "Unix Makefiles" .. \
                 -DMLIR_DIR=$PREFIX/lib/cmake/mlir \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,8 @@ jobs:
           command: |
             export BUILD_DIR=/home/circleci/llvm-project/build
             export PREFIX=/home/circleci/llvm-project/build
-            git clone https://github.com/cornell-zhang/hcl-dialect.git
+            git submodule update --init
             cd hcl-dialect
-            git checkout f2f5e43a93173f9a86671c8f5004d5fb21cb329b
             mkdir -p build && cd build
             cmake -G "Unix Makefiles" .. \
                 -DMLIR_DIR=$PREFIX/lib/cmake/mlir \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hcl-dialect"]
 	path = hcl-dialect
-	url = git@github.com:cornell-zhang/hcl-dialect.git
+	url = https://github.com/cornell-zhang/hcl-dialect.git

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export PATH=${LLVM_BUILD_DIR}/bin:${PATH}
 To verify HeteroCL is installed correctly, you can run the following test.
 
 ```bash
-python3 -m pytest test
+python3 -m pytest tests
 ```
 
 

--- a/heterocl/passes/__init__.py
+++ b/heterocl/passes/__init__.py
@@ -1,0 +1,2 @@
+# Copyright HeteroCL authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/heterocl/passes/nest_if.py
+++ b/heterocl/passes/nest_if.py
@@ -1,9 +1,9 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from hcl_mlir.exceptions import APIError
 from ..ast import ast
 from .pass_manager import Pass
-from hcl_mlir.exceptions import *
 
 
 class NestElseIf(Pass):
@@ -50,7 +50,7 @@ class NestElseIf(Pass):
             return
 
         # if-elif-else chains
-        chains = list()
+        chains = []
         for op in scope.body:
             if isinstance(op, ast.IfOp):
                 chains.append([op])
@@ -95,9 +95,9 @@ class NestElseIf(Pass):
                     raise APIError("Invalid if-elif-else chain: " + str(chain))
 
         # remove ElseIfOp and ElseOp
-        new_body = list()
+        new_body = []
         for op in scope.body:
-            if isinstance(op, ast.ElseIfOp) or isinstance(op, ast.ElseOp):
+            if isinstance(op, (ast.ElseIfOp, ast.ElseOp)):
                 pass
             else:
                 new_body.append(op)

--- a/heterocl/passes/pass_manager.py
+++ b/heterocl/passes/pass_manager.py
@@ -1,12 +1,10 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from ..ast import ast
-from hcl_mlir.exceptions import *
-from hcl_mlir.ir import *
+from hcl_mlir.exceptions import HCLNotImplementedError
 
 
-class Pass(object):
+class Pass:
     """Base class for all intermediate pass.
 
     A pass is a visitor that can mutate the Intermediate Layer.
@@ -35,7 +33,7 @@ class Pass(object):
                 self.update_level(body_op)
 
 
-class PassManager(object):
+class PassManager:
     """A pass manager that manages a pipeline of passes."""
 
     def __init__(self):

--- a/heterocl/passes/promote_func.py
+++ b/heterocl/passes/promote_func.py
@@ -3,7 +3,6 @@
 
 from ..ast import ast
 from .pass_manager import Pass
-from hcl_mlir.exceptions import *
 
 
 class PromoteFunc(Pass):

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ def setup():
         setup_requires=["numpy", "pybind11", "pip", "cmake"],
         install_requires=parse_requirements("requirements.txt"),
         packages=setuptools.find_packages(),
+        package_data={"heterocl": ["harness/**/*"]},
         url="https://github.com/cornell-zhang/heterocl",
         python_requires=">=3.7",
         classifiers=[


### PR DESCRIPTION
This PR fixes issue #510, while adding a few more maintenance: 
- Switched `hcl-dialect` remote from ssh to https, so that user does not need to add ssh key when simply cloning the package.
- Adds `harness` as package data, so that `harness` is also copied to `site-packages/heterocl` during installation.
- Fixed a typo in README.